### PR TITLE
Update webinar notebook

### DIFF
--- a/webinars/2014_06_17/intro_to_gpu_python.ipynb
+++ b/webinars/2014_06_17/intro_to_gpu_python.ipynb
@@ -1,1962 +1,1839 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:a410eec7de682ac54623e105f693da5ace74b3e0a6d6eba788d07446584554b0"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# Introduction to Python GPU Programming with Numba and NumbaPro"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Misc. import\n",
-      "from IPython.display import Image "
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "skip"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# Numba\n",
-      "* Opensource BSD license\n",
-      "* Basic CUDA GPU JIT compilation\n",
-      "* OpenCL support coming"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numba\n",
-      "print \"numba\", numba.__version__"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "numba 0.13.1\n"
-       ]
-      }
-     ],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# NumbaPro\n",
-      "* Commercial\n",
-      "* Contains library extensions and extra multicore and GPU features:\n",
-      "    * Parallel vectorize\n",
-      "    * GPU vectorize, guvectorize\n",
-      "    * CUDA library bindings: cuRAND, cuBLAS, cuFFT, cuSparse\n",
-      "* NumbaPro namespace re-exports all public symbols in Numba\n",
-      "* We will import from numbapro whenever the feature is NumbaPro only"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numbapro\n",
-      "print \"numbapro\", numbapro.__version__"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "numbapro 0.14.1\n"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Ignore this\n",
-      "# Forces flushing of license information for trial user\n",
-      "@numbapro.vectorize(['int32(int32, int32)',], target='gpu')\n",
-      "def dummy_flush_lise(x, y):\n",
-      "     return math.sin(x) * math.cos(y)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "skip"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stderr",
-       "text": [
-        "Vendor:  Continuum Analytics, Inc.\n",
-        "Package: mkl\n",
-        "Message: trial mode expires in 29 days\n"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# The CUDA GPU\n",
-      "\n",
-      "- A massively parallel processor (many cores)\n",
-      "    - 100 threads, 1,000 threads, and more\n",
-      "- optimized for data throughput\n",
-      "    - Simple (shallow) cache hierarchy\n",
-      "    - Best with manual caching!\n",
-      "    - Cache memory is called shared memory and it is addressable\n",
-      "- CPU is latency optimized\n",
-      "    - Deep cache hierarchy\n",
-      "    - L1, L2, L3 caches\n",
-      "- GPU execution model is different\n",
-      "- GPU forces you to think and program *in parallel*"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Get all the imports we need\n",
-      "import numba.cuda\n",
-      "import numpy as np\n",
-      "import math\n",
-      "\n",
-      "my_gpu = numba.cuda.get_current_device()\n",
-      "print \"Running on GPU:\", my_gpu.name\n",
-      "cores_per_capability = {\n",
-      "    1: 8,\n",
-      "    2: 32,\n",
-      "    3: 192,\n",
-      "}\n",
-      "cc = my_gpu.compute_capability\n",
-      "print \"Compute capability: \", \"%d.%d\" % cc, \"(Numba requires >= 2.0)\"\n",
-      "majorcc = cc[0]\n",
-      "print \"Number of streaming multiprocessor:\", my_gpu.MULTIPROCESSOR_COUNT\n",
-      "cores_per_multiprocessor = cores_per_capability[majorcc]\n",
-      "print \"Number of cores per mutliprocessor:\", cores_per_multiprocessor\n",
-      "total_cores = cores_per_multiprocessor * my_gpu.MULTIPROCESSOR_COUNT\n",
-      "print \"Number of cores on GPU:\", total_cores"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Running on GPU: GRID K520\n",
-        "Compute capability:  3.0 (Numba requires >= 2.0)\n",
-        "Number of streaming multiprocessor: 8\n",
-        "Number of cores per mutliprocessor: 192\n",
-        "Number of cores on GPU: 1536\n"
-       ]
-      }
-     ],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# High-level Array-Oriented Style\n",
-      "\n",
-      "- Use NumPy array as a unit of computation\n",
-      "- Use NumPy universal function (ufunc) as an abstraction of computation and scheduling\n",
-      "- ufuncs are elementwise functions\n",
-      "- If you use NumPy, you are using ufuncs"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print np.sin, \"is of type\", type(np.sin)\n",
-      "print np.add, \"is of type\", type(np.add)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "<ufunc 'sin'> is of type <type 'numpy.ufunc'>\n",
-        "<ufunc 'add'> is of type <type 'numpy.ufunc'>\n"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "# Vectorize\n",
-      "\n",
-      "- generate a ufunc from a python function\n",
-      "- converts scalar function to elementwise array function\n",
-      "- Numba provides CPU support\n",
-      "- NumbaPro provides GPU support"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# CPU version\n",
-      "@numba.vectorize(['float32(float32, float32)',\n",
-      "                  'float64(float64, float64)'], target='cpu')\n",
-      "def cpu_sincos(x, y):\n",
-      "    return math.sin(x) * math.cos(y)\n",
-      "\n",
-      "# CUDA version\n",
-      "@numbapro.vectorize(['float32(float32, float32)',\n",
-      "                     'float64(float64, float64)'], target='gpu')\n",
-      "def gpu_sincos(x, y):\n",
-      "    return math.sin(x) * math.cos(y)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "```\n",
-      "@numba.vectorize(<list of signatures>, target=<'cpu', 'gpu'>)\n",
-      "```\n",
-      "\n",
-      "- A ufunc can be overloaded to work on multiple type signatures\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "### Test it out\n",
-      "\n",
-      "- 2 input arrays\n",
-      "- 1 output array\n",
-      "- 1 million doubles (8 MB) per array\n",
-      "- Total 24 MB of data"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Generate data\n",
-      "n = 1000000\n",
-      "x = np.linspace(0, np.pi, n)\n",
-      "y = np.linspace(0, np.pi, n)\n",
-      "\n",
-      "# Check result\n",
-      "np_ans = np.sin(x) * np.cos(y)\n",
-      "nb_cpu_ans = cpu_sincos(x, y)\n",
-      "nb_gpu_ans = gpu_sincos(x, y)\n",
-      "\n",
-      "print \"CPU vectorize correct: \", np.allclose(nb_cpu_ans, np_ans)\n",
-      "print \"GPU vectorize correct: \", np.allclose(nb_gpu_ans, np_ans)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "CPU vectorize correct:  True\n",
-        "GPU vectorize correct:  True\n"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "## Benchmark"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print \"NumPy\"\n",
-      "%timeit np.sin(x) * np.cos(y)\n",
-      "\n",
-      "print \"CPU vectorize\"\n",
-      "%timeit cpu_sincos(x, y)\n",
-      "\n",
-      "print \"GPU vectorize\"\n",
-      "%timeit gpu_sincos(x, y)\n",
-      "\n",
-      "# Optional cleanup \n",
-      "del x, y"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "NumPy\n",
-        "10 loops, best of 3: 56.4 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "CPU vectorize\n",
-        "10 loops, best of 3: 53.5 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "GPU vectorize\n",
-        "100 loops, best of 3: 9.15 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "- CPU vectorize time is similar to pure NumPy time because ``sin()`` and ``cos()`` calls dominate the time.\n",
-      "- GPU vectorize is a lot faster\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "\n",
-      "## Behind the scence\n",
-      "\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "\n",
-      "### Automatic memory transfer\n",
-      "\n",
-      "- NumPy arrays are automatically transferred\n",
-      "    - CPU -> GPU\n",
-      "    - GPU -> CPU"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "\n",
-      "### Automatic work scheduling\n",
-      "\n",
-      "- The work is distributed the across all threads on the GPU\n",
-      "- The GPU hardware handles the scheduling\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "\n",
-      "### Automatic GPU memory management\n",
-      "\n",
-      "- GPU memory is tied to object lifetime\n",
-      "- freed automatically"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "# Another Vectorize Example"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "@numba.vectorize(['float32(float32, float32, float32, float32)'])\n",
-      "def cpu_powers(p, q, r, s):\n",
-      "    return math.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)\n",
-      "\n",
-      "@numbapro.vectorize(['float32(float32, float32, float32, float32)'], target='gpu')\n",
-      "def gpu_powers(p, q, r, s):\n",
-      "    return math.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Generate data\n",
-      "n = 5000000\n",
-      "p = np.random.random(n).astype(np.float32)\n",
-      "q = np.random.random(n).astype(np.float32)\n",
-      "r = np.random.random(n).astype(np.float32)\n",
-      "s = np.random.random(n).astype(np.float32)\n",
-      "\n",
-      "# Check results\n",
-      "np_ans = np.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)\n",
-      "cpu_ans = cpu_powers(p, q, r, s)\n",
-      "gpu_ans = gpu_powers(p, q, r, s)\n",
-      "print \"CPU vectorize correct\", np.allclose(np_ans, cpu_ans)\n",
-      "print \"GPU vectorize correct\", np.allclose(np_ans, gpu_ans)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "CPU vectorize correct "
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "True\n",
-        "GPU vectorize correct "
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "True\n"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "## Benchmark"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print \"NumPy\"\n",
-      "%timeit np.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)\n",
-      "print \"CPU vectorize\"\n",
-      "%timeit cpu_powers(p, q, r, s)\n",
-      "print \"GPU vectorize\"\n",
-      "%timeit gpu_powers(p, q, r, s)\n",
-      "\n",
-      "# Optional cleanup \n",
-      "del p, q, r, s"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "NumPy\n",
-        "1 loops, best of 3: 1.97 s per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "CPU vectorize\n",
-        "10 loops, best of 3: 151 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "GPU vectorize\n",
-        "10 loops, best of 3: 72.2 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "* NumPy is slower than CPU vectorize (likely due to allocation of temporaries)\n",
-      "* CPU version is slower than GPU version because of multiple cores running (even though copying to card and back is costly)"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# Generalized Universal Function (guvectorize)\n",
-      "\n",
-      "- Vectorize is limited to scalar arguments in the core function\n",
-      "- GUVectorize accepts array arguments"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "@numbapro.guvectorize(['void(float32[:,:], float32[:,:], float32[:,:])'],\n",
-      "                      '(m, n),(n, p)->(m, p)', target='gpu')\n",
-      "def batch_matrix_mult(a, b, c):\n",
-      "    for i in range(c.shape[0]):\n",
-      "        for j in range(c.shape[1]):\n",
-      "            tmp = 0\n",
-      "            for n in range(a.shape[1]):\n",
-      "                 tmp += a[i, n] * b[n, j]\n",
-      "            c[i, j] = tmp"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "```\n",
-      "@numbapro.guvectorize(<list of function signatures>, <a string to desc the shape signature>, target=<'cpu', 'gpu'>)\n",
-      "```"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "a = np.arange(1.0, 10.0, dtype=np.float32).reshape(3,3)\n",
-      "b = np.arange(1.0, 10.0, dtype=np.float32).reshape(3,3)\n",
-      "\n",
-      "# Use the builtin matrix_multiply in NumPy for CPU test\n",
-      "import numpy.core.umath_tests as ut\n",
-      "\n",
-      "# Check result\n",
-      "print 'NumPy result'\n",
-      "np_ans = ut.matrix_multiply(a, b)\n",
-      "print np_ans\n",
-      "\n",
-      "print 'Numba GPU result'\n",
-      "gpu_ans = batch_matrix_mult(a, b)\n",
-      "print gpu_ans\n",
-      "\n",
-      "assert np.allclose(np_ans, gpu_ans)\n"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "NumPy result\n",
-        "[[  30.   36.   42.]\n",
-        " [  66.   81.   96.]\n",
-        " [ 102.  126.  150.]]\n",
-        "Numba GPU result\n",
-        "[[  30.   36.   42.]\n",
-        " [  66.   81.   96.]\n",
-        " [ 102.  126.  150.]]\n"
-       ]
-      }
-     ],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "### Test it out\n",
-      "\n",
-      "- batch multiply two 4 million 2x2 matrices "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "n = 4000000\n",
-      "dim = 2\n",
-      "a = np.random.random(n * dim * dim).astype(np.float32).reshape(n, dim, dim)\n",
-      "b = np.random.random(n * dim * dim).astype(np.float32).reshape(n, dim, dim)\n",
-      "\n",
-      "print 'NumPy time'\n",
-      "%timeit ut.matrix_multiply(a, b)\n",
-      "\n",
-      "print 'Numba GPU time'\n",
-      "%timeit batch_matrix_mult(a, b)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "NumPy time\n",
-        "10 loops, best of 3: 126 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "Numba GPU time\n",
-        "10 loops, best of 3: 125 ms per loop"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "- GPU time seems to be similar to CPU time\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "\n",
-      "## Manually Transfer the data to the GPU\n",
-      "\n",
-      "- This will let us see the actual compute time without the CPU<->GPU transfer"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "dc = numba.cuda.device_array_like(a)\n",
-      "da = numba.cuda.to_device(a)\n",
-      "db = numba.cuda.to_device(b)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "* ```numba.cuda.device_array_like``` allocate without initialization with the type and shape of another array.\n",
-      "    * similar to ```numpy.empty_like(a)```\n",
-      "* ```numba.cuda.to_device``` create a GPU copy of the CPU array\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "\n",
-      "## Pure compute time on the GPU"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "def check_pure_compute_time(da, db, dc):\n",
-      "    batch_matrix_mult(da, db, out=dc)\n",
-      "    numba.cuda.synchronize()   # ensure the call has completed\n",
-      "    \n",
-      "%timeit check_pure_compute_time(da, db, dc)\n",
-      "del da, db, dc"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "100 loops, best of 3: 9.24 ms per loop\n"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "* Actual compute time is **a lot faster**\n",
-      "* PCI-express transfer overhead"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "#### Tips\n",
-      "If you have a sequence of ufuncs to apply, pin the data on the GPU by manual transfer"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# NumbaPro CUDA Libraries Bindings\n",
-      "\n",
-      "- Access to CUDA libraries \n",
-      "- Work seamless with NumPy\n",
-      "    - auto memory transfer\n",
-      "    - managed memory\n",
-      "\n",
-      "- cuBLAS: CUDA version of BLAS\n",
-      "- cuSparse: CUDA sparse matrix support\n",
-      "- cuFFT: FFT on CUDA\n",
-      "- cuRAND: random number generation on CUDA"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "# An Example with CUDA Libs\n",
-      "## Convolution on the GPU"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Import cuFFT"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from numbapro.cudalib import cufft"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "#### Misc. imports"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from scipy.signal import fftconvolve\n",
-      "from scipy import misc, ndimage\n",
-      "from matplotlib import pyplot as plt\n",
-      "from timeit import default_timer as timer"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Build elementwise complex array multiplication CUDA function"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "@numbapro.vectorize(['complex64(complex64, complex64)'], target='gpu')\n",
-      "def vmult(a, b):\n",
-      "    return a * b"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Prepare image and filter"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "image = misc.face(gray=True).astype(np.float32)\n",
-      "\n",
-      "laplacian_pts = '''\n",
-      "-4 -1 0 -1 -4\n",
-      "-1 2 3 2 -1\n",
-      "0 3 4 3 0\n",
-      "-1 2 3 2 -1\n",
-      "-4 -1 0 -1 -4\n",
-      "'''.split()\n",
-      "\n",
-      "laplacian = np.array(laplacian_pts, dtype=np.float32).reshape(5, 5)\n",
-      "\n",
-      "response = np.zeros_like(image)\n",
-      "response[:5, :5] = laplacian\n",
-      "\n",
-      "print \"Image size: %s\" % (image.shape,)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Image size: (768, 1024)\n"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Convolution on the CPU"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "ts = timer()  # Start Timer\n",
-      "cvimage_cpu = fftconvolve(image, laplacian, mode='same')\n",
-      "te = timer()  # Stop Timer\n",
-      "print 'CPU: %.2fs' % (te - ts)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "CPU: 0.08s\n"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Convolution on the GPU"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "image_complex = image.astype(np.complex64)\n",
-      "response_complex = response.astype(np.complex64)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Trigger initialization the cuFFT system.\n",
-      "# This takes significant time for small dataset.\n",
-      "# We should not be including the time wasted here\n",
-      "cufft.FFTPlan(shape=image.shape, itype=np.complex64, otype=np.complex64)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "skip"
-      }
-     },
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 24,
-       "text": [
-        "<numbapro.cudalib.cufft.api.FFTPlan at 0x4caa050>"
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "ts = timer()     # Start timer\n",
-      "\n",
-      "d_image_complex = numba.cuda.to_device(image_complex)\n",
-      "d_response_complex = numba.cuda.to_device(response_complex)\n",
-      "\n",
-      "# Forward FFT\n",
-      "cufft.fft_inplace(d_image_complex)\n",
-      "cufft.fft_inplace(d_response_complex)\n",
-      "\n",
-      "# Multiply the image with teh filter\n",
-      "vmult(d_image_complex, d_response_complex, out=d_image_complex)\n",
-      "\n",
-      "# Inverse FFT\n",
-      "cufft.ifft_inplace(d_image_complex)\n",
-      "\n",
-      "cvimage_gpu = d_image_complex.copy_to_host().real / np.prod(image.shape)\n",
-      "\n",
-      "te = timer()   # Stop timer\n",
-      "\n",
-      "print 'GPU: %.2fs' % (te - ts)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "GPU: 0.02s\n"
-       ]
-      }
-     ],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "plt.title('Original')\n",
-      "plt.imshow(image, cmap=plt.cm.gray)\n",
-      "plt.axis('off')\n",
-      "plt.show()"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAVIAAAEKCAYAAABACN11AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsvXmMpGd1PXxq3/e1a+vu6n3vmZ7xbB57ZjAG2+A4hgBh\nkwgCJQGiKAIJKYqwEAEJgRILgpM/EhGIwCwO4AXsMGOPPbtn6Z6Z7uq9q7qrqmvf9/37Y7576cny\nxb+QjyG/1JVGnml3V7/11vuc595zz7mPoNPpdNCNbnSjG934L4fwXl9AN7rRjW78T48ukHajG93o\nxq8ZXSDtRje60Y1fM7pA2o1udKMbv2Z0gbQb3ehGN37N6AJpN7rRjW78mtEF0m781sdXvvIVfOIT\nn/hv/97/LIRCIba2tv5bXqsb/3eHoKsj7cZvOr797W/j61//Ora2tqDVavG7v/u7+MpXvgKdTnev\nL+2uEAqF2NjYgNfrvdeX0o3f8uhmpN34jcbXv/51fP7zn8fXv/515PN5XL58Gdvb23j729+ORqPx\nb76/1Wrdg6vsRjf+z6ILpN34jUU+n8dTTz2Fb37zm3j44YchEonQ29uLH/7whwgEAvinf/onPPXU\nU3jve9+Lj3zkI9DpdPj2t7+Np556Ch/5yEf4db7zne+gt7cXZrMZX/rSl9DX14dXX30VAO763kAg\nAKFQyN9vsVjw5S9/mV/nzTffxJEjR2AwGOBwOPCZz3zm3wXzbnTjP4sukHbjNxYXL15EtVrFk08+\nedfXVSoVHn30Ufzyl7+EQCDA888/j9/7vd9DLpfDhz70IQgEAv5en8+HT33qU/j+97+PSCSCXC6H\n3d1d/v97v5fiwoULWFtbw5kzZ/DFL34Rq6urAACxWIynn34aqVQKly5dwpkzZ/Ctb33r/6d3343/\nm6MLpN34jUUymYTZbIZQ+G8fu56eHiSTSQDA0aNH8fjjjwMA5HI59tL4P/7xj/H444/j6NGjkEgk\n+OIXv3gXeP57lP8XvvAFyGQyTE9PY2ZmBgsLCwCA/fv347777oNQKERvby8++clP4vXXX/9vfc/d\n+N8R4nt9Ad343xNmsxnJZBLtdvvfgOnu7i7MZjMAwOVy/Yevsbu7e9f/VygUMJlM/5+/126389+V\nSiVKpRIAYG1tDX/2Z3+G69evo1wuo9ls4sCBA//H76sb3ehmpN34jcWRI0cgk8nw3HPP3fX1YrGI\nl19+GQ899BCAf788p3A4HAiFQvzvSqWCVCr1X7qeP/qjP8L4+Dg2NjaQy+Xwl3/5l2i32/+l1+rG\n/+7oAmk3fmOh0+nwhS98AZ/5zGfwyiuvoNFoIBAI4H3vex/cbjc+/OEP/7ul+d54z3vegxdeeAGX\nLl1CvV7HU0899Z/+zH8UxWIRGo0GSqUSKysreOaZZ/5Lr9ONbnSBtBu/0fjc5z6HL3/5y/jsZz8L\nnU6Hw4cPo7e3F2fOnIFUKoVAIPg3Gener01MTOAb3/gGPvCBD8DhcECj0cBqtUImk/2b76V//0fx\nta99Dd/73veg1WrxyU9+Eh/4wAfe8s92oxt7oyvI78b/6CgWizAYDNjY2EBvb++9vpxu/C+Nbkba\njf9x8cILL6BcLqNUKuGzn/0spqenuyDajXsaXSDtxv+4eP755+F0OuF0OrG5uYlnn332Xl9SN/6X\nR7e070Y3utGNXzO6GWk3utGNbvyacU8E+X/xF38Bt9uNUCiEa9euIZlMYnR0FGazGdvb2xCLxajX\n65BKpejv78f09DSKxSLK5TLy+TwMBgO8Xi/8fj8SiQQMBgN2d3eRTqcxMjICo9GI+fl5lMtlFItF\nFItFNBoNTE1NweVyIZVKIRaLIRQK4cknn4RQKMTu7i4KhQLsdjtqtRo2NzdRLpfR6XRw6tQphEIh\nWK1W6HQ6NJtNaLVarK6uotlsIpvN8nXMzs6it7cXr776KqxWK5xOJwQCAa5cuYKRkRFks1mo1Wqc\nP38eTzzxBN58803kcjkIBAK4XC4YDAaIxWKIxWKk02mIxWJks1lks1mIxWI4nU5MTEzg9ddfx+bm\nJkZGRpDP57lbrdPp8Oabb0IkEqHdbiORSEChUGBsbAxyuRyZTAYymQz5fB5KpRLpdBp6vR5SqRSt\nVgvLy8vsJhKJRBAIBBgdHYVcLsfp06cxODiIdDoNs9mMffv24Sc/+QmOHTuGgYEBrKysQC6XY35+\nnoXv5XIZUqkUJpMJCoUCer0es7OziEajyOfzWF5exuTkJEqlEjY2NnDo0CG0Wi3s7u6i1WpBo9Gg\nWCzi0KFDCAQCMBgMMJvNSKVSSCQSkMlkEAqFcDqd8Pl8GBwcZK1pq9VCMBiETqfDfffdh9deew0y\nmQwKhQJqtRoGgwGvvfYa1Go1PB4Ptra2cPz4cSwuLsJmsyGZTCIajcJoNKJer0Mul2NsbAw7Ozu4\nefMmNBoNjEYjpFIpdDodlpaW4HA4AAASiQSJRAI6nQ7tdhtyuRwAkEql0G63oVAoMDQ0hMXFRTSb\nTVQqFbjdbmQyGTSbTcRiMajVakilUqhUKnQ6HbRaLQgEAnQ6HXQ6HRQKBWg0GoRCIeh0OtTrdVSr\nVYjFYuRyObRaLahUKgBALpeDXC6HWCxGqVRCo9FgU0Sz2US1WoVEIoFIJIJMJkO73YZYLEaj0YBE\nIoFUKkW5XIZQKIRCoYBEIoFcLufXLxQK6HQ60Gg0MJlMMJlMUCqVUKlUEAqFqNVqaLVaaLVa+O53\nvwudTodqtYpIJIJWqwWhUAihUAi5XI7Pf/7zePbZZ5HP53ktNBoNfh7F4juw1W630Ww20el00G63\n0el0UKvV0Ol0oFQqIZPJ0Gw2oVQq0dfXB5FIhEajwZ+HTCaDSCRCtVrF+Pg4enp6sL6+jvn5eXg8\nHrRaLXz1q199S5gmeuqpp5767wTJtxLf+c53cOvWLZw8eRJmsxm1Wg0bGxswGo04evQoent70dfX\nB6fTiUAggGw2C7lcjqWlJcjlcggEAmxubqK/vx8qlQpvvvkmVldXcd9990GlUuHZZ5+FVqtFb28v\nNBoNHA4H8vk8VldXIZVKIRQKEQwGEYlE4HK5cPv2bdTrdTgcDuh0OkgkEng8HrhcLuTzeYTDYQwN\nDaFarWJ3dxdWqxWtVgterxdarRahUAharRbZbBZCoRD9/f1wOBwIh8NwOBy4efMmZmZmkEgkEIvF\nYLFY0NPTg2g0Cp1Oh0QiAYvFgkAgAI1Gg1wuB5VKhWw2i+vXr2Pfvn0YHx+HTqfjhUYPkN1ux7lz\n52AymVCr1aDRaKBWqxEKhbB//34AwNjYGOr1Ovbv34+bN2+iVCpBr9djamoKAPD666/jXe96F1Kp\nFIrFIur1OkqlEprNJsxmMzY2NpBKpdBqtaDT6VAqlSCRSADc0XVub29jZ2cHZ86c4WEilUoFk5OT\nKBQK0Gq18Hg8mJmZwfLyMmQyGeRyOdrtNgwGAw8UqVQqWF9fh1KpxODgIBQKBd544w2USiUolUoM\nDw/j3LlzmJ6extbWFlqtFsxmM6RSKer1OoRCIcbGxrCysoK1tTXMzc1haWkJbrcbxWIR/f39UCgU\n0Ol0kMvleOONNzA0NIRgMIharQalUolsNotWq4VKpQKFQoFOp4NoNIq+vj7k83m4XC6+xnK5zBtz\nq9WCQqHgz69cLqPRaCAej0Ov16PdbkMkEqFWq0GlUjFAUtOMQK7ZbKJQKKBcLkOv10MoFEIgEKDZ\nbKLRaPDvq1QqcDqdyGQy0Gq1EAgEqNfrMJlMKBaL6HQ6kEgkEAqFaLVaaDabUCgU/LnS9bbbbdRq\nNQaoZrPJP9dut9FutyGVSpHL5SAUCtFsNiEWiyGRSBi86JnR6XTQaDTQ6XRQqVQMyNVqFfV6HdFo\nFD/60Y9gNBqRyWQQjUYB3JGZCYVCuN1ufO5zn8N3v/tdlMtlCAQCyGQyVKtViEQiiMViiEQiAL8C\nUXp/jUaDQVKj0UAikUChUEChUHAyU61WIRAIIJVKIZVKAYCBulqtIpvNYnd3F263GwaDAfl8Hg8/\n/PBbwrR7AqTPPfccRkdHsbGxAY/Hg4ceeggKhQKtVgtra2u4ePEihoaG8NOf/hSHDh1Cs9nE/Pw8\nxsbGoFar0Wq1UCgUOKtwu93o7e1FNptFKpWC1+vFysoKVlZWUC6XkUqloFarcfDgQezs7CCfz/PO\nq1AosLGxAQCIRqP8/10uF9rtNgYGBmA0GvHzn/8chw4dgt1uRz6fh0Kh4AWjVqtRqVTg9/uhUCgQ\nj8fR19cHvV4PhULBmQJdy9WrV3HixAkUCgXMzs5CKpVCo9FApVIhFArx7ulwOOBwOLCzs4NarQaz\n2QyFQoFqtQoADOByuZxBJJvNYmVlBbVaDWKxGDMzMxAKhRgYGECtVkM8Huf3XSwWcfDgQUxMTEAu\nl8NgMECv18NkMqHZbLL/XalUotVqwWQyYWdnB4cPH0apVMIrr7yCSCQCjUaD+++/HyKRCPV6HbVa\nDYlEAoFAAEajEZVKBT09PWi32zAajdjZ2YFYLIbRaOR7IhAIoFQqodVqkcvlYLPZEIvFoFAoIJfL\nkc/n4fV6kclkYLVaIZfLUSgUIJPJMDw8jM3NTRiNRgSDQc6IZDIZnE4nEokEg7/VasW//Mu/QKVS\nYXh4GLVaDSKRCNlsFlarFdlsFjabDc1mEwCQTqehUChgt9vRarVgNBrh9/shl8tRrVYxMDCAarUK\njUaDjY0NTE9PIxAIcPaoUCjQaDSgVCrh9/s5e1IoFFheXoZUKkWz2US73Uar1UK73UY6nWZQ7HQ6\n0Ol0KBQKUCgUCIVCEAgEMBqNUKlUDIpyuRwSiQSFQgG1Wo1tuAQ8YrEYtVqNp1uJRCJIpVJUKhUo\nlUoGPLFYzCBTr9cBAKVSCWKxmIFNJpOhUqlwhletVqHX6/lZVCgUd2XR5XIZoVAIL730EqxWKxKJ\nBJLJJG8QcrkcNpsNH//4x/H3f//3fO/UajWKxSKDH4EpvT/gTjZdr9d53KJSqYRIJIJQKIROp0Nv\nby9n8EKhkDcJAm+pVMoVWCqVgkwmQyaTwXPPPYdgMIg//MM/fEuYdk+A9Omnn8bKygre+973IhAI\n4J//+Z+h0+kgFAqxvb2ND3/4wzh//jze9a53cRlBGQuVfNlsFtvb23A4HEin05BIJDCbzfD5fCiV\nSjCbzZicnITNZuPdcXNzE7lcDocOHUK73eaMIBgMolKpQK1W44knnoDL5cKVK1cQjUaRyWSg1+tx\n+PBhnDt3DjabDQKBABaLBclkkj/gqakpXLp0Cfl8HpVKBc1mk6+ZNoLZ2Vnk83ns7OxAo9EgmUyi\nWq1Cp9Phxo0bSKfT6O3tRa1Wg9PpxPr6OlqtFlZWVhCPx+Hz+TA2NoYbN24gFArhox/9KGKxGG7c\nuIGjR4/i9OnTMJvN2L9/P4rFIqrVKlZXV1Gv1yGRSHDhwgWMj4/D7/ejWq3CbDbjJz/5CUZHR/HS\nSy9hfX0d73//+5HL5XD06FGcO3cOQ0NDOHXqFLt/Hn/8cSwtLaHT6WBwcJDvkcFgQDgc5oVvtVph\nMBjgcrlQq9WQTCYxMDAAi8UCrVbLYEsLoNPpcFY+PDyMbDaLyclJZDIZyOVyiEQilEolFItF6HQ6\nGAwGaDQaCIVCiMVilMtlOJ1OyGQyJJNJ5PN5OBwOxONxuFwu+P1+ZDIZKBQK1Go1rK+vQyaTQSwW\nQ6VSoVQqoaenB1tbW0wDBQIBNBoN5PN5CIVCaDQaaDQaxONxDA4OIpVKQaPRoNFoIJvNot1u873e\n2dlBu92Gw+FAKpXi5yGVSvGipiyyUqlwuUl/BwCNRgOBQIBKpQK5XI54PI5WqwW1Wg2dTodoNMol\nr1AoRLlc5uwPAGdzAO4CGwIkAvBOp8PZnVQq5WyTAItAWSqVcvncbrf52qgkB+4MmaFqg743FArh\nzTffhNVqRTQaRTabRbPZ5GSmt7cXn/70p/Gtb32Lf0ez2WRaSCKRcOZI2WexWEQmk0GpVOLNSalU\nQiqVQqvVwmazwWq1cgVAtIJUKmVqJ51OI5fL8Z9qtYpSqYR6vY7BwUG4XC68613vekuYdk+69n/1\nV38FlUqFq1evYnp6GvV6HUqlEkKhEEqlEslkEtevX0dPTw/m5+fRbrdx/PhxKJVK5HI5jIyMwGAw\noFgsYnt7G8Cdncnv92N4eBipVIpHq9Eia7VaMBgMkMvlmJycRDKZRG9vLxYWFjA/P8+Zr8Viwfnz\n52E2mzkDjEajmJ2dRblcxu7uLkZHRznbpIlF7XYbFosFX/ziF2Gz2TA2Ngan0wm5XA6TyQSfzweJ\nRIITJ07gS1/6EgKBAP78z/8cYrEYa2trsNlsWF9fh8FgwLVr11AsFnH48GFEIhEcP36c+aIXX3wR\nw8PDMJvNkMlkMBqNKBQKWF9fx9LSEgqFAvbv3w+dTofd3V309/cjn88zX2cymfCzn/0M5XIZJ0+e\nRCQSYQCinx8dHYXNZoPL5cLm5iZu3boFuVyOdDoNu90Oq9WKsbExrK6uIpfLcVZ4/vx5DAwMwOl0\nIhQK8cM5OzuLYrGInZ0dzrITiQQEAgFarRYsFgsDlkgkYn7vxIkTCAQC2N3dRbVaZX4UAHZ2duDx\neNDf349sNguz2Yxf/OIXOHDgAAqFAkwmE5f74XAYTqcTi4uL6OnpgUwmw+rqKlqtFiYnJxEKhXiR\nptNpqNVqOJ1OZLNZ1Ot1FAoFGAwG5HI56HQ63miCwSB8Ph96e3vRbDZRLBYhlUqRyWSQSCRgs9l4\nYyGgrVQqnN0SV0mUiUAgQCwWY75Qq9UilUpBpVLxRkI8MwBIpVJEo1FoNBp0Oh0kEglIJBLuI6RS\nKQiFQgZTiUTCIF4ul1EoFGA0GpHP51Gr1XizAMAgRllqo9GAQqEAcMcEQVQEcaWUCOn1eiiVSojF\nYshkMgQCAWxubjI9QJthrVaDzWZDf38/3ve+9+Fv//ZvmfskkKfMtNVqQavVwmq1wmq1oqenh+kD\nSmQITAks8/k8f/6VSoU3Q4VCwdfZaDRQKpUQiUT4s6YNg17zb/7mb94Spt0zIKUdqdFocAk+OTmJ\nsbExxGIx5PN5FAoFTE1NIZlMIhKJYHp6Gjdu3EC9Xoff70c6nYbX68Xg4CCkUinzPyqVCna7HWq1\nGtVqlbmS27dvQywWY2NjA9vb2zhy5AhqtRpMJhMWFhbgdDqxtbWFYrGIRCIBt9sNgUDA10Blb7Va\nhdFohEQigVarhUqlQj6fh0ajQSqVwj/+4z/iwQcfxM7ODo4cOYKBgQHk83m8+uqreOCBByCXy7Gz\ns4Nbt27h6NGjWFtbw+TkJMLhMN544w1MTEwgkUig0+lgfX0d1WoV+/fvh8PhwPT0NEKhEILBIEKh\nEDdC6PszmQw8Hg9EIhEvQCqHJBIJGo0GrFYrOp0OSqUSHA4H1tfXIZfLcf36dWxvb8PlcsFoNMJg\nMGBychJXrlxhTvjq1asYHx9n6sBsNiOTyUAgEMBms0Eul+Pll1+GSqXC/v37EQqFoFKpuBFUq9UQ\nCASYX15ZWcHAwABkMhk6nQ7kcjlneS6XCzs7O9jY2EBfXx9cLhfC4TA0Gg1EIhHW1tZQKBTw+7//\n+4hGo6hUKtDpdDh37hzEYjGGhoag0WiQyWS4+VSr1aDX66FSqXD79m3Mzs4inU5DKpXCYrHg1q1b\nGBgYQCQS4YaDXq9HNBpFKBRioBgcHEQwGIREIoFer+cNZXNzE5VKBeFwGIODg5BIJNBoNAgGgxAI\nBJBIJFCpVKjX64hEIgya1LRJp9PMz1GW12g0IJfLuYRXqVQoFotQKBRMwcTjcQYDpVKJarXKXCnx\nngA4i6RGql6vZ96dGjB0nwAwCBMIpdNpppIEAgG0Wi1zlzqdDlqtlvlZqhopmaGEhhrJXq8XH/rQ\nh/DVr34VJpMJ5XKZqYjBwUGMjo7C5XJBo9Fw9lyv17G9vY2VlRWEw2GmqgwGA2w2G/R6PWfUlNVS\nEH1Bv4PWCP0Oj8eDZDIJn8+HW7duwe/3Y2dn5y1h2j0B0kuXLiGXy2F1dZW5FLVaDeDOWLRIJALg\nzmSfM2fOQKPRwGw2w+FwMDdZKpXg9XoZLORyOdbX17G9vc0PnsPhgEwm4wzM4/EgFApBoVDgkUce\ngc/nw/Xr19kZ4/f74fF4UC6Xsbi4iKmpKVy7dg0ikQgf/OAHsbOzg/n5eRw5coQ5NY/Hw+WHVCpF\nrVbD6uoq73pbW1uYm5uD3+/H3NwcVlZW0NfXh2KxyBxZLpfD6dOn8bGPfQw6nQ4///nP4XK5kMvl\nkEql+He0223kcjl4vV5cunQJAwMD2NnZwaOPPoqnn34aEomEu8tUerlcLggEAu7e9/T0IJPJoFwu\nIxaLYf/+/fB6vQiHwyiXy8wRRaNRWCwWWK1WVKtVbGxsQKVScbleLBYxMzODUqkEj8eDy5cvI5/P\nM89HnWORSASXy8WfST6fRyQSgVwuh9FoxJEjR3D69GmMjIxgdXUVRqMRTqeT+a1oNIp6vY5GowGN\nRoOenh68+OKLOHXqFC5evMjNvWw2y83H3d1dvj+VSoWpgkqlgs3NTWSzWQwNDSGfz8NqtSIWi2Fo\naAi7u7uIRCLo6enhLMtut7PKQyAQIBwOY2xsDMPDw1hZWYFareaOeKfTgVgsht/v5+zRbrcz9TQ1\nNYWFhQXmGGnzA+4Mt9ZoNIjFYqhWqygUCtDpdJDJZCgWi6yC6OnpgUAgQKPR4E2hXq9zw4v47Fwu\nx5ldvV6HWq3mzS+bzTIdQPw9AahKpeLXrlQqaDQa3I1vtVqcjVJTp9PpQKFQQCaTQSKRcDaay+WQ\nzWYhEAg446UMU6VSob+/Hw899BC+9rWvwWKxwOv1Yt++fTAajdwEa7fbyGQy2NjYwPz8PIrFImet\nnU4HRqMRvb290Gq1XBGQQgf41QZE1BBtAK1WC51Oh3lSn8/HG4tcLsf999+P/fv3o1Kp4GMf+9hb\nwrR7AqTf//73UavVYDAYsLy8zN02k8mEa9euwev1wmq1QiqVwufzoVgswuPxYGFhgcvxY8eO4ebN\nm+y1VigUyGazKJVKOHDgAKrVKstY7HY7KpUKy4OKxSLOnz8PrVaLdrsNm82Gvr4+XLlyheU94+Pj\ncDgczEOtrq7i7W9/O0qlEi5duoSpqSmoVCpuYGi1Wib3NzY24PP54PF4IBaLYbPZ8IMf/ACPP/44\nCoUCL9SNjQ2srKzgkUcewdbWFr73ve/hE5/4BJaXl7kLv7S0hHa7jZ6eHiwuLsJkMnG2+PLLLyMa\njeLTn/40jEYjrl69iu3tbbjdbohEIigUCgbHSCTCC8RutyORSEAkEkEkEqGnpwcbGxs4duwYfD4f\nYrEYl+g+nw/NZhMjIyNot9u4ffs2+vr6OPNvNBqsrhgeHkYmk4FarUY8HucmBclstFotenp6kE6n\nkc/noVKpWBbV6XSwtbUFpVIJt9uNarWKoaEhrK+vQygUIh6Pw+FwwOVyQS6XM+emUqmQTqdRLBYB\nALOzs9jd3YXBYEAgEMDCwgL6+/vhcrmYNshmswgGgxAKhax8sFgsyOfzyGQy0Gg0aLfbkEgkOH78\nOM6ePQudTodGo8ElvtPphN/vh9frhUgkQj6f5/KdmhudTgfj4+N47bXXIBAI8PDDDzOYS6VS5pRN\nJhNntPQMU2OkUCgwL9xoNNDb28sZNPGx6XSaFRB7u9Plchm1Wo1BVCKRIJfLMeCT8kMsFnO2Rs8M\nPSuNRgNqtRr1ep2513a7Da1WyxkyNacIADudDgNTpVLhxhRtsJOTk9i3bx8SiQSGh4e5jBYIBFhe\nXsbKygoKhQIkEglKpRLLoxQKBSwWC0sEs9ksisUiP8c0uIZkXABYekXSqXq9zr9LLBbj5s2b3Egj\n0K9UKlx13r59+y1h2j1pNv31X/81Lly4gHg8junpaczPz2N6ehrVahVHjx6FXC7H4uIitra2eMdu\nNBo8e/Ld7343XnnlFVSrVV6kxOk8/PDDOHPmDHQ6HSYmJuB2u6HX65FIJHDlyhVsbGwgmUxifHwc\n/f39XJ6eP38eXq8X09PTWF5extbWFnZ2dvjmUpfb4/HAarXi0qVLXM5Ss8VisSCTyUCpVKJWq/EA\n4Vqtxkdp9Pb2IpPJoFarob+/H3q9nt/Xgw8+iHw+DwBYXl6G0+lEOp3GxMQEtra2WLbTarUQDodx\n7Ngx/hmdTocrV65gZmYGyWQS2WwWyWQSw8PD6Ovrg1QqxfPPPw+Px8PlKTVBSqUSDAYDFhcXMTY2\nxrrGZDIJuVyOoaEhlmrt7u4yJ7q9vY2enh7k83mcOnUK4XAYxWIRQ0NDnD2dPHkS5XIZBw8eZIqG\nyk0q5/V6Pfr7+1k6ZTAYIJFIkEwmMTQ0xNKhSqUClUrF2ZvdbmfJWalUQjKZRCwW4yZWT08PNBoN\nstks4vE4dDodgsEg7HY7isUiJBIJHA4HVlZWMDMzwyVqqVTCyZMnEYvF0Nvby8oL2typDJdKpdwg\nJC6xVCpBq9WyvpQ2RKFQCLVaDa1WC4vFApFIhFAohNHRUcRiMdZcBoNBaDQauN1ufj0CMZlMxlwy\ncbqkIaaMi6qQQqGAZrPJlZ5cLmdpFYGKQqGASCRiCSJlyrTmKpUKc520UVHiQN10Ak76/lqthnq9\nDoFAgFqtxuoHgUCAUqmEQ4cOsezR7XYjHA7j5Zdfxs9+9jNcvnyZs1ilUsl0g8lkwuDgIGQyGUKh\nEBYWFpBOp1nqRxknbQoAmC+tVqssF6T7SJXR2toa34tarYZMJoNqtXrX5vInf/InbwnT7gmQrq6u\n4tSpU9Dr9VhfX8fU1BSq1SrS6TRu3LiB5557jhsV6XQag4ODWFpaQiAQwKOPPop/+Id/gMvlYkFt\nNBqFSqWC0+nEG2+8gcceewzhcBgXLlzAwsICKpUKJBIJUqkUTCYT9Ho9S5xqtRr8fj8vEqVSyZKO\nQCAAlUqFSqUCjUbD3d59+/Zx1lIsFqHVarl7WiqVIBAIYDabce7cOSiVSvh8PuYLK5UK0uk0/H4/\ntra2YDSO5kzGAAAgAElEQVQauRyLxWIQiUS8qCYnJ2E2m1Gv13HgwAEMDQ1BJpNhe3sbjzzyCHdu\ns9ksl92JRAKJRAKPP/44gsEgy3NUKhU++MEPsjzJZDIhHA7DaDTCbrdzQ8Hj8cDn80Gr1fKhcCaT\niSU3arUaRqMRW1tbmJ6ehkwmQ71eR7FYRDAYRDAYhEql4gW4uLiIarWKWCzGsqWBgQGMjIxwBqNW\nqxlcc7kcZ15U2tXrdZTLZSiVSqjVai7JGo0Gy7NIgUFlvN/v5zKzUChALpcjkUhgdnYWm5ubsNls\nqNVqyGazcLvdiMViMJlMkEgkzK3Txmiz2VAsFmGz2ViepNVqucqhe9BqtXhTNZlMnI2RXM/tdrMe\ndGtrCyMjIywFU6vVXOGQ9I6yI51OxxrhcrnMlRRlTs1mk0Gbnj/KwmjearvdRjQaRavVYo0lbTbh\ncJj7FQQ2e3WolLnS66XTaaYFqClEgEnZI71vukfHjx/He9/7XkxMTCAajeI73/kOXnzxRQSDQeTz\neUilUuj1ei6/CbAFAgFSqRQ2NzcRi8V4Q3M4HLxxEPhRhUHZNZXwAFiKJRaL2cxBSRjRGKSWoPGJ\nQqHwtxtIf/jDH2JnZwejo6MwGo1YXFxkDSGNQyOpzNTUFHNOH/3oRzE/P8+7NXU5jx8/DoFAgJ6e\nHvh8PqyuriKbzcJgMKBSqaCvrw8jIyMMkoFAAMViEdlslrWs2WwWo6Oj6Ovrw40bN7gzSjKiaDSK\narUKr9fL7hStVguv14vr168zIU5yJZVKBavVCqFQiJGREYTDYZZDERk+NDSEQCAAq9UKjUaD9fV1\n3hmj0SikUimeeeYZqNVqrK2tIRaLYW5uDtFoFH6/HzKZDD09PfD7/XxNlUoFer0eOp2OtYtEjwSD\nQZbQRKNRDA4O4tq1a6hWq1AqlTx5vlgswmw2o1qtYnl5GX6/n0FNJpMxz7u+vg69Xo/h4WFUKhXc\nd999WFxcBPArGUx/fz+sVivuu+8+LjkJyK5evcruL61WC5PJxHSI0+mExWKBRqNh4CD+lgCAqINC\nocASNovFwqJ0uVyOQCDA3Xa6TzabjRs6hUKBFyyV0fF4HHa7nV1rBoMBIpGI1QVra2swmUxIp9No\nNBpcFqrVaphMJqhUKmQyGQZ3gUCATCaDyclJ7qybzWaEw2HW9NrtdsRiMUxNTXGzVafToVwu80ZO\njSLiNYkjNxgM0Ol0rN+s1+t3qUmoQURZMwG2VCpFo9Hgaq5er0OlUt3lxKLMrNlsQq/XIxaLodPp\nMHe6V89JpXu1WkWtVoNUKsUjjzyCd77znejt7UW5XMbTTz/Num2ZTHaXWoCE9BKJhDl80mqTY8lk\nMvGkL2qi7nU7UaOMMlQyFlBzLJ1OI5vN8veS5Gmva2zvz/5WA2mhUMDIyAheeuklLCwsQK/XQywW\n44c//CHK5TLzefQw0xk9Z86cQaVSYdFxIBDAu9/9bi7rFhYWoNPpoNPp4HA4sLGxAafTiX379kGl\nUkGhULD+sFQqQSQSYWRkBEeOHOGGSzweRyKRQLPZhNVqRS6XQyaTgVgsRjKZhE6nw9jYGIxGI+Lx\nOIvNSXKiUCiwuLiIZDKJvr4+XL58mcsQuVyOc+fOMYivrKxwhtJsNuH1euH1epHP5/HAAw/g2rVr\nOHXqFFwuF3eSG40Ga+qEQiGMRiMcDgerB/R6PWq1GlwuF+bn52EwGHDkyBEWpLdaLfj9fnZaHTx4\nkBteSqUSdrudu9DFYhF2ux29vb1QKpUAAJPJhNnZWQwODsLr9bKC4uDBg/D5fDh16hRrSqmRIxaL\nsbCwgGaziVAoBLfbjVqthpmZGV5g1GHX6/UwGo3odDpsL5RKpRgYGEAul+NSNZPJsFOIMsl6vc5U\njd1ux8rKCjvZ2u02SqUSEokEhoaGuNwjk4DT6UQ8HmeHk9Vq5Y5wOp3mSoGsleVymfndarXKWf/G\nxgYcDgfzzOVyGXK5HNFoFC6XC/F4nJuSxJeTtEgikXCZT/I2v9/PWSV1vgnU4vE4hEIhc4NUWmcy\nGbaPymQyNnpQVkt8KvGY1Lyi90j8KWWW5XKZOcm9siTK6EhHqlAoOEN3Op3o7+9Hq9XC9vY2nn/+\neczPz7MJgzStRNWQnZOycGp0EV8LAL29vfB4PHdxtcSP7s0i6d8ikYiz0Ha7jXg8ztlru93m+7kX\naOl9UVb8qU996i1h2j0B0tdeew0XL17EyMgIpqen4ff7EYlEMDs7C5FIhBMnTuDw4cNoNpvcWSfu\nh3gdq9WK48eP4/Lly7h8+TJzPul0GkNDQ1haWoJYLGarXz6fx/Xr16HT6dDpdDAwMICHHnoIt27d\nwq1bt3D79m1UKhV4vV4IBAIm5aVSKWs6JRIJbt++jRs3bqBYLMJkMjFYkxsnEonA6/ViaWkJKpUK\nuVwOyWQSRqMRw8PDqNfrLOo3Go3sMKFMgRxNxJ9RyRgOh3nD8Pl8aLVaWF9fRzKZ5O44EfLU7KGs\nKRwOw+PxIBKJ8HUkk0mIRCKUy2V+ryaTCVqtFmq1Gu12G1arFc1mEzabjXft27dvY3t7G81mE6ur\nq5ienubfp9FoUK/XEY/H8dBDD7HjpdlsYnh4mAGDeGvgzvEj/f39EIlEkEgkLPAmsKINUCQSMbdL\nmRPpBYk37u/vx9raGuLxOIMYZTIknbFYLLyIKMuNxWKsK8zn8+jt7eXFTPefhPXE+xENE4lEkM/n\nMTAwgFKpBLVafVdJXCqVsLW1BbFYzCYOi8XCoETc6eLiIiwWC/r7+2EwGNg/T5ssWYnFYjE0Gg2X\nriRgJ86UfifpQcm+SeVzJpNhioHuC/GwpFSgjLfT6aBer/OGRZpOytwIfCQSCc88oGywVqshGo1i\ne3sb0WiUK8i93n2igEi4T9dP7402DZFIxBstAP7d9IeyUVoDBJz0tVKphHg8zptAvV5HNpvl90Sv\nSQ0qAmGxWIw//uM/fkuYds+AVKlU4vLly1haWoLVaoVer4der8fExAQqlQqy2SwUCgUGBgY4Q4rH\n46z9Gh8fx6uvvgqNRoO5uTnOFqamphCPx1lUrVAoUKlUYLPZkEqloFAooNVq8cYbb7Asg2yIgUAA\n7XYb29vbUCqV7Iufnp6GVquF2+3G0aNHsW/fPkQiESSTSS6ZDQYDpFIpCoUC+vr6mF8dHBzEjRs3\n2HNNJXen00E8HsfGxgZnitFolDOjUCiEkZERVKtVrKysYGlpCVNTU9jd3cWTTz4Jn88Hm82G8fFx\nlu/IZDK89tprXL7q9Xq2pno8Hmg0GkQiEaYBSIM4MjLCwnhqqKVSKX7Y6/U6dnd32TOvVCpx8+ZN\nZDIZtndGo1FuHoyMjGB+fp6F6mS7FAqF2NnZQbPZRF9fHy8opVLJpXUqleKFTEFc9F6ZGW06pB6g\n4RT0Oezu7rIUiTIOAgHK0qrVKjdU9vrSq9Uq5HI5D4shaRBVKuR4Ir6ZnjGJRMIZp1KpxLlz55DL\n5VCr1eD1etk4YbfbUSqVWOYkFothMplgMBj4PZvN5ru4RxoUQ776RCIBjUbDXOTehhsJ/kmKVqlU\nYDAYeO6BUChEOp3mISTkviOuP5fLMciToJ+4RsryKAum+y4UCrnBRQ0n0ouSDRbAXaBLFQGB3l7O\ntVqtotFowGazYWBggDN22jQo8/zXf/ZmqWKxGMViEblcjp930tdSRkx0BGWjRBPQBvFbbRF99tln\n0el04HA42LJZqVRw/fp1LC8vIxQKYXNzEysrK7hx4wb8fj9arRZsNht0Oh0GBwdx4cIFfhh9Ph9S\nqRRLZlZWVriRRR1b6piePXsWOzs7LFCmpoTX64XP54NMJkNfXx96e3sxMjKCubk5ZLNZ3Lp1CwsL\nCyyfyeVyOHHiBNxuN7xeL6rVKkKhENRqNcrlMsxmM1566SU8/PDDyOVy8Pv9nKGSbMVoNOLJJ5/k\nrwFAIpFgS2C9XofL5YJarYZYLMby8jLUajU7rXw+H44ePQq3281SE5FIhOXlZUxNTbEge21tDR6P\nByaTCVevXmXwqFQqOH36NJRKJcLhMIMSmReIw9rc3MT9998PrVYLjUaD3d1djI2NYWhoiLWLs7Oz\nyOVyKBQKyOfzmJubYzCu1WoIh8OQy+WYmJjA1atXYTQaWcoCgK2EmUwG29vbKJVK/PCTGSIWi7Fe\nk+6JyWTiQSOkt6QONQDOGqnjTV/fqzkk2+HeUpZcR5Qh53I5VCqVu3SK5L0vlUrcHCUwBe5MXDIa\njayCIFuj0+nkyVxOp5NLWJVKxRkSXU80GoVcLmc9MFUZarWaOWKZTMbCc3IYkYyJsjfSjtIzJpFI\nmDOs1WrMQ2cyGd6oaNMhows1pEgvSs/RXmssNW3IHw+A7zmpIvaW4XstqpTtU6ZIDjtyVFG2SeC8\n1ze/d6YA0R3kMGu322g0GvxsAmB52r8G0b0ArVar8fGPf/wtYdo9AdLTp08jEolgcXER73nPe/DN\nb34ToVCInQ02mw1utxtqtRoWiwVSqRRWqxXlchkajQYvv/wyZzXUsQTAukSBQID19XXONPbt24dA\nIMDOFOpIymQydtfY7XaeQPP888+j3W5jcXERZ8+ehdlsZg6T3E+lUgk//elP0d/fzwM83G43kskk\nZDIZA0in00F/fz8DZCqVgtFoZJDy+XywWq3Y3NzkjjSNF1teXobdbmepT7lcZrnNyMgI9u3bhx/9\n6EeYm5vD6uoqisUiBgcHodfrce7cORbTx2IxOJ1OJvEpm5ibm8Po6Ci0Wi2q1SpcLhfq9TqMRiNM\nJhPrOk0mE1KpFMrlMjdzZDIZu7ysVit++ctfwmq1wmQyIRAIsIvq4MGDEAgEKBaLcDgcEAqFrM/V\narWQyWTs0qLGjdPphFKpRDweZ01iJpNBX18fYrEYDAYDgwUNfCEAo7JcJBLB5/PBYrEgkUggm83y\ngqVMlCoBohUKhQJTRMRHk3efMj4C93Q6DaPRyJk08Yi0aJPJJMRiMXp6etjLTVObiDqyWCxYX1/n\n5hhpN8n+SO6rTqcDr9eLYDDISpO1tTXuxtMmSnRINpvlBhI9A9VqFTabjdUqQqGQJU3kaKJRivRs\nyuVy7gtQ9kqSNcroiE8leRFJlvb6+glkKcOlrwPgzHnvzAGFQoHx8XGmSQjwSKVD9/lfAyBZOwUC\nAXZ2dtjwQLMQyK21lxogEKa/k8HA4/HA7XbjiSeeeEuYdk+A9O/+7u/g8XgwPT2NV199FQcPHsTw\n8DDfkFAohEgkwg8FcTwymQyJRAKjo6OcUdVqNVSrVTidTrzjHe/A6dOnMTw8jPHxcZ41SHwgEdW1\nWg1Wq5W7ruPj4+w3X19fx9GjR1njSeBBD1Amk2EnCwBWDtBUo1AohKmpKdaQknib/P9TU1PQ6/Ww\nWCy4ePEinnzyScTjcdx3333Q6/V48803USwW2ba2sbEBtVqNCxcuwOFwYG5uju+PWq3G1tYWN70M\nBgOuXLmCsbEx1Go1xGIxHDp0iBf5a6+9hrGxMS5Tb9++zQ4s4i1XV1eZ6+vv78fk5CSUSiWOHTsG\nm80GqVSKWCzGw09mZmagUCgwMzPDGfng4CByuRxmZmZw9uxZDAwMYGpqCrdv34Zer4dIJIJWqwVw\nZzDHysoKc4k0ZzORSKBYLN7VGKnX69BqtUzv0KIEwNkScGcqllKphEQiYeCkBh1xvXuzSnLtlEol\nGI1G1Go11gHTpqtUKhGJRNifXq/XWT9KGWGj0eBpQjTxiWgJWsw6nY4F7slkEiaTicfJSaVSpFIp\nRKNRDAwM4M0334TP52NJ1+7uLs89JQUI0UlUctNUNCq5U6kUv9fJyUnmK2l4C1VCpDqRSCQoFoss\nEdw7KIS+h2RGRB0A4BKdpFfUQCJFCDVvqLkFgCkDGoFHDV6v18vde+Iu9zaV9ja6CAQpMWo2m1hf\nX2dQJ4nb3uE4FHvBk7JjSlKoV/DII4+8JUy7J0B69uxZdgPt7OzA5/OhXq/zwF76IOlBpZKm2Wyy\n9Im4qng8jrGxMUxMTOD8+fMoFAqIRCKIxWJoNpsYHx9HMBjE8PAwYrEYCoUCgDvlDekPt7a2MDY2\nhkAggHA4jEAggO3tbZ7ZeOjQIYyOjgK4ozgIBALo7++Hx+PB7OwsarUaA1a1WmUyP5vNIp1OY3Jy\nEpcuXcJ73vMeiMViRCIRti8mEglMTk6yfMfj8aDdbmNlZQU+n4+dN3a7HRsbG8jn8zy4VqvVYmho\nCPPz85iammIRO2WSdrud53rSeDqtVsuCcZo0FY/H4ff7Wbv3tre9DZFIBAaDgfWuNGiYbJVXrlzB\n8ePHUSgUOLsiPjuVSuHs2bM4efIkPB4PLl26BJ1Oh4GBAZbPkIWyWCwiEokwaKbTaeZJ6RlJJBIw\nGo3sgAuHw5xJUInX6XQgk8kQj8ehUCgQi8W4cUL/paEkxKOJxWIGO1pING+VOFpq0lC1RLZIAo5i\nsYh8Pg+j0cgaSzIU0D0LBoOsTSX3UT6fR7lchtfrRTqd5vKZQCiVSvE9+tdjAolKILMBARhpROne\nxGIxSKVSyGQyDA4OYnd3FyqVilUeqVSKp3GRMYBcQXsHhpAllP67l05QqVRceVGHnHoAdD1EBwC/\nmjxFmxs19WhtO51OLuGJr6SmLwHpXr0oASw10gKBAA+ZJuXJ3s9r7wg9AnSa5jY2Ngaz2QyVSsX2\n3Le97W1vCdPuCZAajUaWi1BZLpfLUS6XMTAwwBKgbDaL3t5eFAoFtNttHDp0iPV/JD/p6+vjyT8y\nmQwej4dLFrFYzA8HlT0k5CYx+MDAAFKpFIaHh1mIPjQ0xFkrZcPUOT9w4ADLOqrVKlKpFA9D2b9/\nP8LhMMxmM4xGI7RaLSYmJpDP59kTLRQK8eijj3JzZ3l5+a6RckTY22w2HDt2DG63G4FAADqdjt1G\nLpcLKpUKly5dwgsvvIAHHngAgUAA165d46YdPczhcBiLi4vw+XwoFAo4fPgwCoUCWq070+O1Wi0e\nfPBBnshDC4OMDpOTk5iYmMDg4CCDVDwex8TEBPx+P1tgyc46MjIClUqFw4cP40c/+hEMBgNmZmZw\n9epVSCQSpgmMRiM8Hg+q1SoymQx30GnMWSQSYXcZqS6y2SyXpdQIJA+8VCplzo+4OxpLR+UplZjU\ngKMhxWRzBYDd3V3mG2mh0lQy0tGSYB0AC/YJQGimKw1LodMbaJq+XC6H3W5n4wI9kz09PRCJRGwa\nISAiNQHpH6kRRxwmdaxpGMrIyAhLuCYmJngj6XQ6bK3sdDr8jMtkMn7OqcNP9NJeBQU1c6mBRLNg\n6T4R+FH2uTdzpVmpVDUQFUCGAjJpmM1mfk8EuES7AGAgpY1j79epSqPuP3G/e4N+nugLkg8ODAxw\nBUhNLfr9p06dekuYdk+A9AMf+ADm5+dx8eJFnpwuk8mwsLCAeDyOaDSKQ4cOIZFIYGRkBA6HAw88\n8ABu3LiB06dPo1QqIZ1OM++3srLCA3SJm6JZlalUCna7HQDY6aDRaGAwGNgqqtVqufza3d2FyWSC\nXC5nTV4wGOTBIYuLi6jX6xgdHcWNGzcgFosxNzfHHfLr16/z+DuXy4W1tTVsb2/j0KFD2NrawvLy\nMiwWC3Z2driUpWnva2trrOejTO3WrVvs+6Ydk6ySjUYDMzMzzA1TR1atVmN9fZ2lW3TMiFqtxsLC\nAlZWVtDT04Px8XGUy2UEAgFEo1Go1Wrs7u7ygAxSQ4jFYly9ehUikQh9/+/JBeT5J90n6WtbrRZ3\nnEkPOT8/jwMHDmB7exsi0Z0hyhaLBWKxGKurq6hUKrhw4QLTHzTYuFQqccecRqhtbW2xNZcWFTm7\n6vU67HY7QqEQpFIpn6JA062oFA6FQgxUtJgoQ6JMlMp04pVtNhuCwSBkMhmXry6Xi2mdRqOBVCoF\np9OJpaUlnoIUDAaZzhAIBBgZGUEkEmEvPIGUSCTikxJIB9rp3JnOHwgEGNBJdwz86ngPGgSi1Wqh\nUChYapVIJHigR09PDw8tITkZNdbkcjlKpRJSqRTL0mi9EFgSP0rNJ8oQ6b4Bv5qfSo2yf63tpKYU\nrUNKVtxuN/Of1Ejam5UCYNCk16MNgZQgJG8ijXaz2eSfpfeyNxuVyWQ8XUqv13Pzkq6Tkq/faiB9\n5plnMDc3h0984hNYX1/H1tYWbt68iaGhIbhcLgwODsLtdmN4eBi3bt3C1NQUfvGLXyCdTkMmk8Fs\nNvOUdnLjiEQintRDI/VqtRoefPBBNJtNLC0twev1otlscgZkMBgwNTWFRqOBzc1NLrs0Gg2OHDnC\n0iQaErx//34epHD79m12GZ04cYKtfAcPHkQoFOIyk479oGnz5PufnZ3lQcKdTgdarZYXnFqt5gUq\nFAqRz+fhdrvZfWQwGLiRQtbZVCqFfD6PUqmEW7du4dixYzCbzZBIJPD5fCztIXE3SY1CoRC8Xi+7\npMLhMILBIB588EFukDmdTvT29vLsU7pOArh4PA6z2cxuJsro6Pqnp6dRLpd5Wr5EIuGhNWSbJR0t\nNenK5TJznCQDIjkcNX6KxSIqlQofCUOgQjwnVRLkSjObzRgcHMSlS5d4Ycrl8rs60MCdjj6JzKl8\nHRwcxMbGBjcwC4UCnzVF1QUdV7O2tsbcW6fT4fFsNHyGJpqRVImyQpKTkf2yVCpBpVLBbDYjmUyy\nlXGvDZIE/TS0g7jCvR7/2dlZ+P1+5jnJebTX7dNoNKDT6WCz2fhoH+IuabYBNQPJckv3iaoBkqMB\n4J+VyWQ8e4KaSbSJ2Ww21lLTkG2ac7pXI7qXGwXAnwFpqXO5HH9u5NUHfmX13Muz0tEjQ0NDsNvt\nUKlUvJERL0tALhAIfruBlDql58+fRzAYhFQqhcfjwcmTJzE7O4utrS288MIL0Ol0MBqN+PGPf8y7\nHBHpPp8PjUYDJpMJo6OjXPrQwysU3hmvtr29jWAwCLlcDq1Wi3g8zt7mdDrNQ3cLhQIqlQoikQh3\nOR977DGIRCL09/dDKpXyqDVyT5EMhRpOoVAIoVAIc3NzfD0k0SkWi2yvvH37NrxeLxKJBI4cOYLl\n5WUAwNDQEEKhEHZ2dnDw4EHmTA8cOMCvLRAIeITftWvX4PF44HQ6oVarMTc3B5VKxd7wS5cucfOH\n6A69Xo/d3V0cOXIEBw8eZLcX2VTL5TJGR0cRCASgUCjg9Xpx48YNtosSPxkKhVjjOjk5yeU2TSmn\nhspekCRfPMl97HY7FhcXeXI9dffJ1UL8GWkl6ZDBSqUCq9UKu93O51g5HA4+24kGZCgUCuzu7nJT\nkuahRqNRFIvFuxoyNCicTB2UeRFQNxoNhMNhtsMSIOh0Ona9pdNpvO1tb+MpXeTXF4lEfJBhvV5n\n00Q2m+XsnxpsBJAkwCcVAAnjKeOjTrvFYuFjSPYeaxOLxXhc3cWLF3kQCKkRaFI/GTGIsiGXG7kH\n6/X6XYOkCcj3ivMBMH9MXXqqSGhMJjVfKSM2GAzcld+rDyYTwl6HEv2+vaV8JpPhwyfr9TrzzDRo\nmrJ2omCEQiFcLhdblulzI/CkDJTKetoYTpw48ZYw7Z4A6Te+8Q3uUJ44cQJOpxNzc3NYXl7Gt7/9\nbUilUrzzne+E3+/HtWvXOIPqdDqYmZmBRCLBwMAA5ubmcPPmTayvrzP/QjIe4M5NpJMmDx06hFu3\nbrHsgsqTU6dOsQWUZCbVapUbCGtrazAYDDh27Bjy+TxeeeUVrK6u8iBqt9uNfD6PlZUVnl964cIF\nnDhxgjNao9GI7e1t7Nu3D1NTU5DL5dja2oJarb4rU+50OgwQNBiDnDZmsxkulws+n49ngh4/fhwX\nLlzA1tYWH43idrt5RNz999+PlZUVzM3NwWKx4JlnnkFPTw88Hg/C4TCi0Sj27dsHi8UCtVqNN954\ngzO0sbExmEwm5lFpl3a73TzekPS2gUAAo6OjLPinQ9/oRAJqypC+k7JugeBXg4H3ynEI5GjD3Tvf\nko53MRgMfIRJKpXiActUqlJJSq4dgUCA3d1drK2tcdOMSjiyJu71i9N0I6fTCY1Gw2DpdruZTjhw\n4ACi0ShTEKRDpYYhud3W1tZ4CAxZjvv6+rC6uopMJsNcIgEtAHZf0fURtw/grrI5m81ySQ3gLg6y\n2Wxic3OTS2bSuVLjiyok0pgODw9jdXWVFSnNZpOlZsQL0yZCnxf1OIgbzefznIkSnUL3lZxMdGAh\nNcZIG+rxeHggyl5J0l6wlkgk2N3d5aSChguR8oSGvextIFosFkxMTKCnp4fPlSLagCiKvaqAvQ6n\nBx988C1h2j0B0itXrqBWq+Gxxx7DT37yE5w8eRI//vGPOXt44okncOvWLdbfzc3Nwel04nd+53fQ\nbrd5MV28eJFlScT/0Bg4khzZ7XYe1kxNFOJoqBtoMBiwuroKm82GpaUl3HfffVzmjYyM4Ac/+AGO\nHz+ObDbLx1WQPOqll15Cq3XnHB23282cVKvVQm9vLyKRCE+R39zcxPPPP48PfehDfLaMTCbD7du3\nORujBhFZHGmYQy6Xw8bGBh566CFEo1FEIhEEg0E89thjcLlcmJ6ehlAoRCQSgUql4iEVyWSSpxJ9\n+MMfxvXr16FUKvGOd7wDYrEYZ86cwfLyMvr6+uDxeLCxscElHh1rUigUkEwmYTabUS6XoVAoMDs7\ni06ng83NTQiFQnbakHedhp4QeFarVSQSCT4dkwZ0V6tVbG9vI5VKseidvp9GoVGJR8ef0DyGer0O\nt9sNo9HIWeXeRUfZnlwu54HfKpWKqw96HqgMpXkCPT09iEQiOHr0KDY3N2GxWLhZQ1loNBpFT08P\nl4U7Ozus3KDxdnRoHXG51WqVZxqQDG8vwNERxVS6m0wmLttJlkR8LJ2GSpsQDRFpNBrYt28fwuEw\nbz7Dw8OcuBBXHgwG+UQDkejOCD4yhtARNuTNJ8ChBittgnvPU6LpaCSJInkVlevkRFOr1Qzs9DkR\nL+T4VdQAACAASURBVErPCmX7ezv3wB1gp2lRNDvW5XLxe6MG095GHfGgNIKS1jzRUESF7G2I7W2e\n3X///W8J0+4JkNJBbi+++CL+9E//FC+99BIUCgUCgQD+4A/+AL/85S8xOzuLkZERFom///3v5yMJ\niMujXZKO2hWJRHwWuUwmw+HDh/GLX/wCAoGABw5brVYMDg5CpVLBaDRienoawWCQXSgEmFKpFCsr\nK9BqtXjggQfQ19eHlZUVZDIZniRFGsN6vY7JyUmcPXsWJpMJQqEQr7/+Og4fPoy1tTVEo1EewJLP\n5zEzMwOLxQKVSoVAIAC1Ws1ZCVnikskkvF4v4vE41tfXkUgkcOjQIT6J8vTp05idnWXB/Pb2NpaX\nl3lQ7vLyMg4ePMgd5MnJSQwODsJgMGBpaQlqtRqJRAJPPvkkIpEIvvWtb+Ho0aMYHR3FxYsXEY/H\n8dhjj7G3f3R0lBttNpsNJpMJm5ubmJ2dZfeJSCSC0+lELBbDxYsXmWsjuy91rTudDg9mptmQ1DEG\nfjVxixYmZUHlchkLCwt8ssL09DQ3FagU/n+Ye/Pftu/7fvxBUvdFUqQoUrx1UBd1y5JlW46PxElq\nJ0HTFlmzLukyoGg3YMAOoBj2w/YHDAOKohuwYcBS1FiS5miTOG0c27Et25ItS7Lui5J4iJR4iBIl\nkrql7w/q4xl5+AKffA8gFRC4Sa2LfL+er+fz8XwclKJubm6K4IJhe1woLi4uytaY/FJu6MvKyoSD\nWFNTI0o1k8kkXZ7VapVnUKlUyoVIfJedOQs8x11uu4lXs4iQ4xyLxVBQUCDiC74eXDId54dycjgu\nleXyhi5WlH3ycrZarejs7BQKFY1GWIiIU/JiMRgMYpKTTCbl5+Nrx46e7z/9C1jcqVDSaDSypOP4\nfBwDJU+Xlw3fM9L8eBEdHh7C5/MJNLWxsYG5uTl5Vo5TpWpqamA2m+UZ4+9GXwtiu/x3AE8tmchT\n/aMupD/96U8RiUTwT//0T/j888+F+/nd734XmZlHmfIffvghVldXcfHiRemcnn/+eXg8Hnz22WeC\nU0YiETz//PMIh8OIx+MyOgJHmI7b7YZWq4XJZBJlSzQafYqMzLC1cDgsB7G3t1cOBRMlm5qa5PNo\nzsw3cWdnB2fOnEFxcbGEo6lUqqe4sEwjJfZ2eHgo0QrxeByBQEBoPewanE6n2LPduXMHWq0WWq0W\n9fX1GBwcRG9vL3Z3d9He3o75+Xn09fVBo9HAZrPhs88+g8FgQEVFBT766CPs7u7C7XZDo9FgdHQU\n1dXVGB0dxeXLl5GVlYWFhQXp8kjJUqlUaGlpwczMDLq6usQQmSYzPT09uH//PhwOh/AFWcSWlpYk\n+4hjGPG3pqYm4elyObeysiL6dh4gbs95Gep0OlRXV8Pj8Qg/ldxiYmk8BBQpkB+6uLiImZkZ0XGz\nK+TiIhqN4oUXXsCtW7fw4osvYmhoCB0dHdje/ipNk7pxlUolDmAcKRcXF2GxWITLSPyWvztt3whB\nsasjP5Z8VdL9qE7i70UqUUZGhiirjnNiiUuTJlVeXi6cbJvNJs++3++HRqNBWVkZ8vLysL6+LmeH\nZt+EZFjsSeQvLS2ViY4d/Msvv4zp6WmR4SqVSrHjI3ZK932eA+KtTqcTRqMRJpMJk5OTEmxJ8Qed\n1SYnJ+Hz+VBRUQGFQoGRkRGsrq7KtEcusc1mg9vtliXScdknF1fsSImNskgDXxlCU4jwR11IP/jg\nA/zjP/4jbt26BZ/PB7vdjh/96Ee4e/cuZmdnsbm5iXPnzuHUqVNIp9P43e9+h5ycHPT29qK3txcv\nvfQS1tbWcOLECTgcDly9ehWlpaXC06SjdzKZFIyT3YPf75dby2w2Y3l5GTabTSIFnjx5IoTqVCqF\npqYmMRth8NtxA468vDxMTk5K5EMwGBQ7vbm5Oezv78t23+124/PPP4fH40Fzc7NsGEnroas6eaQE\n74uLi7G/vw/HMTOU7OxsMSm+e/cumpubcfLkSRgMBoyOjmJ9fR1nzpwRHPHy5csIh8OYmZlBS0uL\nUEU++eQTjI+PY3d3F5cuXYLP50N2djbUarU8fEqlEi0tLdBqtbBarZKDFAqFhMmQn58vfp8AZMuv\n0WgES9vf30ckEsHo6ChisRhyc3Oh1+txcHAgSzyr1fqUFyYAKdBcKCWTSXR0dODs2bPCBOCITa4o\nmRs0dKYb1sTEBABIt8uDXlxcLOIIv98vUmONRoNYLCaHjsWc34evFy0MNzY2ZOkZCoXkUgcgngbs\nhADICBuPx6UrO+4eddzikOMqC6tKpRJJI2M4KAJxuVyCMaZSKekWtVqtGJ+QG7u0tCSFiLxTQgnk\nWVOSSx4tpcF5eXkSf8JzFY1GBVvNyMgQWSshH+Kpra2tKCwslL3Eq6++ivLycmGo6HQ6DA4OYm9v\nD1VVVbBarfjtb3+LkpIS4ZzPzc0JPl5TUyP2g5w0jv9vwmnHWQAsolxQ8z3hxx91IS0tLRXJ4+bm\nJrq7u/Hzn/8cbrcb586dg0p1lEj4r//6r+jp6cGpU6cQDAaxtLSElpYWxGIxXLlyBX19ffjss8/w\nyiuvwOv1QqFQwOl0IplMimxOrVbDYrEIrkqjh+3tbdTU1EjiY11dnZhNmM1mZGVl4fnnn5cNK31R\nt7a20Nvbi56eHrS1teHWrVtwuVzY2tpCYWGhaM0dDoccHJ1OB6PRiJmZGeGmkoz9+PFjTE9Pw2q1\nCqd1a+som5yYXyqVgtFoRCKRgEajwUcffYSioiJkZmaiubkZOzs7ePDgAerr68WfU61Ww+/3Izs7\nG6dPn0ZFRQWWl5fR2Ngoy6rx8XGUlZVBoVCgsrISDx8+RH19PdRqtYD/hYWFyMrKQiQSwf3797G3\ntwe9Xg+v1yvEb9LOTCaTuOhPTk4K3YQmIFRjMcKFFBqtViuGLoeHh0Kq5yjO4sIOX6vVijSW8krC\nPDS4IEbKJRe703A4DOCrzoOYKqliTF7gSKtSqeTZ0mg0Upz5+QxJJCOBozfpXXwumO7JBRILpcFg\nkEVWTU2NPD+ESogTMsueX/+4O5NCcWQuwoUOcc+SkhKEQiEkEgnxQaCpM83DScpnR3yc68nxmi5T\npKDRutFut8NgMGBxcRE5OTmw2+0YGRlBVlYWrFYrlpaW4HQ6JS7EaDRCr9cjmUziueeek/9WXl6O\n6upqgcUKCgrkWXG73aipqUF2djYePXqEV199FRkZGZibm5Png8WXvzffV2LLLKL0ACAOyguJXetx\nmStZAl1dXV+rpn0jhfTmzZtYWFhARUUFnE4nbt68ifb2drhcLuTm5qKvr0+iH86cOYOxsTEEAgE0\nNTXB7XbDYDBgcnISoVAIRqMRxcXF0llSGkbOHoPiFhcXxaeRoDn/PjXPPDwnTpwAACGoU7JJ2hLj\nOaqrqyWP3m63i27caDRibm5Otru0UWPwXnd3N9RqtUQmkJs3Pz+PeDwuN/je3h6mpqaEI8lMmebm\nZjn4dKYn55FuVi6XCydOnEB2djZu374NleoozZMS3GQyKVEhxJSrqqpw9+5doQ3t7+/j+vXr4g3Q\n0tIiBh08AJQOVlVVCV+PcdgAxN394OAAer0eGo1GaEixWEy6wVgshlQqJVQ1btH5NbnEYBGxWq1i\nmUfzZdKmSEonb5LuTyw8FFLk5+ejoKAAq6ur8nNRo8+Lgg73HDW5zQcgxiu1tbVCwqcPg9/vlw6H\nhWR1dRXhcBg2m00uUxodHx4eZVeZTCZ4vV5RxrHY5uTkiPopMzNTuj4q7zhhxONxCTcsKSl5KpmB\nSi7yLVmsOBVxSUZ1GUdyAFJE+TrTWIXFLysrC7Ozs9jdPYrRHhwchN1uR0NDAwwGgyip2tvbcerU\nKUm0dTgcMuofX27xPSSMQr8HnU6H0dFR4Z9aLBbBqNnd/2+HKAoJjmOohCdYOFlYj19ysVgMzz33\n3Neqad9IIb1//744vFy9ehVvvvmmUDt6enrg9XoRj8dRVlYmps/19fXiip5OpyU/3O12Y3R0FFlZ\nWejo6MDDhw+h1+vx7LPPwu/3i/xzampKxj/iPKlUCktLS+jq6kI8HsfJkycxPDwMt9uNoqIifPDB\nBzCbzWhsbMTAwAC2t7dht9tx7949Ue3Mzc1hfn4eSqVSLgdSQM6fP4+FhQV0dXVhZmYGpaWlsnEn\nj5CEfGJWdNFfX1+H2WyWDi0jIwMjIyM4deoUVldX5XNSqRRKSkpgNBqxsbEhXfDDhw/R09ODixcv\noqGhAf/1X/8FrVYrHfSjR4+g0+kkdoMQxXe+8x3o9Xo4HA7s7OxIBIperwcA8T4lPsfDRmcjj8cj\nXRdxJnYHo6OjgvsRN1xdXYXL5QJw5H8AQGhoh4eHEqNMyGNnZwdtbW0Ih8OC11osFhiNRll2EdMj\ndQg4cgajnHR8fBzpdBpnzpxBbm4upqamYLFYcObMGaysrCAvLw/xeBwajUY6FS4D6WW5uroq3rlF\nRUVQq9VYWlrCwcGBpDMwaJD+rwcHB9je3obVapV0zoqKCng8HhiNRoEweFFtbGygpKQEGo1GvHWJ\nIXPTT2oX0zQzMjIQjUZl+iIdiNJHev2q1eqnBBrkJ7ODZy6XyWSSZFouOrm8yc7Oxvr6uohOaORd\nWloqQZJ5eXmorKyUpS1xYcI+ZE2wM6bPwsbGhjz3vBy5VKuvr0dWVpbQnAAIrsnX4Phoz+ftOBzC\nyxn4ypOUdKxYLCZL6+9+97tfq6Z9I4V0fn5elibl5eX48ssvcerUKbzzzjvweDw4ceKE0CAWFxeF\nKM7FAbmhxHKqqqrQ3t6O3/zmN+jq6oJWq8WjR49kU9zU1ASPx4PNzU3U19djZmYGWVlZMm6NjIxg\nY2MDoVAIr7zyCtLpNHp6elBdXQ2lUokvv/wSJSUlMJvNkhrKzbzRaERHR4fwIZ1OJz7//HNxj6mr\nq0N/fz/m5uZgNpuRk5MDrVaL+/fvy7+zADx8+BD5+fno7OxEaWkp3nvvPZSVlSEWi2F2dhZdXV0o\nKyuDWq0GcKQLd7vduH79uoxZe3t7Et2SlZWF0dFRjI+P4zvf+Y74pAaDQRiNRvh8PuF7ZmVlSbGk\nm30gEEBVVZXQUpxOp/gTcIkSDAbh9/uRlZWFkpISSVkNBoMoLS2VbgGA8IFHRkYEc1xaWsLe3p7E\nt6jVamg0GiwuLgrdx2AwAIB0eAqFAs3NzRJ4yEUJDwxfV/5d4qHZ2dn49NNPodFoEAwG0dTUhIWF\nBcTjcVRUVIiYYH5+HmfPnpVxndt8WhBSsGGxWGRxqFarMTIyIvlUkUgEDQ0NT+GpNNyORqOC5/Pn\nI06qVCol/oWCBrVaDYVCgUAgIJZ+JOIDkClsc3MTxcXFAL7aQLPLJMOBJie02Ds4OJCctEePHkkX\nyNSFwsJCLCwsiJCDnR0LOXmxTCLlM2e1WsVnor6+XlRrx7nFZEdw2UvjGk5jhJJIHQyFQlKsFQqF\nGJArlUp5jcgHPa5QOq6UOu4YdlwuqlIdRXUTQgyFQlhfX8cPf/jDr1XTvpFCeufOHTQ3N+PnP/85\nxsfH8dprr+FnP/sZXC4X1Go1rl+/jtLSUtn+ZmRkoKioSFJCGbU8Pz8vWCE7SxaoQCAAh8OBpaUl\nlJWVYXZ2VnTOpDzQTYftfWNjI2ZmZiS1EQAqKyvR39+P7u5uyQBiLtKjR49EvsiF0MbGBoLBINbX\n13H9+nW88soryMnJEQIxlVShUAgKhQItLS1CJRkcHBRifHl5uahCuBibmJiAQqHA6OgootEoEokE\nfvWrX+HMmTNyML/88kucPXtWTIQB4NSpU5icnBRDmP7+fjnUXCYQ0H/77bdx/fp16PV6uZzsdjta\nW1vFJ3Vubg6FhYXwer2w2Wyor69HRsaRGz313YxCJqOB+noaR/t8Pnmd1Gq1XEQzMzMYGxtDIpGQ\n9z07O1uMVoCjrjg3N1fgmJKSEjgcDvn6iURCxjcmlH7xxRdwOp0Ih8PY3t5GaWkpRkdHpagUFRWJ\nX2pfXx9cLpdYIq6trUn8NZczJpNJ/ER3dnYkrbW1tRWrq6uyLacByfGwOBZ2ujyRK3l82eTz+VBQ\nUCAKKy70uCBKpVLy36n40el00mXOzs6irq5OiPP0UCVMQV9V8mmJ4XMJxi4cgGQdMZ+KghHyRfk9\nCBsUFhbi3LlzWFhYwPPPPy+WiVzycGJh90e+eDgcxurqKiKRCNbW1kTevLGxgbKyMgBfaf75vtJB\njayI41JZFtHjhZSX7XH6Eylx9DDlZXN4ePjHXUivX7+OX/7yl2hsbMTZs2fx85//HC0tLUilUkJp\nqa2txeHhIfx+P9rb22XBUFVVJUmOjj8Y/V65cgVbW1u4c+cOmpqahD4SDofxwgsvYH19HYlEAktL\nS7Db7dLRElsrKCiAxWJBMpnEwsICGhoaoFKpMDU1hbW1NZw8eRL9/f3Q6/U4PDxETU2NxJEUFBSg\ntrYWKysrKCgowOjoqPh55ufno6enB5WVlbh8+TLGxsbkwKTTaYRCITGsjkQiOHHiBB4/foympibs\n7u6KAz3jppVKpRg609HJ6XTi1q1bsmiJRCI4ODiA0+nE3bt3kZ+fj48//hgdHR0Ih8MYGhrC9773\nPYyOjsLpdOKLL76QUZZGzIuLi5iamkI0GsUbb7yBsbExDAwMiO8BN/p0JqIAQa/Xw+l0QqFQYGdn\nR5YfNNPY3d3F6uqq8BdZJAKBAJaXl8WgmUYo9OwMh8Oy5OHyJhwOw/EH5y+OdRzZ5ufnJfNIoTiK\n5TAajVhaWkIkEoHJZEIoFEJFRYUYZY+NjSEajcpiip0noYGtrS243W7BlCsrK2G326FUKuH1enH6\n9GmRZM7OzuLChQuCkUciEYTDYZhMJlFzbWxsoKqqChUVFXIZM6OeCampVAp2ux0qlUrSG9ip0iuU\nfM3d3V2UlZUJEySZTIqnLCEQEuJ3d3dhtVqxsbEh8lIq/XZ3dyUdgGM9Oz2yI46rhljQGB9eUFAg\nkTgvv/yywACEWRKJhDix9ff3CxRDSho79+XlZYRCIVlMMmGBfNS8vDwkEglMT08LjHR8ucSJ7LiT\nE58RPicAsLS0BJ/PJxPQcZ/ag4MDvPXWW1+rpn0jhfTu3bt4/fXXEY1Gcfv2bXg8Hly4cAFPnjyB\n2+1GaWkppqenoVarYbPZcO7cOTx8+BDRaFSSF6m//sEPfoDp6Wlcv35dojCY6BmLxdDS0iJdA29r\n5p97vV4AENMLdqqVlZVQKBQSvfHo0SOUl5fD5/Ph/Pnz2NzchNfrFV9Rwg1caDU1NSEYDApVhaT6\nixcvwu/3Y319XbCtdDoNj8cjcj5iTHq9HiUlJcjMzERTU5NQkLa2tgT+uH79OtLptFCpzGYzampq\n8G//9m9wu93StVHh8+yzzyKZTMJkMqG+vh67u7uYnJyUmAm9Xo/S0lI4nU7xyYzFYvjWt74l5tZW\nq1XoOGVlZfD5fHA4HEK2Z8dFtQ09Uily4FKBBO9YLCadRUtLi4ySlAQzIYBjKpUxNPFl1hG7tXQ6\njbq6OoncIId0fX1daE1FRUUIBAJiR5eZmSmZWsFgUPw6GW3NjjUcDgtMUVZWhpKSEhmbNzY2sLOz\ng5WVFTQ0NCAvLw9jY2M4PDyUzfXxLpcuV3T1p+ooJycHoVAIWq1WOiX+d41GI25SoVBIFjKkI7lc\nLsTjcRGnHB4eih0e8FX2VU1NjXSgOzs7siWnQo2Fk8IBds/HTUB4IfBSeu6557CwsID29nZEIhG8\n/vrrTwUBRiIRwfPJwTabzVhfX8fy8jKWl5cRCAQwPDyMJ0+eYGhoCJFIBKWlpVCpVKL952LIbDZj\ndXVVdPYApHgeNyDh78Liz6IaDocxPT0Nn88n5jbAVwWUBfePupAuLCzgzp07MmK+9NJLuHfvnow0\n8/PzOHXqFJRKJS5duoQnT54IRlpRUYFr166hsrISb731Fr788ku88847sNlsMBqNkvMdjUbx4osv\nCn6WSCSgUChE71tfX4+JiQloNBosLS2hvb0dk5OTaGlpAQBcu3YNra2t0r3SQo7hdU+ePBEyvl6v\nF29O4kd2u13oPTz08/Pz6OjogF6vR19fH9544w3ZGFPPbTAYkEwmMTk5KfLC0dFReL1eXLt2TehT\n8Xgcb775Jmw2m7iA37hxA5WVlejo6MDy8rI4ypOCNDIygsLCQty+fVv4jM8//zxqamoED2Tmd25u\nLsrKyqDX69HT0wOr1QqHwyGu8bTBI26aSqVEt81oaFr0Hfd0ZdwuAOmCmdWUSCRgs9kAQMw6WGgp\nQ2T3xlHXbDYLRaygoEBGZQCiwSc2S4ggMzNT2BR8/RmEyPchGo2K/aBCocD09DSAow7m4sWLUnyj\n0agwMGi1xz+LioqEAnTcxGVxcRE6nQ7pdFoyuThi86JaW1vD7u6uLGToE5ufn49gMCjEd/IfiWF7\nvV5cunRJFo80F2Enu7GxgdbWVlm+8AKh+IFj9+HhUcRLdXU1IpHIU8su4GiLT54zn3dKud1utxDd\no9GovPdK5VH6hVJ5lEU1MTGBYDAoMmZS1KqqqtDQ0ICKigoUFxdLc0MhCbmoq6urePTo0VNb+ePq\nJXbsnFgIJfh8PszOzsrEQXYIiyiFBADw53/+51+rpn0jhfTtt99Gfn6+UGpSqZRwF9lBra2t4cUX\nX8TY2Bg+++wzuN1upNNpTE9PQ6PR4Mc//rFwMA0Gg0jlCOCTSkIX8EQiIZEb5eXlQq8KBALQ6XTQ\n6/UYHx/HlStXMDo6Kjw5nU6HyclJ8Rx98OCBuO/09/cLdpNKpeD1esXyjJ+7s7ODaDQqdn69vb1o\nbm5GRUUFNjY2EAgE4PV65eb1+XwyrpaUlAieptfroVQqxaJtaWlJIjXcbjeqq6slh358fByxWAz9\n/f0Se9Lb2ysULToa7ezsCO5qs9lQVVUly6LMzExxE6qurpYDyfGK0cDkTHq9XsHR2J1tbW1JF7Cz\nsyOFka76dD3ig6/X61FQUAC73S4HEYB8LjE+jpPsSHQ6nXBQrVarFPtUKoX19XVEIhEZ7XNzc2XZ\nQwkrdf1arRabm5swGo2Swkrfg0AgIJcPn0N6oBYVFYmrExVNLOChUEiWZ8d/Hwb1ra+vo7CwENFo\nVGKwKfcsKCgQO8CtrS3odDosLS2Jqz250sDRVBUKhRAOh9He3o579+6hoqICjx8/FqpXY2OjOKrx\n4qFHAilTfH9pEMPLk3aStM5jR6pSqVBdXY2uri6UlJSIekmlUgl9jP6wZKpMTU3J8m9lZQVzc3My\nztNMh9p5Qj+BQACFhYUwm81CCTObzUI54/ckzY0dOSlzqVQKfr9f4Lrj8NNxAv5xXmlOTg5+8IMf\nfK2a9o35karVarS2tmJhYQGRSAR+v18MbXd3d/Hss88iKysLw8PD0Gq1sqk2GAx48803MTExgbff\nflsMnHn7LC8vw+FwwGq1YnJyUrrKsbExoV1QNXT79m1sbW3h0qVLGBwcRE1NjXACGcE8MzODCxcu\nIBgMIplMipZcr9cLrsQDzc2/0+lEcXGxbIFpPr23t4dTp05Jod3c3ERlZSXm5ubQ3t4uhfPmzZtP\n5RctLCzI7fvjH/8Yv//974Wnube3hxs3bmBrawsnT55EVVWV+IEyY8ftdosKiJBCb28vpqamnhp/\n9vb2cO/ePYTDYayvr4u8ll0XDy5/7/v370s6ajweRzgcllud8kluZNkdEvcOh8Pw+/1iiMKuEgAc\nDodII8kjVCqVov2m1eHq6qq8nyaTSZYqHJM3NzdFPMCFYCwWE4EAHZn29/eFl8qF4enTpzE4OCjG\n1pmZmYLj0u7QYDDgyZMnoiJi4KLP58PBwVH+z/T0tDwHGRkZguvn5+eLSU9ubq5cnHzvKMnk705f\nz83NTbS2tqKgoACRSAQGg0H4uXR1cjqd2N3dfYqjShPwkZERUSdRzaVSqSStdHt7WyTBFJOwi/V4\nPDLVtbe3Cy/7tddeEwodnyNKtj0eD+rr63Hz5k3Mzc2JnHNiYgL379/H6uoq1tfXhT5H5yguoBQK\nhZj20LeXCrjt7W08fvxYOkh24OzS2YkuLS1hfHwckUhEuvjjxHv+fX4OpzGDwYArV658rZr2jRRS\nlUqFYDCITz/9FF6vV2IfNBoNurq6sLCwgHPnzuEXv/gFHA6HLHdSqRSef/55HB4e4le/+pXEtU5O\nTqK5uRmLi4twOBwwGAzIzs5GdXU1srKy0NfXB+AI16KV1r1791BQUACbzYacnBxMTEzgu9/9LiYn\nJyWqo7e3FydOnIDf74fRaEROTo4oQkZGRlBRUSHgORMXa2pqkJmZiZmZGYlOSKVScsvF43HodDp8\n+OGH6O7uFoks+X4lJSVwOp2IRCJwOBziJlRUVCTSw0uXLqG+vh5msxmxWAy1tbVYXl7GwsICiouL\nMTw8DKfTCbVajUAgAACSQVVeXg673Y4LFy6grq5OtuhUltjtdhiNRmRkZODOnTsoLCxEXV0dcnNz\nxSiDh7apqUm4ggaDQSSKFosF9+/fFyI/cTZ2JD6fTwost9Q0ymAXw4UAjbyZ2EkKV0FBgWTFZ2dn\ny4ac3VM6ncbm5iZCoRDMZrOECG5sbIjCx+/3o6ioSNydSPbnFv3g4ACRSAT5+fmSkkCPVspai4qK\nUF1djbt37yIzMxNWqxX9/f34kz/5E3g8HsFhtVqtSDXJhWbHT/yupKQEW1tbQqLnxUKsmJxis9ks\n3rlMfPV6vWhsbITH45E4FoPBIObatLiLRCKSCEABCl/r450ZHdEKCwthMBiEDrWzsyO0ru7ubrS3\ntyMnJ0cWVRsbG5iZmRFTc8I5xJ339/clb+rEiROyvJqfnxdogRMFAKGOKRRHyauEhoqLizE2NvaU\n1JedMn/O9fV1TE9PY3FxUQj4x53fCAERdsjNzRWHMYYU/lFnNv3Lv/zLUwYjCoUCp06dQiKRlfje\nEgAAIABJREFUQE9PD37605/i9u3b4uzt9XpRW1sLs9ksPMj5+XkYDAb09/fj9OnT4rMYCoVw+fJl\nGaHff/99eaObm5uRlZWFwcFB6axIDWLRJRxw+/ZtdHR0YGZmBg0NDcjOzsb09LQ41MzMzKCzs1NG\nwdXVVVy+fFlys0OhEE6fPi1cNspGE4mEqGk6Oztl9GO39vvf/x4FBQVwu91oaGiQf+jFOj09jf39\nfXzyySfo6OjA0NCQcC8ZlUJ6CGWElZWVwv8sLCyU7vLzzz/H7OysXBpTU1P47LPPhItXV1cnxHDe\n2qSFMYIllUohFArJ2O5yuTAwMIDq6mrpJI5nTNFliCYktLTLyckRAQBHUX7t+fl5kddGo1HE43FJ\ntkyn05iYmID3D3EpVqtVNPV5eXmIRqNIpVIoLS1FKpVCOByGxWKRkRU4Uh7RKCYWi8m4SOHD1tYW\nUqkUzGYz0uk07HY71Go1Hjx4gMrKSgQCATQ2NmJxcVGy02tra4XzmZeXJ0ogHlpyKulYVVhYKJ0+\noQi/3y+vBzt8AILtKZVK1NbWIjMzU5Zkxw1O8vLyEA6HEQ6HxbzcbDZjaWlJyOqMtLHb7VheXhY/\nhJqaGszNzcHlcskFWVlZiXg8jr/6q7+CyWRCQUGB0BSj0SiWl5fx/vvvi3Uli/fW1pYo0DY3N8Xt\nzOfzoa+vD6urq2hra5OLhdMdOdfJZBJFRUWoqKiQ6CEmUHABRRydVKzl5WWJsWGh5RIUwFPyWkKK\nRUVFAi2yaeju7v5aNe0bM3a2Wq1iVFFbW4u1tTWsr6/j+9//PtLpNG7cuCHyrnPnzmFiYkJMhcfG\nxkR2mJ2djWeeeQaLi4sYHR1Fc3OzGNKGw2EUFhZibm4OVVVVMi6xM2QQmc/nE3Kv0WjEb37zG5SX\nl2NoaAjf+ta3kE6nxWkqIyNDtu5bW1vo6urC9va2UIl441Jxk5GRISMFuYUk4A8NDaGqqgolJSXC\nIXU4HMKdfO+995Cfn49bt25JmiQXHKlUCrdu3UJbWxveffdd2O12OJ1O/Nu//Rv+4i/+QuhJiURC\nlGLc9E5NTaGurg7V1dVobW2V0dPpdKK7uxs2mw0mkwnpdBpTU1NP6ZcViqPERb1eD4PBIHhlcXEx\nysrKsLKyIuRrjqaMg3A4HIjFYkJ3ohSQl09ubi4ODw/x8OFDMaWorq5GQUGBhOVxBCeWSKd1dqbp\ndFqKHZ3muXgZGBjAmTNn8PDhQ2i1WnR2dmJ6ehoOh0Pee4PBIFxj2v/Nzs6ivr4efX19KC4uRnV1\nNX79618L4Zwdvd/vR0tLC+bn5yWVYH19HdFoVDwD6Oq1urqKqqoqTE9Pw2KxYGFh4amOikuz/Px8\nERuwEDBimQsfKn+USqVkehEuUyqVWF1dhclkwsLCAtra2oRrTcochQbM/GKhphvW6uqqXMCdnZ3i\nlFZWViY4ONVtLpdLvCfYxXLJw839zZs30d/fD7/fL9EzQ0ND4ofKTpGKI4vFgr29PSwvL2Nvbw/V\n1dUIBAJPJcKSUhUMBjE7OyvmOXxmj2c28evzMtNqtSIlJy2Pi7RTp059rZr2jRTSBw8eQKvVoq6u\nDgrFUWzF3NwcbDYbWltb0dvbi7q6Omxvb+PcuXP4/PPPYTKZAEAC3MrLy/G73/0O3//+9+H1etHf\n34/Lly/j5MmTiMVi0Gq1+P3vf4+NjQ3o9XrRJdO4lpp6PrCMLJ6YmEBZWZl4nFZUVMDr9YqRtMPh\nkPwbppju7e3hnXfeka6NG0KbzYadnR1kZGQgGAwK3kaZXkdHB+7fvy/KK3pD5ubm4vHjx1haWkJR\nUREWFxfhdDrx9ttvo6OjA1arVQjLHo8HjY2NmJubExL91atXBYvLzc2F3+9HVVUVFAoFJicnYTKZ\nsLy8LAooEsj9fj9mZmawubmJyclJJBIJVFdXo7y8XDrr4xnkvNW5ke7v75eF087OjpDr19bWJNiO\nvrDAUde+t7cnPEM6HZnNZlRXV8tYSnUTkwgCgYBciNy+U3bJC5bjITff0WgUlZWVmJmZQXV1tThs\nsaPlxn91dVU8AMrKykS109nZiWAwiNbWVszNzcnCqKysTLa+yWQSPT09OH/+PMbHx2EymTA6Ogqb\nzSYRz3t7e2hraxOf0o2NDfEIZYdO6ScnAK1WK5Hdh4eH0Ov1ktZK9yle0mq1Gul0WihGjI2x2Wy4\ne/cumpqa8PDhQxQVFSEWi2Fubk5UVUw+TSaTKC8vx/DwME6ePIlkMikTBvX/kUgENptNUhwUCgWW\nl5dFmLC5uSlQxsTEhBDdA4EA9vb2YDQan1r2UXIMQJg1BQUFEsxH71VOsVxU8d+j0ShCoZB01exS\nCVkcx0M5vbIuMHqZ/GaeU6VSiZMnT36tmvaNKZuIiRwcHMiW9/Lly5JiOTAwgHPnzgmeBkCwJeAo\nQfHEiRNyuMrKytDe3g6lUolYLIbJyUnBWYiDUn0Uj8cle357exsajUaUH0yY7OrqQm9vL1wulzyY\nXq8XRqMR8/PzsNvtCIfDqK6uForH7u6ufC/msgcCAbS1tWF+fl5iR6xWK4LBIBwOBwAgFotBpVKJ\nbRmt0EKhEDo6OuTAulwuIeLTgKKpqUlu5Hg8jvHxcdTX14sn6vT0NPR6PZ48eSKJjel0WqS0//Ef\n/4Hd3V3U1dXB4/Hg4OBA9Pe1tbVIJBKIx+MSKU0aF41O2Hnu7e0Jr3J9fR1KpRIajQZ1dXUAIJZ5\n1ICT9M1iTGWTWq0WGaHRaJQphJJEm80m2m12Y1xCkLOYl5eHWCwmCyhKenn4aURMbmt/f7+kstJh\njAR6Ci20Wi3i8Tjcbjf6+/tRW1uLqakp4SWHw2Hs7u4KtNHU1ITFxUVUVFQIV/Hu3bvo7u6W9wuA\n/B65ubkYGhqSJSXD4rKzs9HW1iZsB5PJJM5TmZmZKC8vx8LCgkxULpcLHo9HClQkEhGuKClUExMT\nqK2tFcpTdnY2Hj9+LPZ1a2trSKfTiMfjMhEwTYDSWC7oyFZRq9WoqqrCzMyM8DrJmuD31uv1aGxs\nlPTfzMxM4RQTPjpueE1z683NTWFHtLa2wm63Y2pqSvxk5+fn5Qwex3k57vPrZmZmSsgkR3hi/7m5\nucIpPq7Zp4HR/+njGymkjO6YmZlBMplEMBjEj370IxQVFeG///u/UVRUhK6uLmg0GvT09MiNyKRD\nrVaL7OxseL1eDAwMwOVyoaWlRcwhHj16JGBzSUkJysvLoVQqce3aNYkSppoHgNBqHA4H5ufnxeDB\nZDLBbrdjeHgYmZmZKCwsFFI0Yya0Wi1mZmYkWoQRC7TBMxgMsFgsmJ+fF+ySTlXENr1er5hTFBcX\n48GDB9Dr9UJx0ev1UqDm5uYAQKgnpCExesHlcgljgbEjOzs7aGlpkbHSbrdjfHwcgUBAFmakhJhM\nJnlA19fXn8oMomJMo9GgoqICi4uL0o0wxoNLOR4Mn88nsIZKpUI4HIbX6xWDDLoL0blIpVLB7XbD\nbrcL7WlnZ0c8CUgqX19fRzqdlsSE0dFRvPLKK4jH4+JJydyr/f196eyys7MxMzMDnU6Hx48fi79s\nX18fWlpasLi4KJLX7e1trKysoLq6GhMTE2LkkZeXh6amJkxOTiKVSsHtdsNisYgRNE2iV1dXoVar\nhRLHgkBDZVrcFRYWIhKJSCgcMcH19XWxQaQNHCc1Jo7yQqDqLp1OC1ZMLJGRMxcuXJBCR7d+cmb5\nvQmN0Hya4X1zc3PQ6XRwOp2SHsAgQcb6MJ03FothYWEBJSUlMqERe7137550jmtra0ilUlLs2RWS\nJ8yRm/lhdKTKzs6G3+9HKBSCz+d7Kp6FYzuXu8dDMyne4LkjRY2MCBZPLqMAoKOj42vVtG+kkIZC\nIVy9ehVLS0tQKpX4/ve/j4KCAnzyySfY2NjAlStXoNFo8Itf/ALBYBDhcBhtbW1Ip9NwOp1IpVL4\n8ssvkUqlcP78eWi1WpSUlKCwsBAffvghUqkUqqurhVNG3M1sNmNtbQ1nz57F/Py8GDRvb2+L2fLU\n1JRsUXmDAxDuJbuYxcVFNDU1weVyoaenR6R2OTk5iEQi4qpz584diS9Jp9Oyre7o6MDg4KAoRohp\n0vHnyZMnuHDhAubn57GxsYG2tjY8ePBAivT29jZsNhsikQjm5uZgt9uF/rG4uIiqqiohJ5MmkpmZ\nKQwGRoRUVlYKc6Kzs1M4t9wy80BSZUUPy1QqhdXVVVnikOQ8PDwsCQQc4ehRSk+BVCollxjwVX46\nTWEGBgZQWloKq9UK4MjkBoBYxR1fTjGGxeVy4dq1a/j2t78tktBoNIri4mLMzs7C8YewOa1WKyoy\np9MpvqlZWUcpsYQLqEM3GAzCFjCbzbhz5w7UajXMZrNkUMViMXR3d4vAg5dbJBJBe3s7VldX4fF4\n4HQ6Ba/lhc0crHA4LON8IpGQuBGqh7a3t+FyuQQH5iRw9+5dVFZWYmNjQ0IU19fX5felg7xSqcST\nJ0/g9XqlmdDpdHjy5AlUKpVIe+mdGo1G0djYKEyQ6elp1NfXY2dnR7ws6HNA3ueTJ0+g1+tRWFgo\n1n29vb1YWlqS1E+v14tQKPSUmTKhMOKjx7Xx3BcolUpUVFRAp9OJXJlUSV6wxx2g2I0WFRWJSTTZ\nE9Tb5+XlPUVRPO70xZ+rvb39a9W0byz8jlvSb3/72zLaz87O4tVXX0VRURF6enqQmZkpnp9ccDCW\nwuFwyKLI4XAIh3NsbAxtbW3SebjdbuTk5GB5eRm5ubkiwdzb28PS0pKQ2GOxGEpKSjA/Py9yPLvd\njrm5OSQSCVRVVUkkMTu0iooKbG9vY2hoSAq22+3G7OysqEXS6bTQUIqKijA3N4e9vT00NjaKpJCL\nCW519/b2UFlZKUKERCKB7OxszM3N4YUXXpCuRqfTYWVlRaIkSNkhd7K0tBRGoxHhcBjPPfechM55\nvV709fWht7cXw8PDeP3115GRkYG+vj5kZGRIV6lQKCTOmhQwu90unQZFBGq1GkajEUVFRdKV84YH\njjb8XIBMTU0hlUpBqTzKpufChFp8GhcHAgFEIhFkZ2dLF0Sca2VlBTqdTmzcDg8PsbKyIrLX45ti\nUqw8Ho+oggwGA8LhsLx/oVAIJSUleO+99/Cd73xHIB+/3w+73Y5PP/0Uzc3NWFlZQVNTEy5duoRE\nIoH29nbk5eVJsB7VP7RA3NzcRElJCSoqKmTh6Ha7MTMzA5fLJd0cO6uuri4UFRXJM7azsyP+BeS4\nUtXGKG42DTT/2N3dRW9vL2pra4V0/+WXX6KqqkpgCuYiZWZmYnZ2Vgy8OfUcf45YFNva2gBA/Gzp\n/rW4uIgbN25AqVSirq4OGRlHia8LCwsyEa6urmJgYABer1f8Briw5aXARRfHbWLyeXl5Mq3RUMXj\n8Ygu/n+72/NPdp40xOEmntgru9DjXF12s/w4ODj42h2p8v/8V/7//yDh/c/+7M+gUCjw6aefIhQK\n4Yc//CGWlpYwMzMDAE9ltPMwarVajIyM4LPPPhNDExKSnzx5ItjYJ598grNnz0KlUuHGjRsyJjY1\nNWFlZQWFhYWw2+1IJpO4fv264DwMtbPZbPD7/WLywC02IxWoaDrOryQxnUot4lQrKyuwWq0YGxuT\nh5aUGIVCgb6+PiGmP3z4EBkZGUJQXlhYeMp5/NGjR/L7rq2toaqqCs888wzGxsZkmzs/P48333wT\nDodDOjulUomJiQkYDAb8zd/8Ddra2tDR0YHi4mLcuHED0WgUTU1NqKiogNlsRmVlJTo7O3Hu3DlY\nrVa0trZiYGBA4l4ikQj29vbg9XoxNTUlCY4shkajERqNRniiHFPdbre42bNzYJHc29sTovzp06dl\nSeDxeCSLnoTzdDotaaiFhYVSSNjx0VmJEwAlrHt7e2JJSApPXV2dGGXfvXsXh4eHqK2thfcPBsvP\nPPMMbt68KcyBd955ByaTCYlEAoFAAG+++aaEJ3LhQs39xsaGiAGAr4yuDw8PMTAwgK2tLTx48EBM\nk+m9y+dwc3MTfX19sqD0eDxYWFhAXV2dWAim02mhi83Ozj61VSeJfn9/H42NjfLzzc7Oyt4gIyMD\n9+7dkwUYlXutra2SFgAAExMTTy2IfD4fBgYG5DVfXl7G4OAg5ufnodPpxE+Yfg5msxlTU1OyUc/M\nzBTIhpxYdp86nU5I9qwDVCIGg8GnlomEbjhZkMnBf5jywA6UvG8KLQCINBSAPI//Tz6+kY60oKAA\nw8PD2Nvbw+3bt1FfX49XX30V165dQzAYhM1mg8PhQDwel/E6Go3CZDLBYDDgN7/5DbKzs/Hiiy+i\nqKgIX3zxBUpKSnDv3j38/d//PT777DNcvnwZSqUSwWBQDu2JEyekbaecjiqM/Px8wf3ouk3Hm83N\nTdTU1GBkZEQygOjmT8MFhUKB6upqMYIoKSkR04WFhQW43W4Jl6M2OicnR0ZMp9OJ9957DxcvXhQ9\nM+klt2/fhtVqRXl5uTAM2JGzk2N3QlOPTz75REB2t9stJr1UdJ0/f/6pZE1GQFBNRVMRjrelpaXi\n/MTivL29jbKyMlitVjGKoEM6cTguDIqLi7G2tiZGMSxwPOQKhQKdnZ04efIk0un0U0seGj4XFxej\np6dHIiPS6TS2trbQ3d2NsrIyBAIBkbYSy11dXcX+/j4MBgMikQiysrJw8uRJKdLRaBQjIyM4d+4c\nDg4OMDIygra2Nly9ehXAURw3PRAWFhYEguDyand3V7q7rKyspxaQNIEJBoPSIS8tLaGmpkZMpolR\nE1elVR0/n4qwlZUVFBUV4fHjxzh37hy8Xi9isZg8AySmE+OMxWJS8FQqlciV2W1Go1FYrVbMzs7C\nYDBApVIJ7h8KhZCVlYWGhgZ5DzMzM8VA5Ve/+pWIMrggczgc8Hg8okZKJBIC9RweHgqXld0hJxKy\nPNRqtdCdyKBxOBziU0HOaiwWEzc3Up/4njOOhbgniyW7Ty5Hj8tIWTDZyRJb5Z9/1MumO3fuoLS0\nFB9//DFcLhcuX76Ma9euiYTOZDKJi/fbb7+Nzs5OHB4eCj64v7+Prq4uMYfgosJutyM/Px/JZFKi\nH4aGhuSFLC0tlRdodnZWbqNAIAC9Xo/W1lb5vhwviZtwQcOUzeXlZdno+3w+GWuXlpaQk5OD0tJS\njI+Py4PB0YQPrt1uFwcbLnjowsOOIBAIoKWlBQaDQdgMJHBbLBbhZ37xxReC3Y6NjWFjYwMVFRVY\nWlpCPB5HZmYmPv74YxkXKysrMT8/j7KyMul2fT6fwAEGgwFNTU3IyMgQziazkSjRI+2EZsHEtlQq\nFdbX16XLoJUet7HU15PkTvI9Rzo6PZFak0gk0NLSIlEd5BybTCZoNBosLy+jp6cHTqdTuiBGyQCQ\nn62goECWHhQmPH78GAaDAdPT07h//z5eeeUV/PrXv0Y6ncZrr70Gj8eD2tpa0X+fOnVKIjSCwSCm\np6dx+vRpzM7OPuV2RTvGtrY2vP/++zKdEFdkoZidnUUgEBBqF8UZNHzhomxqakrUV5yMyEO9d++e\nuFuVlpYKLY7LEi79tra25FKbnZ2V7PqRkRFhkmg0GszMzDxVdOjQxXGYEE9VVRWuX78Os9mMpqYm\n9PT0IC8vD44/JCtsbGwgHA4LJ3Z7e1twbS5zaXG3v78vi1mz2Qyj0QiLxSK4vM1mQ3l5OcbHx3Hv\n3j0J8mMRZeeZk5MjwZB0GqMY53hx5D/AV0F3pEVxaUXM9Y+a/uTxeHD//n288cYbYsrs9XqxuLiI\nRCKBtrY2/Pa3v8X9+/fx+uuvw+/3Izc3F+3t7Xj48CEMBgOam5vh8/lw//59nD59GsFgEMAR5YLU\nnwcPHsBkMomF2fb2NtRqtdBsmHFEakVlZSW2trYQCATk5qKTEX1QDw8PEY1G0dLSguXlZRQUFGB8\nfBx5eXniqB8KhYQaQgcobh/HxsbEoo6XwtDQEHw+H/Lz84VaMjQ0BIfDgQ8//BBWqxU1NTVwOp3i\nT0DJ44cffohkMomSkhIoFArU1dXJ1jU7Oxvz8/NwOp3SLdL8AgBu374NAHj11VexsLAgOG1BQQHu\n378vnRE31zyIVMnodDpoNBqhXR0eHgp1iQ82x3/axgGQGGxm3GdmHiWwnjp1CiaTSYw1aD5DOlg0\nGhVrO8bL0Et2YGBAzGjGxsZgMpkkJjkajcLpdCIUCiEQCEjcTHl5ueDNExMTMJlMaGpqgtfrRXV1\ntfALx8bGJIDQbDZLl2Q0GpFMJlFXV4cbN26goKBAnLToobq8vIxUKoXKykrcuHFDoKrq6mp4vV6U\nlZUhEomIKQ1FJrTxW15elqyt+vp6WCwW3L59G06nU7w6GVdCKXVTUxPGx8exvr6O/Px8LC8vi7yS\nBsjs1Oh1y+UMjV0YIUP/gmQyKZEz+/v7GB8fx8HBgTBEzGYzKioq5H2mmz0LJ02JOFYXFhYiPz9f\njEg41m9ubgrMs7q6iuzsbOh0OqytraGvrw+xWEzGeF6+xON5Zlk86drGZRb/NwswR3n+/6RI0Td3\neHj4jztqJBKJ4OTJk3j33XfFvJjAen19PcbHxzE8PIzm5mYkEglJD9zb28OdO3fw1ltvYWBgAGq1\nWkjW9Dil+zxje4/7lyoUClgsFonGoIPSs88+i5MnT2JsbEy2yjabTfiQtO2iS9Dw8DBqamqEdcCu\nsqysTG5js9mMhYUFiaXl6D89PQ2FQiHGC4QPSMcgPzMnJwf3799HQUHBU8mbw8PDKCwsFAlecXGx\n8B3Jdfze976HcDiMzs5OaDQabG5u4vLly2hsbBTbO1JLFhYWsL+/D5fLhcLCQng8Hunmp6enhevL\nro78TtJEUqkUVCoVKisrcXh4+JS/aE5Ojsju1tbWxIFLoVAIu4GE/AsXLoivKJc2GRkZmJqakoRK\ng8GAmZkZrK6uIiPjKKqZ3F+9Xg+j0Sju9yTuH184WCwWPPvss5idnRVYJiMjA9euXRPCvclkwvz8\nPDIyMmC1WnH79m1otVp0dHRgYWEBarUaU1NTcDgcYpk3PT0tXMTy8nLJlacJzdramuQMUXZJRgGX\nOhMTE9BqtRK2SMpSTk4OlpaWUFdXB5/PJ7QhKq9qamrE7zaZTMLj8UCv1yMQCAhmnUgkRKmn0+nQ\n2toqrxlpYZQub29vIzMzE48ePRIBQUZGhnjYrq2tyZa8ubkZBQUFqK+vFx725OSkePvyIiacRdyX\nghiNRgOr1Qq1Wo3c3FwYDAbU1dXB5XKhvLwcjj8Yd09OTmJ8fFygp+zsbImgJs7K7vP/rngCENkz\nCy6ApwxxOFH4/X6Mjo5iYGAAKysr+NGPfvS1ato3UkgnJiZw7949LC4u4s6dOxgdHZXx98GDBygu\nLpao4Hg8jr/9278VnfGLL76I9957D263W+zYlpeXcfbsWaENud1ujI2NSUYTjRPi8TgaGhowODgo\nxOjx8XE4/pBkyMO+ubkpRe/EiRPo7e0VFVAoFEIwGBQTDrPZjOXlZRlNuBSgcW55ebngasdTMWks\nsb6+DqPRKEWFm+2MjAw0NzfjwYMHsNvtqK+vx8HBAT7//HNsb29L+F9DQwMKCwsBHOF5586dw8cf\nfywb+srKSmRkZMDlcuHf//3f8T//8z+IRqOoqqoS8+P79+/j8PAQLpcLFy5ckAUbJa56vR4WiwXB\nYFAOHaEWUmaOy0iJyfHWZ65RIpGQzB21Wo3u7m4JOeTEcJw8rlKpZORcWlpCKpXCM888g7q6OtTU\n1MBisUCj0aC+vh4rKyv44osv8PDhQwmt293dFdqZx+PBmTNn0NPTg87OTuzu7mJkZAQzMzN49tln\nEQ6HJc6auHt3dzemp6fhdrvh8/kwNTWF7u5uZGRkiLqpo6MDZrMZfX196OjogFJ5lOV18eJFjI+P\nAwBaWlowPDwMo9EoOVhkLHDspdKM+n+aVjOemz4BCoUCZWVluHv3Ll544QUEAgHMzMxgbW0NXV1d\nsuxLJpPQ6/WorKwU/NVsNouqbG1tTZYwY2Nj0o0BR1NdbW0tcnNzsbi4iJMnT2J9fR0ffvghGhoa\nBArLzs6WRQ+zxOg4trGxIUwFMkCysrKEDsdOcmtrC6FQSChYNPjhYplCCcbSABD1H+EBFubjSbHE\nrI9r8LkU5uvLMZ6qvt7eXoHGaCD9R11I/+Ef/gHRaBTV1dXY3NzEt771Ldy8eVM2u1TWjI2N4fXX\nX8d//ud/4sSJE1AoFBJXzNgIdlYWi0U4kjs7OwgGg7BYLCgtLcXW1ha0Wq10LUajEZubmxgaGhKl\nSzgcRk5ODnw+H/x+P9xut8RSTE5OiuIknU5LNDQ7TXYQlZWVYlxL+R/jalmIiL/U1tZie3tbkgDM\nZrMc0FQqhYaGBiwuLqK6uhrNzc3wer2YmJgQE4uVlRXZOk5NTcHlcmF2dhazs7M4c+aM3MpDQ0PI\nycnB5OQkrFYrmpqakEqlxLiFhrz19fX48ssvMTs7i9bWVrjdbhl9+cCRskbbNx5EQhTsAhSKr3LW\nU6kUotGomEETL6TH6alTp0QuqNVqYbFYBP+ia7nX60VRURH0ej3m5+dFjZZOp4UgX1tbKxlULJ5M\nqmWX0tvbi87OToFNNBqNaNNpFJxOp2EymcT+zmQyITs7W56Tzz//HA0NDeLKZbfb5RJlqGNfXx9q\namoExtnd3RVNOS8LHuyRkRHYbDZZ+qlUKhQVFUknW1hYKKYw5JySIUHaoFqtxrlz56SoKBQKgWkY\nMxIMBuH1etHe3i4+uiqVSv5kvDEJ7OxYOzs7hfFSUlKCaDQqQXV7e3vQ6/XY29vDtWvXcO3aNYE9\nZmdnhZVC13pS0Th2M5GUufR8tnU6HWw2mwgBuJvgFELeJ39fdpr/uwMlLep4hhNdr4AjKhcXYrOz\nsxK4SUx5f38fP/nJT75WTftG6E9arRYvvfQS7t69ixMnTuB3v/ud0ImSyaQQ13/yk595wBGgAAAg\nAElEQVTg6tWrsFgs0Ol0YnSytbUllAty3e7evQuVSoWqqir4fD7U1tZK5AJVHE1NTfD7/bJ9BSA3\nPm3X9vb2YLFY5A3OzMwUVQU3owcHB5LuyO5Lo9EAgKhZtFqtKIHIdSsoKIDL5ZKoiLy8PJw8efIp\nkwSqRwic22w2+Hw+TE5OQqfT4eLFixgbG4PBYIDb7cbw8DBeeOEFlJeX48qVK3j55ZflgBMwJ57l\ncDiwuLiI5557Dnt7exgfH8eDBw+wtbWFd999FxcvXkRNTQ3m5+cxPz+P/v5+LC8viy8p3fp5wHNy\ncsTJiLZjarVa7Owo6SXMMjExgdnZWeGAMpPJZrOhq6tLlkDkFZIzSnVVIBCQC+POnTsiitBqtZiY\nmBCKj8vlQnd3Ny5evIjs7Gx0dHSgtbUVZrNZGB5erxetra1SlBobG5FOp/Hee+/Jsm1iYgI1NTUA\nICkBP/zhDzE4OAgAUKvV6O/vR0ZGhgS0+f1+PPPMMwLX0OnLbrfD7/fD5XJJMVldXRVMubi4WA44\nqVCEiiwWC2KxGDo6OrC+vg6dTofLly/L5fXiiy+KNJlxN8XFxcjPz4f3D4Y1OTk5opbjGSSGvL+/\nD4/HA4/HIwsxh8MhLlosTnTap3ViZ2cnlpaW8MUXX6CyshIXLlyQws9ng2oySj0pQnD8IW2CzInl\n5WVR0rE4T09PY3h4WDB1hu0dx0GJ97LrBCDQw/EYZqrvDg4OkEgkMD4+jkePHmFiYgIrKyvSLFCI\nQXexr/vxjXSk6+vrGBwcxPe+9z189NFHyMjIwNrammytdTodrly5gnv37qG7u1s27lSMRKNRIdOW\nlpZKxIbBYBBKTyKRgEajQTgcli15OByWgllQUIB4PA6DwYDHjx+L+cTKyorgj3SZGRkZgdFoFCpV\nPB6HzWZDZmYmUqmU0GsoKWWsq0qlgsFgEAI0KRuMpuBWkw8+WQIGgwF5eXmor68X/ujh4VHW+8OH\nD3Hp0iUYjUaRrlZWVkrXTI34rVu3JC+d2Nlvf/tbXLp0CWNjY6ivr0cwGBRJI8ennZ0d8RRwOBzY\n3t6Gz+cTv9LjmnkaU/Ci4INHkjwln/R3PXHihOSZp9NpuN1ucahibAu3+KTF0CeSvFBuyIn9kqLV\n1NSEgoIC+f2NRqO4cG1ubmJiYgIdHR2IxWKYn58Xt/Tz58+LmUZOTg7++Z//GTdv3kRHRwcsFgtu\n3ryJU6dOYW5uDrm5uRgbG4Pb7UYsFkN7ezumpqZgNpsxNzcnPz/VaZSZxuNxJJNJMXIeHx9Ha2ur\nwBL07RwcHJSxd2dnB36/X7qw8+fPi8t+bW0tqqqqJJiR6rfFxUVMTk5if38fTU1NsoTc2NiAUqkU\nCTSLxuHhoWRZMRyRAXYtLS2i0CN2mpubKz6o29vbgpEzKZUJDwCEl8txnHE6pFNtbW3BZrOhoqIC\nVVVVgos7nU5hFiwuLmJtbQ1ra2vY3NyUrpOTDwvncTXScXyUfFAu8VZXV7GwsCAKq62tLSmy9Dbg\nxMii+td//ddfq6Z9I4WUt/jo6KjIImkVtrKygsuXL+PWrVtifafVaoUSpdfrxQastrYWT548ERd4\nn88nW/ji4mI0NDRgeXlZokioTZ6dnRUJnsViEWf34uJibG5uYmNjQ9xh0uk0lpaWxFyYW2xyAYuL\ni7G+vi5d7MjIiNxqGRkZ8iBzyWUymeRhstls4tgOHPlMkkKiUqnEE5UPIbX+FRUVSKfTOH36NFpb\nW5FMJrG/v4/+/n4AR+GCdXV1CAaDmJiYENyxuroaGxsbMBgM0Gq1OHv2LHw+H65fvy4b6XA4DKfT\nicLCQvm9jUYjPvroI6TTaRiNRrnByd0j7kTpKkdzOgXNz8+LNymzljjeEu9ixDU3yCsrK2Jsc3h4\nlFJZXFwsCyXSshhDQeMS4urceEejUUlauHfvHhoaGoSqFo/HMTo6KpSw/Px83L59W1gg7OpYLAcH\nB3H69GksLy+LV6hKpZIDT3VOKpWSOBav14uDg6MMd5qTG41GXLx4UcxvBgYGkJeXh2AwCL1eL9gi\n3cXoGbCysoK6ujpoNBpZfA0PD6O7uxtbW1uCt7/00kuYm5sTs/CpqSm0tbVhc3NTLCUHBwclanpx\ncRHAEW44OjqK4uJiqNVqjIyMQKfTYXl5GRsbG2IERIoWs7AMBgMODg5EKciinEwmhffM6BZq6IuK\nikQZB0Dw07W1Ndy7dw8PHz5EMBgU2hTHd5qKHLfaA/CUrPS4OTdwNMJTPEA2BTnWpATS8JmqNi5E\n//Iv//Jr1bRvpJD+7Gc/Q1lZGaanp+H3+8XTMJ1O40//9E+FZO50OqW7oKeh3+9HKpWCyWQSHJVG\nu/39/WJg3NTUJLK3ra0tNDY2Ih6PIxAICGn9eKdDMjsjjR1/cNr3eDywWq3Iz89HTk4Odnd3ZVnD\ngsItPDN7jkfaOp1OLCwsCDZjtVpFWz43N4eWlhbs7OyITV9raytCoRDW19extrYm7uw0LGHQHo1W\ndnd3MTg4iMzMTJw8eVLMQD788EN5wDlae71esVfjAxuNRnHlyhWh6RgMBnHtIeNgf38fFy5cEF0y\nU05pOZeRkYF0Oi0OVDSgyM3NlWwsvg9Wq1WWdLu7u6J5ZkfDLpOXJ8n34XBYDi4AKWQtLS1wu90S\noldUVASj0QiVSiXcxunpabz00kuwWq2yIMnJyUFZWZkU2+LiYmRlZcFgMGBwcBBffPEFvv3tb0ts\nNongOp1Ouhfa3jG8jbaGhFCmp6ehUqnQ2NiIR48e4cyZMxgaGsLLL7+MRCKBZDKJlZUVeV/IK6Y6\nZ3FxEVqtVojpGxsbsNlsuHr1KkwmE/x+P8rKyoRHS7PxqakpuUz5GpHmpNPpkJWVhfLycrhcLvzy\nl7/EuXPnMDc3h7W1NZw4cUKwV0IqwWBQpMh6vV5ysubm5uBwODA2NoalpSVUVlaiu7sbH3zwgbxf\nfK3pjkX/Wq1WK9HanHIotw6FQl8VqD90ocQ4uZNgF3ocl6dNHnHaaDSKyclJzM7OCs7M6Yt4KqEN\nFmRS/Gjl93Ux0m+kkPb09EhOC/EPUmCysrJgsVhgs9kwPT2NZDIp3LrMzEy8//77eOONN0RltL29\njbq6Oly/fh05OTkIBoOoq6tDWVkZlpaWJCJWo9Hgo48+kiUIDWPp0kMFFUdBi8WC3Nzcp5yeAoGA\nkIeVSqWElpEexQeHNKBkMonS0lLRfA8MDOC5554T0j5J2xyJS0tLpbPa3NxEbW0tIpEIksmkGAZ7\nvV48efIEa2traGlpEcz4zJkzmJiYwMOHD1FRUYG33noLLS0teOaZZwTzq6qqQmtrK86cOYP29nbU\n1tbCZDLh7t27Qlc6ffq0jHH0aqWPK4tgZmbmUyFvjOulATaLH8PoACAvLw8VFRVPZbNzucCvzy5D\nrVaLo09BQQGysrKEv8n4FmrV4/G4sAi41HjvvfeEKeF0OqHRaIT/Go/H0dLSgvz8fGxubuK5557D\n+Pg4FhYWcPr06aewajrwU/9eUlKClZUVCY9TqVTiV0qNOcPV6uvrYTKZRBbMbt9msyEcDqOvrw8n\nT57EBx98AJfLJZ0bmRTb29sScnfv3j1cunQJNpsNb7/9NjY3N/Hyyy/jl7/8JZRKJc6fP4+3334b\nzz//vLAWOjs7UVpaKmegubkZHo8HACQy+d1338XLL7+M/v5+bG5uChZ+586dp7w/aX1oNBplStNq\ntWhvb8fCwgLC4TBee+01ZGZmYmxsTHjbFFcYjUYpbgy9pEs+0wHS6TT8fj98Pp8kqnJUP/7Bs3tc\ngQRA/t7u7i4ikYiM74TT2H3yOSFnlcs1FmsKORji93U70oz/LwXx/+3H2NgYzGYzEokEurq6cPHi\nRYRCIQwNDaGyshJDQ0PQ6/VSwLhVnZ6ext/93d/h9u3botm22WxyqIeGhmCxWFBXV4erV6+is7NT\nlFJUsfCAb21tQa/X4/9i7s2C2ryz9OFHiF2AQGySQIDEvhsMxsY2tvGaxXF6OumtepKumZrU1KR7\nunqm+2KWmpqb6amZf1cuunqZuemku3pJKk4cJ06ceLcJYBazmH0Rq0ASktCOWAT6LujnRO7/V9+X\nO7eqUqnEGITe9z2/c57zLN3d3WLUEROzHwnC4kAjitnZWdlgZ2ZmPqHKoWckJZGkQNF2j16eLADU\n9ANfOMJbrVakp6fD5XJhZWUFFRUVCIVCYguYkJCAoaEhvPTSS7h8+TJaW1thMpnw+PFjZGRkyM9J\nT0/H3//93+N///d/8fDhQ3HyycjIQGtrq8gRnU4nZmZmRA76wx/+UAB78h9puEFqCR2Rtra2pNOl\n4xWNdkOh0BM34s7ODux2O2JjYyWMjjlB7Hx587K7phJnY2ND3OWDwSAKCwtFJcbgNypRNjc3xYDE\nbrfj2LFjWF9fh8fjEdK2QqGAyWTC6OioeD3k5+fjs88+wwsvvICCggLcu3cPXq8XLS0t0imq1WqJ\nZqaAIzk5GRUVFXK9IpEIDh8+jJs3b6KlpUXUNsRddTodbt++LWP7wsKC0Hc4fhNPZbooO/SdnR3x\n6WWnWlVVhT/84Q94+eWXsbu7C5vNhu9///v4xS9+gZaWFuTk5Ei+WDAYxDPPPIPbt28L1/Pdd9/F\n9vY2cnNzsbOzI6wHYN8H45vf/Cb6+vrE5auiokK09XzfCQkJ6OjoQEVFBdrb2/Huu+/C5XIhPz9f\n/ISZZkDIhvAXjYN4YFDDPz09jb29PTnMoumCXKwBkOIZzXGOTiOglp/TVLSxCeXDhMOiC3U4HAYA\nyYgi5PZlXk+lI/3Nb36D5uZmvPbaa0hMTER/f7/odVdWVmQEiY2NxcTEBFQqFdRqNXp6evDgwQNs\nbW1JTENGRgYGBwclPvav//qvMTAwgJiYGOh0Omg0GqSmpmJpaUny7Zk8qtPpRGLHAhLt3EQmwdra\nmjhDVVVViZVbJBKBzWZDSUmJhJqxUNDouaGhAbOzsygsLJSQPnp9Go1GOSSmp6eRmJiItrY2DA0N\nyYa0u7tbpHPd3d2orq7G6uoqLl++LOYrhw8fxpUrV5CdnY2JiQkkJSXh9OnTUKlUePDgAV5++WUZ\nc2kVl5qaiqysLBQWFsoSz+VySdc2NTUFv98vemiaRzDalkRmqpdoTsKu3O/3IyMjQwoEeX7p6enI\nyMiQzoAYKbuP9PR0YUAw14uu99vb20hPT8fm5qZsoaklZ4R0RkYGzGazqKBGRkZw+PBh6HQ68UbV\narUyrpeUlCA+Ph7z8/PCRKDcsr+/H+Xl5XJosmBPT0+LvR0x1LS0NEQiEVgsFoyNjWFlZQWnTp3C\n6uoqKioqJLJ5a2sLqampojYjXzYpKQnj4+MoLi4GABkv/X6/LNYASCwO76HV1VW0tbUJ+6CxsRF6\nvV6MvL1eL3Q6HVZXVyXllEogxqecOXMG29vbouyan5+XQ4qKOX49lX9OpxN1dXXY2tqS3K/t7W30\n9PQgPj4ehYWFcm8wGp1FlM+Xw+FAR0cHBgYGsLKy8oQFHsdtju9/WkR5CBELt1gssswj1kl8PXr0\n54TF78eFFeXDoVAIubm5OH78OC5cuIAjR458qZr2VDrSs2fPIikpCe+99x6Wl5clXO7mzZvC2UtI\nSEBXVxdeeeUVRCIRrKysCPhcVVUlILfNZsPm5iZmZ2fxt3/7t7h9+zYqKysxODiIAwcOyHLJ6/XC\nYDBIlAMleTTloNWeSqVCWVkZzGazGFLk5OSI+QVVK48ePcKZM2dEF096FL0kacrMsR4AsrOzpVNw\nOBwoKiqS6I2EhASJENnc3ERLSwv6+voEGtje3sb6+rpgnNTJh8NhWSYMDw9jYmICP/rRj/DWW2+h\nubkZ//qv/4pf/vKXaGlpwd27d3Hnzh3odDocO3YMvb29stSgnwB9WY8cOQKXyyW0pvj4eAQCAbFV\nI/GbNzYBe7ob0T+ADvB8GKLdsVhM2b2T+hYN53D7S8EC8TQ+CGq1Gk6nE11dXSgoKEBpaanELFdV\nVWF9fR2dnZ3w+/24ePHiE5g2sE9XS0tLk6A15t4vLi7iW9/6Frq7uyUkcXBwED6fD6+//jquXr2K\nAwcOAIAUwby8PGxubkKr1WJyclLMmmlIPjY2hpKSEnz88cdoaGiAz+dDXV0dlpaWRO1H3jM7JoPB\nIDlXhL/I5BgcHMS5c+fw61//GsnJyXj99dfR3d2NxcVFZGRkYGZmBhkZGfjpT38Kg8GAM2fOCDRE\nL1umNzx+/Fiez6SkJOksOXpnZ2fj/v37on2ngTPVan19fUhNTcWpU6dQVFQkefLRogydTieSYL/f\nLxAXWQEA5FkhR5rbd3JOKQCg5y1jm9lNkgVDL15u3wkHcJRnJ8tkCpVKhWPHjqGyshLx8fHw+Xzy\nnr7M66l0pP/zP/+Dzc1NVFdXS5RBd3e3OKnv7e0hMzMTJ06ckJuM9BJGBqvVahkdk5OTUVdXB5fL\nhb6+vicyzo8cOYJbt25BqVRiYWEBxcXFcDqdklvNsXtpaUmiMmiQrNFoxEFnY2NDsK/BwUHhm66u\nrkqueldXF/R6PZKSkuD1ehEbGwuTyQSLxQK9Xo/c3FxZnNDN3ul0wmg0CvWJXoxKpVLMOehsNDEx\nAZvNBqPRiOeeew4AMDU1JTgUscrf//73+O53vwuXy4Xf/va3MhY3NzdDp9OJvJGabIPBAKvVit3d\nXZw4cQIbGxuYmZkR+zIuiqju4viUkJAgRsMAZInA68jRKhwOS8fO/HPgi2AyYli0u6PzFrt7fk92\ni263WxIk6elaWloqBjYktM/MzIgIgCF41OKrVCo8fPgQZWVl2N7exv379zEzM4OFhQUkJiaisrJS\nRkKz2QyNRoPFxUVZeup0OlgsFqjValitVqyuruLixYsi4qCxx9jYGNxuN/R6PfLz8/Hxxx8jJycH\nZWVlsFqtsFqtMJvN4js7OzuLlpYWLCwsQKVSYWpqCvPz82hubsadO3dgMBgQCoWkWx8aGkJsbCxe\ne+01vP3221CpVKitrUUwGERRURFu3bqF1157Ddvb27JIKioqwvPPPw+73Y7+/n6J8snKykJ9fb0E\nLFZUVAi5fm5uDpWVldjd3RUDFT5/4XAYRqMRlZWVWF9fl/x6FkO1Wo2CggLEx8cjKytLcHSXywWr\n1Sp0KACijuPf5T1E2ImR0kxH5XPOTpZQQLQ/aXSny4UUu9WysjJcuHAB7e3tgv+SgwoAR48e/VI1\n7akU0pmZGej1ely7dg1HjhzBm2++iczMTAwODiIuLg5f//rXRdNeXV2Na9euoby8HF6vF9PT0zh6\n9KhkYS8sLKC+vh67u7sYHx9HWVkZcnNzhTdInGx2dhY5OTlwOBwoLCyUAqFWq4UrmZ+fL7G4jBFJ\nTU2FxWLB9vY2vF4vVCoV7HY7AMgCITMzE7m5ueju7kZaWhoqKirg9XplYeFyuZCVlSXWZVTk0BuV\njjWbm5uYm5tDbW0tJiYmYDQakZ+fj+np6SdwILpO6fV6tLS0CO2DeegXL17Em2++CZ1OB4fDgba2\nNiHmX7x4ER9++CEWFhagVCpx8eJFhEIhgVI6Oztx4MABlJeXQ6vVQqVSAdgfpRYWFqTLpAOU1WoV\ng16NRiPSPHbpJE8zS52m2Ht7e7Jk29zchMfjkc23xWKRUTsuLk78LMk3pW6bBPP4+HjJr8/PzwcA\neT8rKyuiS2cx5jKztbVV3gujbEhz6unpQV1dHQoLCxEMBiWymP6c0Yukqakp1NXVoba2FjMzMzCZ\nTCKh5CjJ2G6VSgWDwYDFxUXY7XbU1dWJIXlKSoo4OxmNRnR2diI3Nxfl5eW4f/++mEsfOHAAFosF\nJpMJgUAAr7zyCoaGhkQyOzQ0JJ9/e3s73n//fVy6dAk3b96UJISPPvoI3d3dwoJoamqCVqvF0NAQ\nUlNTRdJL/XpGRoakR8TGxuLx48cwmUzQ6/USBbK7uyuBcpSKMsIkWjVks9nQ29sLs9ks9w+LXbRD\nEwA5YN1utxw8jJnhNMTOk0WSnWY0/kn7wO3tbVRUVODUqVM4e/YsCgsLZcHMxRphBYVC8eddSN95\n5x1cu3YNf/VXf4UPPvhAKCU7Ozt49dVXxX5Np9OJ1HNxcRFDQ0P4/ve/j/j4eFy9ehUjIyM4ffo0\nNBoNOjs7UVZWJtk6brcbL730Era2ttDX1wer1Yrs7Gwhz1Mtwm3i2toaSktLxbmbDkTMa6e2XKvV\nIhgMYnp6Wpx+1Go1dDodxsfHJa+eY/Hu7q4YHNOgmuYUVM1YLBa5iRhc5nA4hL6VlpaGhT+aDJPE\nnZaWBpvNBrPZLPLSpKQk6HQ68dIsKytDeXk5bt++DYVCgZqaGnzwwQeoq6vDoUOHsL29LRJSrVaL\n5uZmcWMPh8N46623cO/ePVHnqFQqGdno4UrPUG7BGTHCUYtjFb0JGH0SrfgC9rtTLvGisVYarEQi\nEeTn50On0yE3NxcApFMirYlyXiqKdnZ2xORXoVBgeXlZFiB0k5+ensajR4+wtraGzMxMwfFqamrQ\n1dUlm+pIJAKv1ytCCnIb19fXMTo6ivr6esmMp7InOgQxFArBYDBgc3MTKysrePz4Mc6cOYPh4WHp\nsIijEi/m5p5xH9PT0zhw4IDwn0tKSsSJnqkSnOhorffuu++iqakJV65cgclkwsGDBzE/Py+af5qG\nUDRBcxhGikSb9XCxGAwGceDAAdy+fVt8JxwOB+x2O7xer/CCCXexq+R1fPjwobBl2AFS508PUQCS\ndmC32+F0OkX8AuAJQ+boVzStiQU5EtlPXj1+/Dja29tRVlaGtLQ0keTSlSocDssCikX4zzqO+e7d\nu2hvbxcpFjPiX3zxRYRCIUxNTcFgMEix+/zzz6HVaqHT6YSCwkjmxsZGWK1W+P1+uN1uCbZrbGxE\nRkYGAGBwcFCI3nwReyLPbXJyEhUVFTIqxMbGQq/Xw2KxQKPR4NGjR3JhSG2iTjk9PV2UNE6nEyaT\nSRRFdrv9/0phJJ+Uv3daWhpSUlLg8XiEv6pWq2X7n5KSIvZoJ06cQF9fn9h95eXl4cMPP8SNGzeQ\nnZ2Nmzdv4ujRo8JDpPGFVqvFxMQEvvWtb6G4uBhxcXEoLS1FQUGBUJO2trZkgbO5uSmdu0ajQUlJ\nCZKSksTsJFrNQl4fRzI+GOy0o0c0Gg9zGRD9D68Fu0QAwjpISkoSgvfW1pY4nsfExMDhcCAtLQ2r\nq6soLi4WMjWXGgySAyDLQXo05OTkoLKyUpyieO2vX78uBwrd2Tm10N6vs7NTeLWnTp3C0NAQhoaG\nZMG5vr4OtVotBHs6RWVnZ0uXq1KppAMl7peWlobl5WV85zvfEVf5zMxMlJSUiGdpTEwM3nzzTfh8\nPuTk5IhVIz1o09PTsbKygoSEBDFLpxzbbDaLzaDX60VMTAyWl5dhNBolGrmurg4GgwH9/f1QKBTi\nUcEdAsn1Pp9PEh8SEhJQWVmJvLw8ZGdniwyVNDm32y0THC38eJhyucV6wA08Dzy+uM2nXJsHNp9t\nHtC8R2pqanDu3DlUVVUJLh+NjxKDjdbrs7NVKpVfetn01Eb7zs5OwV/i4+NF8WO1WnH06FEZoXt6\nenDhwgVcuXIFNTU1Es2hUqmQlpYGg8GA5eVlTE1N4dChQ+jt7YXJZBKciHnq8fHxcDgcOHz4MB49\neoTW1lbJ8OZoUFpaKiNlSUkJgP0TsqenRxyb6HcaLUVkNg27lsLCQtHwWywWVFZWSq4P+a0MLMvL\ny8PExMQT2uCEhARYrVZJZ1SpVDh06JB4fq6urkKj0aC8vBzz8/Ni9kv7QOrwf/3rX0Oj0UjWuNFo\nhMfjQWFhoQSyMYmT49jAwAA2NjaQkJCAnJwcMY/IzMyU7HdaBRKTZZdApgEXS9EHF3FU8vVIYyIm\nDEBoT0lJSYKr0lGdXRi33CSnZ2ZmIisrC9nZ2YJx5+bmIjk5GT6fTyI1uORqbm4WN6K5uTkxp6iv\nr8fs7KwkZFZVVWFwcBDb29u4du0a6uvrMTU1Ba/Xi9raWjkA+/v70d7eDpVKhdXVVUxMTKCyshLJ\nycl47733UFVVBbPZjPPnz8Ptdou02Ww2Q6/XY3R0FFqtFiUlJRgeHpauOjk5WRaIjC8eGxvDc889\nh+npaUkO0Ov1IqNOSUmBw+HAq6++KiYwer0eKpUKc3Nz+PzzzzE/Py+GJ5TjWq1WHDhwQKKK+/r6\ncPXqVSnaXD4VFRVhZmYGOzs70Gg0KCsrQ3FxMbKysmAwGKDRaKSRWVpaEutKTpvx8fGYmprCgwcP\nxAqQmG0oFJJ7idHT0TAQoSB+r+jDmywSimBSUlJw7tw5HD58GJmZmU/IRf+0WEZDCX8afKdUKv+8\nU0SvXr2KqakpWdawiBYWFgqW5Pf7ZVt448YNKBQKNDQ0YGRkRKJ9a2trhZeXk5ODiYkJZGVlibTu\n0aNHEgtBh3TST6huiib2sp1PTEwEAJH7cbRPT0/H0tKSjGu7u7tobGyE2WyWDpcdFBce1BQPDw8j\nPT0deXl5EtjHrHuj0Yju7m5UVFSIoQqNb4PBIFQqFTweDyKRCDQajTyEs7OzePjwIex2u+SoE5sa\nHBxEW1ub0I7YhQaDQbz77ruyBWcxm5qaQm9vr6S1UvrJf6+vr2NhYUEgBHJH7Xa7LMlIsmZnQXyQ\ngXYc2cjr5DaWIzxdhpaWluD1eoWkv7KyIgF7wWBQJMADAwPiY8sOnYsMv98vnNfNzU3k5uZCpVIh\nJmY/VlqpVKKgoAC7u7vCAaZyi/dDS0uLGOhEx95wIvB6vSgqKkJhYaHAFTExMbKki4uLe8IucXd3\nF3Nzc7h27Rr0ej38fr9EtpSVlUnHlpKSgsLCQgwNDUli7djYGF599VVcvXoVeXl5mJ6exqVLlwQ3\nnZubw+7uLp555hmsrq5KlA4Pl8zMTGi1Wuzt7UGv14s81GAwoKioSJZGNpsNVpp+XN0AACAASURB\nVKsVaWlpMBqNOH/+PNbX1+UaE6KhIQ2pRsyVt1gsEihJM2div0qlEkVFRThw4AAqKipw4MAB6PV6\nSSDweDxwu91P8ENZPHngAV9QoNiRkmBfXFyMZ555BvX19YJ1RvuS8t+ckNgF87lnLSBvdWdn5897\ntL969Sq8Xq8k+4XDYbS3t0tcCNUdlMvduXNHbgRKJhlN63A4RIJIi71z584hFAphcnJSJJmPHj0C\n8IXrDbmHJETn5uZibW0NwWAQRqNR8mliY2MxOzsrmfSrq6uCH3m9XrlRCwoKkJSUJOFldKenExKL\nOjmsarUaCwsLEu8AfMFXpXacyxkaXZBUnJmZCafTifHxcahUKpw9exYOhwPhcBgvvvgi8vLyEIlE\nsLS0hIyMDFFnEb/kQWEwGHD06FGxTFOr1fjJT34Cn8+HiYkJ9Pb2StgZE1mJDzPVksWRVoJ7e3sS\nOMbRG4AomkhdoREFF2h8INhZMpkgNnY/9XFlZQVOpxPx8fGCXdPwJDU1VRZS9LLkw0I7PPIhKb7g\n+/P5fNDpdDJV7O3tifQyGAzixo0bOHv2rMhJExIShKBO9U5ycjI++OADFBYWYm5uTtRhXIKSpaHT\n6TA8PIyioiL4fD74/X4cOXIEk5OTKCgokDym6G12SUkJtFotTpw4AbPZjLt37+Kb3/ymKAIZnazV\namEymXDjxg2Ew2GcOHECN2/eFJs+nU4nLv7ME0tMTBQvCOKjSqUSMzMzKCsrkwlkfX0ddrsd6+vr\nYi3IpoSsGh5cxcXFIreNj48XoxJybrk03dvbg8ViwaNHjwRH3djYEAiMGDEPKMJF0VLOxMREZGZm\n4siRIzh58iT0er10mfHx8TKy8/4kbBRtF0hoiv/mRp8y0j/rQvqrX/1KMIzJyUkcOnRICtLW1hYm\nJiYET3K5XBgdHcXJkyclJ+nWrVtobW2VMZPLpY2NDdTX1yMzMxP9/f0yBsTFxSEtLQ0rKyvY2NhA\ncXExxsfHxUjW7XaL075arcb6+rpISZmTRCyLPEmS05VKpRRFZisZDAbpuki4J5E6KSkJBoNB3PsD\ngYB0c3xQS0pKZBRicUlNTRWHcv5dFvaOjg5ZEtCnlYu1sbExlJWVYWdnB729vTh8+DDOnj0rGeUd\nHR1ISUmR1FTirpTzlZSUYGZmBmtra3C5XBK4RuCfVDFq6wGIYoUbdgCSo8QHg+R3YH+pwN+J7up0\nPqdsksYtsbGxUgTo40peME2AiZEmJCTI3yXsQCMVetsSVgC+0FlXVFSgp6cHWq0Whw8fxv3794WK\ntri4CI/Hg6qqKumSBgYGBMOnGs/j8aCyshJutxsdHR1YWVkRGXFsbKxkYJE+R1Nng8EgWV/E0UkV\nYs4S+cwlJSXo6+sT2evq6ioaGhqwtbWFO3fuoK2tDRUVFUhKSkJmZibKy8uxuroqKj1+9mVlZeIC\ntbGxgdLSUjgcDlgsFglwVKlUiIuLw8DAgEBlXq8XGRkZYsCdnZ2NQCAAALIMtVgsmJubg9PpxMrK\nCmZnZ2GxWIQDSgNoh8MhC61oOhSpgAAET01MTERVVRWOHj2K0tJSJCYmSoElnBS9NKIjVHSWFRsA\n/nm0bR5FH/Hx8WhpaflSNe2pEPKpHuBW8oUXXsD169exu7uLlpYW+P1+rK+vY3Z2VjTvPp8Pp06d\nwp07d3Dy5EnhGCYlJYk/psfjQWtrK+7du4eYmP3c+cHBQXHldrvdIpvkKbi9vQ2tVitjIaNuA4EA\npqam8OKLL4qBLQnWjNaNj4+XiN+0tDQkJCTI+LizsyNa/Onpaej1esF5uMXe29uDVquFxWJBQUGB\nZD+ReKzVamV5wL/D0TQ3Nxfb29vo6+tDSUkJzGYzCgoKMDMzg+PHj8Nms6GhoQG1tbVoaGgQTXhf\nXx8uX74Mt9uNr3/962hvb0cwGMSVK1fQ1taGnJwcAMDExATi4uLQ398PlUoFvV6PjIwMmEwmWRYE\nAgHpNFkwKa/lWE5SM/Oitre34Xa7xfVLo9EIaZ9YFw8LulRFO5ZvbGwgOztbyN5KpVJysUij4WjI\n3Cq6pJPWw2ug1+vhdDqhVO5nOPF9OZ1OHD16VLq9gwcPYmBgQAqbUqnE0NAQVCoVTp06JRQdo9GI\ntbU1MSd3OBxYWVnBP//zP+PatWvizH/16lVsb2+LmTZdwsrLy9HR0YHS0lLprKhqionZTy1taGiQ\n5NZ79+6hqqoKoVBIEmJ7enqEqJ+SkoKSkhJcu3ZNonna2towOzuLs2fPore3F/fu3RPDcUbVhMNh\nFBQUiGLqo48+QmZmJnQ6nWSXkWdNF7Nbt26hqKgI5eXlElyo1+uFAsZnmod3T0+PZHYBXyTmsjki\nzBJtgqNWq1H0x4jxaAXUn2KgHNeJhXKMZ1cavQCl0U7011IG+2cvEb1y5QpiYmLw6NEj/Nu//Ruu\nX7+O/Px8RCIRjI2NIS8vD7/61a/E7ZyUH3aZdXV1GBkZQUpKisTsMlVSp9Ph2rVrQv+gAUY4HMbS\n0hKysrJQWVkJr9eL3NxczMzMyJbVbrdjbW1NomFJfqYkcX5+Hunp6aLsqaqqEpcmYJ/qQ0cb0qro\n30hnqKKiIqHosAARy5uamhJXK8ok19bWUFdXh9TUVKysrAjtY319XRIOb9++ja2tLRQVFaG5uRlv\nvPEG8vLyxGRkdHQUi4uLuHv3LnZ2dvDCCy/AYDBIZtb/+T//B21tbRgeHkZMTAxu3bqFlpYW8b1s\naWlBWVkZjEYjtra2xPWJFCBuUJVKpTjq80blzcgDgvgrCxkVYIR6YmNjhU4W/d9cMjG8kOMeTVtS\nUlKwt7cnDAiObYysYH47WRCcGDIyMiSShFgrAKhUKni9XuTl5Qn8MDc3J8sq3qfEANfX15/A5Gia\n7HK5YDKZZIS2Wq1CFaLtXjgcFrVSIBBAIBBAbW0tent7UVJSApPJJOF1NTU1WFpawtWrV3H+/HkM\nDQ3hyJEjuHLlCm7evImdnR0J8NPpdPj0008Fv0xNTcXu7q6kyOp0OtHqLy8vIxwOo6ioCMePH0cg\nEMDjx4+FfsiGhd4I/BxZ4AwGgwgmaG1IR/r+/n5sb2/LtLS1tSX4KicP3j8KhUKYOexQCwoKUFJS\nAqPRKD4E0Vv6aBI/dwI8ZGnVyALK0Z3TEaNNuAQlT5oL3/b29i9V055aHPP4+Dh+9atfiU/lw4cP\nxTghEAhgaGhI5HNHjx5Fb28v1Go1zpw5g/7+fvh8Puj1eigUCgwODkKtVqOpqQkTExPweDzIzs7G\nw4cPUVVVJfpip9OJcDgs20UuW7hFXlhYQCgUQnFxMcxmM5qamkSH7vf7ZcOdnJwseBwpJ+SbcmMb\nHx+PnZ0dLC8vw+/3IysrC+vr6ygrK5NtOcchOi/RFLesrAzBYFBupOzsbBk/rFardE4cRV9++WUx\n7FAqlXjppZfw4Ycforu7G9evX5cExtLSUly8eBG9vb3Y2NjAsWPH8JOf/ARNTU1YWFgQrPEb3/gG\n5ufnUVNTg/n5eQwODmJ9fR0rKyuCIzNxlaA+b0RGPxCa4PKHxcjj8QgOtrKyAqvVCpvNJrQj4lPs\nHMklJLYb/XBw1I3W85MHTNgFgPAD2aECkAeOXqfkitpsNmRmZsLlckGr1Yq5R1lZGVQqFSwWC+Li\n4nDw4EGsr6+jpKREMG9mTZHq5PP5YDKZZOm2uLiIDz74AD6fD4mJiZLtNTMzI7xXpgZotVqYzWZU\nVFQIPYnd6Pb2Ns6ePStR2x0dHXKYVVdXw+/34/jx4xgfH8fc3Bx8Pp8kJmRnZ0tjMT4+DrPZjObm\nZhw7dgylpaUAgN/97nd4/PixjN8rKytiDE1O5vLyskh9yXohKb+8vFxECaTOkRIVHUXOZ50QEHcA\n29vbsivhgQp8kT4brZ/nvRC9JORCKdrDNNrABPiCb8riTYw/OTkZarUaly9fRmxsrCgI//9eT6WQ\nvvHGG/jBD34ApVKJ6elpJCUlIRgMirvNm2++iXA4jIaGBiF/k3w/OzsrJsBJSUnY3NzE4OAg2tvb\nodPp8PDhQ2RlZcFms8HtdkOhUMgJTEYAqTzEc+iJyHExJSUFer0edrtd/p5er4fX6xX5Irf0XBYx\n616n0z0hUevs7BRFDMcjdnN0F2cnOz8/L5w9PtgE1RUKBebn55GdnY2amhoolUrMzs6ir68PCoUC\n1dXVyMjIwLvvvosPPvgA58+fF0oVb1pujcvLy1FSUoK9vf0kyNjYWDQ1NSE3Nxe1tbVYXFzEwYMH\ncePGDdlaDwwMyInf0NAgeCi7CpKvae5B+hNdo4iJarVaJCYmYmRkBKmpqcjJyUF2djby8vLkurBb\nZ6fCAstOhAmSAIQaReVUbGwsNBqNMAXops8uOCUlReS7jHPh6AdAFiVpaWmy7GQXQ/ev9PR0vP32\n2zh9+jScTieys7PhdDqly6XPAH8Gs+zZ/c3NzSEhIUHoWYxIYTrE6uoq8vPz8fjxY7S1tcHr9aKm\npgYHDx6E2WzGxsYGJicnkZGRgby8PAnPu3DhAurr6zE4OIiOjg5MTU3BZDLhueeeE6HDwsICDh48\niOLiYnz88cdoamrC7Ows5ubm8PHHH0sCQSQSwYEDB/Dss8+KZ0VaWhr29vYwMTEhsSf8bLj4oW0i\nO8+dnR0sLCxgcXFRokRCoZDkePFwZDGml8Kf8kNZDLl0inbDJ12J15HFk/g3uafRLB1+b7JKWFi7\nurpgtVqRkZGBzz777M/fIb+pqUnyzJmXvba2hsHBQcTE7Ge9EPsD9re+ra2t+O1vf4uDBw9iYmIC\nx48fx927d5GdnY3z589jcHAQOTk5QleyWCzQ6XQygjDbnMbEXFSxnY+J2Q/94gNATI7u7FwccUTk\nVpERtX6/H7W1taLrDoVC6OjogF6vh06nk9/R7XaLgXReXp5sp4F9G7O2tjYxKqFNG5c9pODcv38f\nx44dQ1ZWFm7fvg2v14ulpSWBJYaGhlBZWYmWlhYYDAYcPHgQMTExMJlMiImJkZtFqVRibm4OZrMZ\nLpdLsOXp6WlYrVbU1tZCq9Xi0KFDaGhoQEFBgXR+u7u7gm+yoAL7nQOlhKFQSLxnp6amxFCCfp10\nbOJGdWNjQ/wv3W633OzJyclCsA+Hw/D5fKKGSklJkXEzWtVC5RUzvrippTUgA+yAJ00yeC1TU1Ol\nK6a4g+Y2DodDcH7+7lRc0RuAngP0Q3W5XHKdOCFFj52kefHwo4Vfe3s7TCYT3G63cGQLCgqEC5ua\nmoozZ87gxo0b4nm7u7srghar1YqlpSVoNBpUVlaip6dHEm5v3LgBn8+H8vJynD9/HgDQ3t6OxsZG\nyVpi5/7pp58KhjgxMSE+GcA+FEIKE+NVuOTNzs6W6Ss1NRVqtRomk0kMecjz5f1DjnK03yj/mxho\ntNFzdGfJohxNaeL/5zWhuQ5NoH0+nzBg3G437t+/j6mpKYRCIfzwhz/8UjXtqRTStLQ0Se2zWq3o\n7OzE1772NQwMDGB9fR2RSERSNnd2dtDf349//Md/xM9//nPo9XokJiYiLi4O2dnZGB0dxfnz5xEM\nBoVAzItps9mQn58vXMOsrCyMjo7izJkzQm/iCMiFBGNHaNpLOhJznGhqAkDUP8PDw7I1pM6eS5iV\nlRUYjUaxi3v8+LGMo8QNGZ2bmJiIubk5NDU1IRAIYHh4GHq9XniFzIpits+dO3cwPj6OZ599Vjog\nn8+Hr3zlK2htbUU4HIbZbIbNZpONO2kshYWFklCQn5+PxsZGwdY6OjrwzDPPYGtrC48fP0ZeXh5q\namrk82LGFDE3dgbES8l/ZVfIiBTm8lDtA0AoMXwAaPgS/bCkpaVJR8Svyc3NlS6EP5MREcTLtra2\nZGogxMBFSWzsflolsL803NzcFG9ZPpjskKInA8Ive3t7ePDgAYqLi2GxWLCzs4OcnBwJl+PCgsWc\nOHpPT48UcMZo8P4k1zcUCuHixYtwu91obGyUMEVuxdnZA/tLGq1Wi7feegtqtRrnz5/Hz3/+c7jd\nbtTU1OD06dO4ffs2DAYDXC6XLAgpLa2trUVTU5M4o2k0Gty7d0+KXygUQldXl2DSnI5oos4uPTk5\nWShThOvYnZJWBEDuE3orkJbHsZ7qLvJHOcZHL4eiiyKvZXRRje5MObazC6WijgWUy8Hh4WF89tln\nQm/k+/2zLqR/+MMfkJiYKGYPOTk54pyUmJiI4eFhfP3rX8fg4CB2d3elyGq1WiQlJWFubg4XL16E\nxWJ5Iif7+vXrqK+vx/b2NlZXV2W5wxhZ2u7RxJkbx729PYmZJQg9MTGBkpISAZ15UyQkJECv18vI\nSWu7SCSCuro6iSRZW1tDVlYW+vv7hZ9H6g0A2O12lJSUQKlUSlDfysoKTCaTGGMUFRVhZGREQueo\n8XY6nbh79+7/hdWpVCoxsY6Li8PNmzdFGpmdnQ2j0SiG2DzIUlNT8dlnn6GyshJ3795FdXU1NBoN\nLBYL1tfX0dzcjLq6OtHa8yDhzUpjEm6uiUUmJyeL5n5jY0PsDqPNSrgM4ojH7pPcTIL/7BRpa0hl\nDg8iYtLx8fFSuJRKpcAJpClFd1c8+KIXDYQjWGzIR2T3S9pRamoqfvGLX6C1tRWbm5s4ceIEYmNj\nhfvK5aRGo5ECtLy8LAf10NCQ4Ki0dWTRIIxEiWlzczPS0tKE0kazFuK+XL5Q0ba0tITDhw8jKSkJ\nzz77LDo7OyULiYyUwsJCKBQKoXBRiQRA4Bj6e3Z3d4tC78KFC8JFjo2NRUFBAXJycrC8vCz4Kwsi\n/VY5MQSDQQSDQWG0sKBFd5ScGpRK5RP3GKeF6FH+T0n10WR6QhOcXgDIZEH7P4/HA7vdjrt37+Lz\nzz+XNAh+Brw/fvSjH32pmvZU6E/BYFCcw9955x2cPHkSWq0WPT09EtJGN5aysjLExcVJdHN/fz++\n+c1v4vbt28jPz5c8I3pD9vb24sKFC1hfX8f4+LhQRxwOB5RKpdBdEhISBAejByUdw4m/sVtipOzC\nwoIQx+12u/BBU1NTxYdyY2NDCiwpLfwahUIBr9crrv48TRlmRo3wxsYGcnNzcf36dezt7WF9fV1S\nRvPz81FaWgqTyYTl5WVsbm5K/s0777yDs2fPIj8/H1tbW3jhhRcQCoXQ3d0tfgMJCQkwmUwwGo0Y\nHh7GwsICfvjDH0KpVMJkMqGrqwvJycloa2vD5uYmrl27hgcPHuDZZ59FbGwsLBYLUlJSJOp6d3dX\nZLZ0V2JqJiWIkUhE4ibIEyVeSc4oR2y1Wi2ael6jaH21zWYTfin9Xml8QfPjcDgMtVotvFPSYYin\nAhDdP30r+fL5fJLiSR9cjUYjPrRZWVm4desWmpub8cknn+B73/seBgYGoNPpkJSUJL8zDwMuHLe3\ntzEyMoIbN25I6gNzhEhc5/haUlKCSCQisBQ7aoVCIQ+80+kEACkWU1NTKC4uhlarRUpKCp599llc\nu3YNtbW16O7uRk1NDRwOBwYGBvCVr3wFer0eq6urok4rLi4WVZHJZML6+jp2dnbw/PPPS84Z1Yd0\nNaOpdnl5uUwA8fHxMm3s7OxIFhht8Dhp8HMnhTAUCsHj8cDr9Ypwg11h9Jge/d/8GdFbeh64PMAA\niCcpcdKJiQkMDg7KvcFuFYBQKulw9mVfT21r39XVJQ7tBoMB//3f/y22W+3t7djZ2UFmZiYuX74s\nG0EGeTkcDiQkJGB0dBR6vV6KjNVqxfLyMtra2qBUKvH48WPU1tZCo9HA6/WKN6hWq5WcdprOxsbG\nyiazsLBQXHio983MzBRPUmri8/Ly0N/fLxZ4dIMizYed78TEBCoqKmSkIueVKqe4uDiRi8bFxaGw\nsBAzMzOSGskFTtEfjaAjkQju3LmD+vp66cY8Hg98Ph8WFxelq6cnAB2onn32WeTk5KC6uloYByaT\nCTabDdPT02LqbDKZMDU1hfX1ddTU1ODIkSPIz88X7K6wsFBwKBqNsJvkQ8QlBB32ObJyKcViQl4m\nu1lapAGQAhcfHy9dOfPMKU202WxCNyPcwIeK6rDd3V24XC7pqtkxs8jzYeJ4yK6LaaUul0uK/9bW\nlpiOK5VK3LhxA3l5eWhpaZH3RglyOByW358mJeyyg8GgFHIe2KWlpXKwBAIBtLa2inSV9yfZINxg\np6SkYGRkRBRu+fn56OnpEbYBTZ7n5+dx5swZKV75+fkwGAxoaGhAYWGh7BHoolVTUwOTyYS1tTVh\nIyz8McKY9+rk5CQGBgbg8XikAPGgoxKQKbTRLvkUU0Sb3LChyMnJeeIgjl4asbtkQWUHyueGBzK3\n87y/AoEAlpeX0d3djd7eXqytrUlBZ8HU6/XIy8sTdkFBQQESExPx8ssvf6ma9lQ60rGxMTGRvX79\numh7yUdzu92IiYnB7du30djYKA7ud+7cwaVLl3Dt2jVcvHgR8fHxmJ2dxTe+8Q1xz6fEj2oRt9uN\ngoICGAwG2O12FBUVQaVSiTGGUqmUh4xcVsoQY2JiJOmTNJmJiQnJDI+Li5O4D6aIUtFD5Q9HNZqN\nMBM+2i2JW/e5uTnk5OQ8YYIcExODvLw8iVXOyspCfn4+mpqaMDY2hhMnTsBiseDhw4eSq1NfX4+y\nsjIUFRUhKSkJTqcTaWlpEnFLOd8rr7wi6jKHw4HW1lYx6cjJycGlS5dQVFQkzkzEdTn+EivmjUsT\nZhZWFhHK9TIyMgRTYxfpdDrl/dHViPJT0qpIH4peDFHzzQeSCyjitCkpKeLAzofNbreLQiomJkac\n1ZniSi4qpcEejwcOhwNWqxXJyckSZzI9PY3c3Fws/DHfi8WAnQ1/X7/fL9eZGVw2mw2Li4sCQ1AM\nQHZDaWkpvF4vmpubn4hi4XY5Li4ODodDjJepMlKr1bBYLOjs7ERbWxsePnwohb+wsFAk2IcPH5bP\nli5chGFYXAYHB3Hs2DHcv38fycnJ4kNLPwClUgm73Q6TyYS8vDxMTU1hZWUFPp9PKFIswKSBBYNB\nSe3NycmRDTxpdQDkXqURDbmznDwIr0S/SLTn4pfPr8fjwcrKCpaWlsQrIJouxxrAa8cul/drdDDn\nl3k9lUJaXl6O9vZ2/Od//qfc2GlpaYiNjUVpaal4TDJOZG1tDbOzs/jLv/xLvP322ygpKRGH966u\nLiwsLEg7n5KSAovFgvz8fFn8MOKjr68P5eXlYmoRDodlW0q+GrtRnpJ0Lk9KSoLFYkF1dbVs87mc\n2NvbQ0NDwxMRBwDELMXlcgkBuaSkRED6cDiMgYEBNDc3y0WjJRxv9MTERFle0RKPheLkyZN49OiR\nFAy9Xo9Tp05he3sbt27dgsfjwcGDB8VXgKYgra2tKCwsFBlhTEyM5BrZbDacPHkSwD4ePDg4CKPR\nKBvOnZ0dMfAIhUIoKCiQkDUWWqVSKZ0glzXsFljwSDfj6B4IBORz4Qac1DAaDNMpitxB4mHknXLE\n4xaWPqCpqaki1ZyYmEB7e7ssPdjBUgO+trYmcFBCQoJwH91uNyYmJpCXl4eioiL09/cjNnY/daCx\nsRFKpVIOZ+J2ZF6woE5NTT1BtdrZ2UFpaalEXfAgysvLE5yUxZa/n8fjwdTUlCwG6XbEfK1Lly5B\nqVSitbVVYCo6VVFpxPGZC1UWM5vNJoV3dXVVZNCnT59GfHw8+vv7EYlEUF9fD6/XK1LP6upqgeKG\nhoZgNBqh1WqxtrYmRuzZ2dky5VHVFxsbKw0PF7kmkwk+nw+zs7Ow2WzSidPZKdq1id8nEonIAW+3\n22E2m+U+UiqVknTBSYgYOwBZOqalpYnTGDH2Py3a/1+vp1JIq6qq8O///u9yIvDmMhgMePToEQ4d\nOoR33nkH4XAYWq0Wn376KY4fP46ZmRkoFAohrFNKSD4mZZk2mw12ux1GoxE3btyQHCSeMhylGCGy\nsrKCoqIimM1mKBQK2O126YroOk8uI/mKmZmZUCqVUKlUUKlUIi1MSUkRmlQwGJSLzFGfMR3EAMvL\nyxEXFyf0KovFAq/Xi7q6Omg0GmRnZ4v9GjG/jY0NpKenIxKJyKbUbrfLiDs5OSnRG2+++SZ2dnbQ\n1NSEQ4cO4dy5c9jc3ER3dzdKSkpEUURddVZWFtLT01FRUSHZS9Tdc3EVFxeH9PR0KJVKwc84zrlc\nLlETUd3FZQ5PfurzebgoFAr4fD7pGPi5ssMkBxSALKfoFsWv5TjMIpufnw+LxYIHDx4gJiYGx48f\nx8bGBj7++GNxxOeyhyMzI5tpcuJ0OkXgAQD5+fmYm5uDVqsVeIFm28QLmVIZvUGmxPfIkSP4zW9+\nIx3y5uYmTp06hT/84Q/Iz89HTk7OE56vNFVmgBw51BkZGXjw4AHGxsakSLW2tgqc4fF4hB7FcZih\nhuxyo8fe2NhYlJSUiE/r7OysFDWr1SrpoZR+dnV1Cac5EAhgdXUV9fX1Ym2pUCgwMTEhAZCPHj3C\n3t4e6urqnjhcSQ2LiYkR5ydaUdrtduEwR99DwBc6+Wg+KJkpnBSZnsAUWUINZB0A+3ldHo9HlqEL\nf0yNiMbvv+zrqRTSvr6+J+gQDPra3t7GhQsX4Ha7xYHH5XLh8OHDKCgowPXr1yU7HQDef/99eeCj\n4zJIg4mNjYVOp8P6+rpIEe12OyorK2Xj/PjxY6HrkHBO3I9AfGZmpnA+bTYb0tLSkJubK4WTD7rX\n64XRaHxis82u1+fzIT8/H3t7e8LP40UdGxuTLCMWDnqp8mYC9vOZ9Ho90tPTYTAYMDU1JZw8pVKJ\n0dFR7O3t4dNPP8VXv/pVPPfcc6IcMZvNGBkZkc2pSqVCQ0MDent7xSHr8ePHCAQCqKysREJCAh48\neICKigqJWWEoIUddqsI2NzeRlJQkDxxTWaO1z0zZJL+WxOpgMCjJAxyzuSRgwfH7/dje3hbp59ra\nmiTLMhIDgGDpzHSKRCI4deoUrl+/jq6uLtTV1WFzcxOjo6MYHx9HUVERZqo7NQAAIABJREFUYmNj\nYbVapZAmJCTA7/fjL/7iL6SLSUlJgdlslvHd7XYjHN6PNr58+TKam5uF1cECy46UXeHs7CwmJyeF\nDcBphb68RUVFQp2iZ0O0TwAVbQ6HA5cvX5YDp6KiAllZWcJ7Za4ZX4FAADs7O1CpVIK38vONzjxj\ntrzD4YBGo0FFRYV00iTzM42UUxvhNKfTifz8fMmbiouLQ0lJCdxut5iPkNnBAuzxeBAMBgUiIvZM\nZWBGRgb6+/uFZ0r4JS4u7omNPu8TvV7/hOItGAxKF88oHHbw7G656OOBZzAYnqBa8b1/mddTKaSN\njY3Cfaurq0NpaSmGh4dRUVGB4eFhKBQKvP7667IpLSwsxJtvvon8/HyUl5djdHQUPp9PiM4KxX5e\nvNFoREzMfsxyd3c3Dh06BI1Gg5GREZw5c+YJlyIuNCoqKjA5OSl80dLSUty8eRNGo1G6JgBCNVlf\nXxfQPHqrzA+dvEaXyyVkf5PJhMnJSbnQ9M7k6EA9t91uh0KhQFZWFoLBoIydRUVFmJ+fF+OQtbU1\naDQaRCIR/P73v5dYksbGRszPz+OVV16B3W7HL3/5SxlPaThRU1ODubk5NDY24vr168jKyhJqVV1d\nHUwmE3Q6Hfr6+lBRUYFbt27hwIEDqK+vx/r6OpxOp5i6EHrY3t4W7JOEbfIAgf3lAB2bOEYzloQk\ndj7s3NBzZKUkkdZrCoUCxcXFT4zy7Ey4GWeE8s2bN+F2u+FyudDb24twOIxAIIDR0VGEQiHcuXNH\nijuwH/5WVlYGjUaD3/3ud+KJGggEEIlE0NjYiJKSEvz+978XkxReq2gMj10NoZRgMCjBfLyXKPrw\n+/2ykCwuLkZubq506fxcWEizs7PxX//1XwiFQlheXsYPfvAD6e6oeWc2FQA5oLis5ARGzq7dbpdC\n43Q6RSYZH7+fgcVpTKvViuyXkTlqtRrBYBB+v1/cqSKRCHp6elBeXg6PxyOuXjxwaTYdExMjUxo7\nbFLLbt26JcvJQCCAwsJCjI2NCYRGTJMR3sSj+ewRPuKUolAoRDHGYEoWW+ZIEUbjEs/r9Ypv65d9\nPZVCCgClpaX4p3/6J/T29uKXv/wl2traMDY2JuMeL2JzczN+9rOfIS4uDjk5OVAqlVhcXJSvo8nw\n4uIijh8/jvj4eExPT8tSiA8KkyRzc3OhUCjklAW+ULUwopmZPkV/jP1gBAe7Uo6VWq0Ws7OzQgbX\naDRilZaSkgKn04msrCx5GFh4lpeXkZeXB7fbLRHM7Hw4zvr9fpSUlMDhcCArK0sWJMx/4s9/5pln\n0NnZiVAohM8++0y8Uom1cRFGX9ePPvoIP/7xjzEzMyPmGezamUnU0dEh0tyDBw/CZrPhxo0bOHr0\nKIqLi2XjzBubyxAqhoiJcgnAjpQjJRkDvHF5U7Pz5CRAv0wWCurT19bWhN4SHx8Pp9MJm82G3d1d\nZGZm4vr161hbWxOIh7glHZBoDhJNr9nb24Pb7UZXV5e4eVGymp+fL3AIl4Obm5tQq9Wy4eX4SCyY\nRZXG0eQn86Enhsc4EGA/u8toNCIrK0vktjExMXC5XEhJScG//Mu/ICsrC6urq3jttdeQkZEhozk9\najmVES7hEom8XPJPKWLgsozvLT09Xbb3cXFxWF1dlUnN7XaLXWD0omhsbEyk0dxp8OvLy8uf6Kr5\nnhiSxyURpa+MZdnc3ITVasXk5CR0Oh3S0tLQ29v7hKEPMVDePwDkPlEoFILxAhBGBacEFlxeLzJC\nKPSJPqC/zOupFFI6aickJKC5uRnl5eX4/PPPkZmZCZPJhN7eXgHc33//fXz1q1/F559/jrS0NAwN\nDckvn5WVJUUFgLjmDA0NCScvKSlJxr+cnBzBnRwOBxQKBVJSUqDT6SQHqqKiQuKcXS4XGhoaMDc3\nB71ej3A4DJ1OJ4YaBLIJTJNQzCUKSdShUAg5OTlCtwoEAqipqUFCQoI8POxIKdvkSOP3+4W07XK5\nYDAYkJ6ejvX1dfj9fszNzUliJXPGLRYLZmdncfToUREamM1mpKam4tvf/rYECJaVlSE5ORlutxuJ\niYkoLS0V/u3S0hK+/e1vyzUifmmxWAAALpcLBQUFwn0F9jee0XQiYqLRevWUlBTs7u5idXVVOjT+\nGWlDxJj5vjwejyRZAvsPEP1n+T0XFhawvLyMUCiEuro6ABB/WxoG7+3tSXwLC3FzczPUajXu378v\nRZ6FxWazCYRitVqRmZmJpaUl+TnsPP/fjIeJAdpsNuzs7KCvrw+HDx8W8xbeM+zW/+Ef/kHuSTIS\nmG+lUOzH61itVgQCAbGa5KHAKYibblpF8v2Qv0zmA983ITK+D/5OMzMzQuPjBETFodlslsWl1WpF\nTk4OIpEIOjs7UVFRIVlrfCYXFxflMKqtrQWAJ+wO7Xa7dLMqlQrZ2dkiqiCdb21tDYFAAC+++CLG\nx8dht9uF2saGiNg+2TOExKanpxETEyOYcGJiotxnhIo4HWRkZAj0xj/7sq+nUkipp+b4kpaWhpMn\nT2JychILCwuIj49HY2Mjuru7sb29jffffx/Hjx+XZRHBZ0YcsyNil0R86vHjxygvLxf8p6GhQboA\njlxc6NjtdgSDQVEh2Ww2eSh0Op1sOqnLZzdMtxin0yljEbmQ4XAYLpdLTDgY9qfVaqUbXVxcRG1t\nLdxuNwoLCzEyMiJfv7KyInI8YlIcTxh9nJCQgNXVVZjNZnzlK1/BlStXJJaEDj4JCQmorq5GQ0MD\n7t+/j3PnziErKwvT09PCxSSbICYmBlqtFi+99BLu3buHM2fOIDY2Fqurq+jp6YFOp4PRaERpaamQ\nqLlJ5eccrVyimw87AV4jLlZiYmKEJsX4k8XFRVFYRY/0NpsNq6uriEQiyMzMRCAQwNzcHKanp2W0\n9fl8uHPnjizm2AlSHsrUS1J4cnJyUF5ejlu3bonPLHHZjY0NKaBJSUlYX19Hf38/lEqlZG5xecbU\n093dXRlL7XY7BgcHYbFYsLm5idnZWSGlEyOlOYjL5RJCPTsqLl4YUMf3MDAwgK9+9auIi4uTwslt\nPClc5NnSRJsjMHHo3d1dBINBeSaJydLZnzJNs9ksy0G9Xi8Bk8vLy1Ao9s2xz507J3EsVqv1CeVZ\nJBLB3Nwc5ufnhbtLji3ZDQwUnJycRDgcFjtLWiJWVVVhYmICH330kdCraP5MehyvF3nTaWlpyMvL\nE2Nr3mN8LsPhMObn5wWTp0k1l75msxnBYBDf+c53vlRNeyqE/LGxMTn9CbwnJCRAq9Vic3NTMsNH\nRkZEZTQ8PIxAIIBz587h5s2bsjAin47yN3YgCwsLgmPSHo4bbnIDSZ3hosfr9T5hOs2HgqMSH6po\nEjFH2a2tLfh8PgnDozWY3+8Xcw6v1yuuUn6/XzBB8tZ40u/t7UlSJ7tftVqN8fFxicmwWq1y+i4u\nLgqfsKSkBImJibBYLHJCHz16FO3t7Xj48KHIAVdWVjA3N4eFhQWkpKSgtLQUzz//vEgI9/b2MDMz\nA51OJ9LbjIwMBINBPH78GPPz81IQycsj5qvRaITszgUHCe0UB3BDHj2GcrooLCyE2WzG1taWmA6r\n1WoolUp0dnZK5Mb8/DyUSiWGh4cxPT2N4eFhRCIR8UsNBoPijk9slcWP1JkLFy7gxz/+sVjAtbe3\nw+l0iuMR/SqJCdK6kF1yTEwMTpw4IdeS9zM7z9HRUYmJ8Xq94lDFJV1+fj6MRqOITWgCwm5yfX0d\nZrMZd+7cgd/vR0ZGBl599VW552g2TSvGaKkkizH9VmmuQ+oXGQsUnfDPI5GIRKSkpaVhY2MDGRkZ\nsnAi1MJrzm6VJjVcsPJaUHXG540yYnI5+f5zc3MxOTmJuLj9rKu0tDQMDg7KgpcwB02xfT6fLNH4\nD5sLALK0NpvNcLvdAACj0Yjc3FxkZ2cjPT1dirVKpZKFIA/rxMREfO973/tSNe2pFFKz2YxQKCQn\nIkc/6pN3d3extLQEv98PrVYLp9MpeEh3dzd+9KMfISkpCZ2dnXLyhEIhqNVqdHd3o7a2VgxMcnNz\nUfTHjJz6+nokJCRgdnYWMzMzAuozund3dxdra2uCiSkUCiwtLcFoNMLv90tWPbfNtBVLTU0VRVFh\nYSEcDoe42ZCcnpSUhJWVFRgMBty+fRsmk0ks2OgWRfUPyeuMo+UpefPmTaSmpqKiogJut1u6WMou\nU1NT0dfXh93dXVy6dAlra2uYn59HUlIS/uM//kPs+vg+L126hOeffx5HjhzB8vIy7t+/j9TUVLz3\n3nt49OgRnn/+eYyNjWFvbw/vv/8+7t69C5vNhtraWhgMBuFpEofiWES2Ahcu7G7YJdntdsFCufyj\nPV1qaqoYc4yMjGBxcRELCwtYW1uDz+fDJ598goqKCjEf7ujokHF+c3NTXKmoLuNihAIBPrRerxdt\nbW0Sq0GT362tLVy6dEkYD6Ojo7LEoNkzC09GRgZCoRCee+45qFQqwWwVCoUsW6KNeAgB/KmhCa9d\nUVGRdJ5cYPLQu3z5smCy29vbyM7OlqaBkspoXI8FMhwOy9KW0wlNYcjLTE5OxtraGuLi4kTKTGYH\nhQhk13DpQ/kruddMOGARp7MamRv8XszJija54aGysrKCvLw8ZGVlSYNRVlYmFCVCYxRLmEwmobwR\n5wbwhEoN+CK1IRQKiY2h2WzG6uoq9Ho98vPzodfrUVFRgerqaolS39zc/PO20aOSicoWPtx0fSou\nLkZlZSUKCwsxPT0tmAjVIO+99x5Onz4t284jR47gxo0bwp30+XyorKwU/t/k5CSamprEQX1ubg6j\no6NPKHGA/TC4GzduoL6+XjAaysg8Ho84E7FTpPFvJBIRZ/DS0lIMDg7KgoWcN25jWYiVSiWsVisq\nKysF69nc3BSrsZWVFeGTWiwWJCUlYWRkBPHx8Thw4ADcbrdgZArFfiTF6uoqiv6YTtrV1YWmpiYc\nPnwYKSkpaGhoQFtbG4qKioQbSvPczz77DCsrKzh48CAGBwfR0tICvV6Pe/fuwWq1oqCgABkZGdBq\ntTh27BimpqYAQEZK4rMk4XNJwg4kukOjsTZt8wDI17lcLnEFGh8fF8J2X18fKisrJT/+7bffxujo\nqEiEA4EAqqur5YAmKZ+OTzTwTkhIEKxsd3dXRur5+fkngtLOnz8vS73a2lrs7e0Ji4EuURQKKJVK\ntLS0iIQW2D9QaGLd1dUl9DqO6KRAra+vQ6vVorKyEocPH5aGgjSmra0tLC8v46233kJiYqLQ4kjp\n4vZ7ZGREFjf8XKMXfSzaXKaEQiHZ3mdmZgq+Sp06oTNGY9PXgKwXQk18Rra2trCwsCAiDUqBKTc1\nmUxyOBBO4yKUhyeNgUhbYuAik1bZgUd7OhDW4MTB4hltYkJq187OjkSQr66uwu12w2q1Ynx8HA8e\nPMDo6ChSU1NRWlqKsrIylJeXo6qqCidOnPhSNe2pFNJ3330XGo0GarVaxtnFxUXBmGJjY0X7Sm4X\nT6TNzU3JMa+srJScmcnJSVRWVmJjYwN5eXmYmZlBeXk5zGazEHFJe0hPT0dPTw8yMjKE+M2tO234\n2E0pFAqkpaUhLi5O4ALitHRzYkcQDoeRm5uL6elpLC4uIj8/H36/H0ajEeFwWFyouBygAxC7FLVa\nLQ8nxxY6/ZDyEgqF0NTUJIoPOrOzmJIaFQgEcP/+ffj9ftTU1KC/vx99fX3Y2tpCf38/WlpaMDo6\niqmpKbFMY7gfDzXq8p1OJ5aXl2XUiouLQ3NzM/b29qDRaGCz2aBQKIS/SAySv6NCoRA8NJqKs7m5\nKRQZmizz96LAYmZmBseOHcNPf/pTTE9P49atW/ja174Gn88n7kqU8hKe4edC9yZ6tLJQAfs4PR9C\nh8MhB9nW1hauXLkCu92ODz74AC6XSwIQKXOM1nPTG6GpqUlgABp3DA0NCQ/T5XIB2JdBpqamIjMz\nExUVFSgrK8ORI0fk/XLhQVOQ27dvY3l5WfioxEj5ffv7+zE1NSWMhJiYGMEkKQQgpYyprQCkMLPo\ncCJkMSWsRYybJjD8/YH9To//n4wYSkONRiO8Xi9UKhWsVisUCgUKCwtRUFCArKwsOJ1O6SxpiE5z\nH3aWxGQnJyeFLsdX9FKP//A98dq43W4sLi6KSsrtdj+R8UQzE2B/Aba8vIzPP/9cGoi8vDycOXPm\nS9W0p1JIX3/9ddy7dw8KhUIMRDIzM2G322G1WlFWViYZ7RqNBnV1dcjNzcXExARCoZCcUPfv38fp\n06ehUCjQ1dWF1tZW4VfypqFVWEJCAq5cuYKGhgZJ64yNjcXU1JTob2lkbLPZUFpaitTUVIlG5tew\nO6TJAp2ZnE4niv5oKqJQKDAyMoLs7GxsbGxIB8iRKC4uDiMjI2hpaYHZbJYtIbtM3vhcKhGXI82j\nvLwcg4ODIkQgVjU7OwuHwyGdIWkmHR0d2N3dxaFDh1BYWIhDhw5haWkJ09PTqK+vx+TkJPr6+jAw\nMICGhgbp1Px+Pzo7O8WS0OPx4OzZs8jIyMDw8DCqq6vR0dGB8vJyIcqzAyf+xhGSHWo0BsiHl78v\nmRx+vx8zMzPCS71+/Tr+5m/+Bqurq0hJSUFHRwcqKysRDocFeoiOYCY3kBxL4t2ENoB9juX29jYa\nGxslDoZjZmJiIqxWq0AFpC8Rc43WdW9vb+P06dNCn0lMTEQoFJJNt1KpxKNHj57Q4ZPs3tjYiMrK\nSqGQEXMnhru9vS0+mWq1GktLS/K1dNvn0mVrawsPHz7EJ598gv7+fszOzorQYGFhQZyeCLsAX7As\n2KFTJchrQryUHXQwGMTs7Cw8Hg9yc3NFxRSd9BAIBLC1tSWJpCqVSrB1LpE8Ho9Y+XGiWl1dBbDP\nvKHh0NTUlLhc8VDmi6wAdtCbm5tiYm2z2YTBwnsheuzn4UtIgIWYnwvx5dnZWfzd3/3dl6ppT6WQ\n/u53v4NKpYLD4UAgEBDrL2YwffLJJ6LVZfufm5uL6upq4XcyEoEb7q997WtYWVlBMBhEQUEB7Ha7\naNQZKbyxsYG4uDg0NDRgenoaOp0OU1NTSExMhNFolE6gtLRUcDCHwyHjOEn57PrUajUWFxeh1+tl\nAcXuKhgMIisrCx6PRzLSeVPGxsbKqJSTkyPbcm5OHQ6H/M7RShpyDisrK7G0tITi4mJRo7Dz297e\nlkWX0+kUGhjVR4cPH8Ybb7yB4uJitLe346OPPpL8q+rqahn129raEBcXh5MnT6K2thYmkwn19fWw\nWCzIzc1Fc3Oz3HhcMmi1Wni9XrnpucQjpSc+Pl46wOXlZUxOToru3mKxCBbpdrsl5sXv96Ourg69\nvb2Sz84Qv5ycHOh0OiwtLQl9B4BQqYLBoKhgyIsk2T8SiWB5eRkHDhyAz+eTZQQXXhwNAQgcQHyO\n3WE4HEZxcTFUKhVKS0vl0AOAhYUFsVW0Wq1ygBCuYPfMWG3GSvPnBAIBfPjhh3jjjTdQV1f3BOWH\nLmQkxAcCAaE3ARC6j8fjQW9vr4zIn3/+OT777DM8fPgQAwMD8Pv9WF5elsmMPhH0VOD3IkygUOwH\n01E9RvNuelzQa4EepPSKpQqJqRMGgwEWi0Xue+45+LnMzc2JgCESiSAlJUUWmNGCF4/HIym7Xq9X\neMm8btFWesAX9nvRnqXsZIEvXKX4e+zt7eG73/3ul6ppT83YWaPRYGFhAS+//DJ+9rOfwWw2Iy8v\nTx6OgYEBGYcIVqvVajQ2NsJisYgHZHV1NRISElBQUIDi4mKUl5eLHr+wsBCzs7PiMD4yMgKtVitE\nZN4s8/PzaGxshNVqFbIyCeTx8fGyNZyamkJ+fj5UKhU8Hg8MBgMWFhZEd+71epGVlYWZmRnBZny+\n/4e6Nw1u877ORx8CIEiAxEaQAEGQALiv4iKJokTtkuUtdpw4bpw4GadpZ9rGbadJJ3WbzKSdTDKZ\nyTRtmnaaZbK46aSxE9tJvVW2rH2hKFGkuEjcCS4AsRIgCYL7gvuBeY5eqv87V/fLVS5nNNq4vnjf\n8zvn2U4CDodDSBUm0USjUYEQWBD5kLOzYioPPf/Up+r1eukugsGgYEXUrWq1Wokiy83NlSSkT37y\nk7h48SJycnLgdrvR3t4OtXp7M+fm5qbEuNXU1CA9PV12A129elV8/ZWVlSJ8HxkZQUVFBVQqleBO\nyWQSnt8lRlGVQW0mgzVIanA/0uLiojwMwWBQ7hNqCmdnZ8WaOj8/j+effx7/9V//Bb/fj4KCArhc\nLvT39yMtbTuvc3NzU6732toa4vG4kDokTgAITOPxeBCNRgU3JDHETp+jInFupkNFo1E8/vjjMt4b\njUZRo2i1Wik29Oaz66Mxg66uffv2AbgXCxcKhXDu3Dn88Ic/RGZmpoykZL4Z8cfDk0Wf3TdH84WF\nBflZOFWkUilUVVWhsLAQVqsVhYWFMhFQIkXLNpPMqLZQqg0ASD6CyWRCOBzG8vIyJiYmYDKZkJGR\nIRI3ThrUifI5y83NhclkwsbGBrxeLwYHB9Hd3Q2NRiMrSihZGxsbw9TUlBC5zCBgoWcRZDfJNxZK\nTkdK2zKvGz8H3/h8pVKp3+9C+tZbb6Gvrw/f+ta3cPr0aYlSe/fdd0XSUVpais3NTQwMDIjPmCsn\nSMgYjUb09/djcHAQ586dE3ae2zq9Xq/sLDKbzTCbzTI6qFTbCfnsRnJzczE7O4uCggLE43GUlJRg\nampKAHWz2YxwOIyZmRkUFRVJoDK74kgkIoB/T0+PuHK4zZTaPLpMWOxYXEwmEwKBgCxOAyAeZMpm\nmIpEZndqagpGoxHJZBIlJSUyklE2VlBQIN7k5uZmTE5OorW1FWazGWfOnMHx48dlw2ReXh4SiQS6\nurrg8XiwvLwsiUDz8/N45plncPbsWUllamtrk/UnHLnLy8ulmDFDlF0OBde8aZXBFRqNBhUVFbDZ\nbIK/MWSDaeYTExMYGxvDwsICuru78a1vfQvvvfceEokEkskkDh48iNHRUSHy+KAxto0PzvLysgS+\ncAQtLy8XFw9xW4ryaZs8dOiQ7JHKzc0FAEkBe/bZZ2G1WrG2tiafOzMzE7du3UI8HseFCxewtbW9\nNI6F6+7du6irq4NGo4HH45GObmVlBd/4xjdw/fp1keFw7OTIbzAY0NraKqJ8KgaAe9tRiQvTKMAA\nZUrbuKabUwv3OnGRHWMgtVqtBLIwKIgdbF5enqR58XXkoT45OYm+vj5EIhHRxobDYXR2doqzbXl5\nWcJJzGYzPB4P8vPzEQqFMDAwgL6+PoHWeGBwwuIBwTeO60rSSUk8ATvZfGU3Sl0v8WDqw3/vC+nL\nL7+M733ve3j99dclo1GtVotVMRQKiceXXmaGI9BLT1cT9zAdOHAA7733Hurr69HY2IhXXnkFtbW1\nslCPi9PKy8tldXEikUAgEJBkpsnJSdTV1Yl+jjdIbW0tRkZGYDabZdd4PB6HyWSSMJSVlRVJ+jYa\njRgcHJS8yFRqOz5vZmZGCACKiMvLy9HX14eqqqodnulgMCjrbCm05gM6NTUl8hCC+Uzppy9dq93e\nyBoMBiW8JTs7G1NTUwgGg1heXkZ5eTn8fj+MRiMGBgbg8XjQ2NiIrq4uFBYWIhaLwe12o6GhAUND\nQ/8rDYcqBI6cWq0WIyMjMvaSDFpZWUE8HpfkrYWFBVkCGAqFJHOTQnadTieibbpQqEvV6XTIz8/H\nd77zHXzxi1+UqDaTyYTq6moMDAxIIA2xM2Jk7OaVW041Gg3u3r2LXbt2SdwetZOEVNhFMYiZ7Ddd\nRiREs7OzYbFYoNFs787y+/1YXFxEYWEhrl27hqamJsH0jEYjpqencfjwYdjtdtnjdO3aNbz77ruS\nnKTE9NbW1lBeXo6/+Zu/QW1trUAGJKrYjR4/flwgBk5fnHJisRh8Ph/6+vokYJoH1dzcHHw+H/R6\nvST+8/NytFepVNJ8UHbHLGFCaSSGE4mE3LcM8iY8wwaCzrXNzU309fXh+vXriMfjYgW1Wq0iW2Ph\nUxZJ5b3IrlnZkRIuUhZVXk9lV0pYT61WixRyfX0df/VXf/VANe2hFFKXy4Uf/OAH/ytBXafTiY2T\n+1SYE5pIJGR8YEo9MZeTJ0+KsJl+/aNHj4o+lN5ls9mMyclJ5ObmYmBgQEKWGTw7NzeHqqoqTE5O\nStdIO5vVahUSpLCwUEZ3jlnT09OoqKgQMXJ3dzc8Hg8WFxcRiURQXl4uL9zGxoZ0X4uLi7h9+7ZY\n6+jMIDGl0+kEx2XAbTgcRm1tLVKplLDjubm5kpHKLtViscBut6O1tRV37tzBmTNnsG/fPsHWGhoa\nBNesqKjABx98gLKyMjE6dHR0oL+/H5FIBM3NzaiuroZOp0NbW5tgqMPDw/D8brdUcXExsrOzZXd6\nIpFANBrF1taW3JwrKyvIysoSUTszB5hslEgkMDQ0hGQyKZmc6+vrwgbPz89jbGwMpaWleOedd/Dc\nc8/BZrPhwoULYmcdGhqS8VoplOe1ZwdCPHBpaQm3bt0SSCgajYpgvLa2FgBgNpulU2FhUWqPm5qa\nkJeXJ7kPyWRSurSzZ8/C4/GgpKQEAISEKigoEOG/VqvF3bt30dXVhb6+Pin2hHDojeffnU6nuPu4\nEpykUXZ2Nmw2m5BN93esyug6ju8ABJZh6AxxfB76RqNRVBFms1kOFGKqVJCwm7NarSIvpD2XChx2\nuvPz80gmk+jt7ZU82rW1NSnsPFA4klOaxYKoVB0QG1USSPw4FlflfaDUmirfjwRYKpXCF7/4xQeq\naQ+lkH7605+Gw+FAQUEBRkZGoFarBROZnp7GiRMnMDo6ivHxcUk/qqurg8VikYg2eqwpVwK2raYV\nFRXCIFL0T4bW7/djZmZGuks6G8gwbmxsSPxXPB5HdXW1EBNzc3PweDzSQTOF2+VyiaSEQuRr166h\nublZNIe0kRLjys7OFt9vMpkUDR5dUexuMjK2N1ouLS2JAJpGAeqtb+9+AAAgAElEQVT71tbWcO7c\nORlPge1AmNnZWfj9fhw8eBCvvvoqpqamxMnT29uLRx99FHa7Ha+99hoqKirw85//HC+++CIuXLgg\n2s2srCwUFhbic5/7nLiZGE5BeUl/fz/sdjucTqeInJk6dOfOHTkcefNST0gcbG5uThYYBgIBgW9o\nCe3t7RVdKLd1VlVVQavdXnvy1ltvweFw4Mknn8Svf/1rNDY2or6+HlevXkVWVpaMniQraP2lYH9t\n7d6qZ8a8EUtlQE1OTo50xbFYTF4Xjv9lZWVoaWkRhplQFHAPo+MmAhaa5uZmRKNRWb5IGOvs2bOI\nRqMAIF0z722O6iMjI7hy5QouXrwoji6mM62vr+PYsWOYmJgQJQMhDt6jFOTTA69SqWCz2bBnzx5J\nwNfr9cjJyZH7kSYDEoiUuDE7lK/X+Pg4AAj5Q+sv5VrUEisDuumMI1nHJCoWTuLU/DOvCfXKfF8W\nRv47gB3jPos+tbB8/o1GIywWC2w2m2xEpQrjT//0Tx+opj2UQnr58mXE43HRXFosFhlzy8rKRNy+\ntraGT3ziE/jOd74jIQsLCwuyG2Z0dBQ5OTkSssxwCq6I4MXjqZObmyssL8HuhYUFuFwuVFdXo7q6\nWnaHDw8Po6ysTPaBE/czGo0YHx+XqLC8vDwsLi6KDo7MKztU5jfSPrq0tCSBCBT8z83NIRaLyQZU\npXSH4zRlU2fPnkVDQ4MkS7FDJxGSSqWEcCovL5esyOXlZdTV1cm1KSsrQygUwvHjx/GTn/wE+/bt\nE/tsXl4edu/ejSNHjkgnnp6ejvr6eqSnp6O4uFjGTmLKWq1WItRKS0vl3zY2NgQf02g0GBsbkzBo\njtrRaFQmBWDbQkzcfH19HXl5edLJ0MPOVdhc7R0MBvH3f//3+Pa3v43q6mocP34co6Ojoobg/UGJ\nUVZWFux2u2CqZOupqiD+qdS82u12SX1SusQI8VBBkZ2dLZCDWq3G1atXJVEoFoshPz8fXq8XTzzx\nhOCN8Xgcly9fRk9Pj0AaJAFZ2NkhEkdm8AYLDDtbhtUQ4uHBR/UGySgSuGw64vE4lpeXJSyE9kzq\nt8m2cyQPBoMSmk6LL+EsBkTPzc1JVCOwTSAyaWt1dXVHZijDYeiUo4KB3SILIWVmnBC4AtpoNIrK\nh00Wr6PJZILZbJZJkhtmec0ICZDwI678R3/0Rw9U0x5KIf2f//kfbG1tSaI107yZnUgW99ixYzh3\n7hxqampEL8gQXZJOylAJYjF8MMicxuNxLC0tYWRkBF1dXbItdHR0FKlUSjrMgYEB3LhxAzU1NdI1\nkshJJpM4d+4cjEYjqqqqJFDF6XTKA0rNJCUq9JnzZyITqNfrxUJIMXIkEkFJSYlgScSJpqamZKUw\ngz/m5uZEMjM+Pg6Px7MjoJaY4zvvvIOmpibo9XpMTk6Ke2lkZEQcUhcvXkQymZQH/bHHHoPf70db\nWxvS09Phcrlw69YteDwe/PKXv0R1dTW6u7tx7do1iZlbW1tDV1cXTpw4IfkGXPdcU1ODWCyGqakp\n6PV6FBcXyy7zK1euiIqB7K7FYkFhYSGamppkxBobG0MkEpEgDJofRkdHYbPZZIHfhx9+iH/6p3/C\nT37yEzidTpSVlUnMIa87GWhKiJiSpNVqYbfbYbPZxBFFnaRy5TELG7tR5r3u3bsXAESLevfuXYEy\nFhYWYLVaEQqFUFFRgc3NTezZswcTExMSKHL+/HmcP39eiC5uhl1aWpI1zMRR6cNXEiw8wOvq6iRr\ngkYRakI5SrODoxQtkUiI7ppyKoaKzMzMiPGAUMXs7Czm5+exubkpEYJGoxEZGRno7++HxWLZMVaz\nw6U9dXZ2VnaHDQ4OorOzU/gP5fienp4uBy5Zf6WvXqm9JVkE3BPp8+cE7hFNnCSUOCv/zs/Fz52R\nkYHPfvazD1TTHkohZXFgkgxxlKysLOlEQ6EQLBYLent7MTMzI4xoOBxGQ0MDcnJypDgxIZ14GmUt\nymDhpaUlyfWkRXV8fFxGEgCoq6sTkF2r1YrvlknalDeR9FlfX4fD4ZCVBfxZfD6feJJnZ2dhsVgQ\nDodFgsOOQqlL3L17t+wmUq4/YfgGu4fr16/LNVCr1bLSd3FxEWr19sI8fg3aHH0+nxBvGRkZOHjw\nIO7cuQNgewQzmUwYGhrCG2+8gVOnTsFqtYoxoK2tDQcOHMA3v/lNvPTSS2JbdLlcMBgMuHjxojDm\nJLS4ipiGBMqwmIAVi8Ukpo3xZcvLy5LdGg6HxbLH68+ADyZMkfmnFMbpdALYltZ95zvfwQ9+8APU\n19dj165dGBwclAJKcf76+rp4vjn+0oFE/SIZYhI3yvxVFgmLxYI9e/YIqeFyuTA4OIiVlRU0NjaK\ny4mde319PRKJhBzW1HLOzMwIzskCEggEdkjFYrGYFEalRpKJTjabTVaMU2bGwsDwG47JVDXw8GeB\n5oocwmIGgwGBQEC6TebixuNxUTGsrKwIj0Flxvz8vCz029rakkQyyvuYy6DT6aRT5DVlYWMxJBfA\nCZOFTklS8l6idpUrsUlWshgTWrFYLPK1ub00JydHuloW7eeee+6BatpDidFbXV2Fw+FAUVHRDpxk\nbW1NPPHESWhloz7w/fffh9lsRktLC/Ly8iTAl3pIujOYzM0Eb4r9OdINDw9j165dGBkZQXFxseBl\narVaGOVgMIiysjJZAVFaWoqJiQmxos7Pz8Nut8saCo7/ubm5yMzMxOXLl+F0OiXWKx6Pw+12o7u7\nGzU1NUIMdHZ2wm63Y3x8HMXFxfJAhcNhaLVaTE5OwuVyYWxsDC0tLThz5ow81BRHs5BwJCXBQH/0\n4uIiGhsbMT8/j46ODumAL1++jPz8fDQ3N6OwsFD0taurq/jVr36FL3/5y/jxj3+Mr3/961Cr1Rge\nHpatn1QGUK7F0z0ajaKvrw/xeBw6nQ67du3akVnAwBZ2s/Rtj4+PCyaXn58vO7lKSkrQ1NSE999/\nXyIQeXhwvTI7iiNHjuCFF17AW2+9hW9+85t4+umnUVxcjInfbfxkF7O2tgaLxSLL/DIzM0V/ykKw\ntbUFu90u3wsT8UlEMYyb8iFODCz6Pp8Pw8PDcLlcOwJ4jh07JiYBqlH4M7AQ0KhgMBiEmCQOyvuU\njDqwjaGS1GEyFa2+7PAooVJqYXkAsOMm884irFKp4Ha7EYlEcP78eezevVtss/X19XL9uMuKa9GZ\nFuXxeCSqcWVlBcPDwyKbikajuHbtmvjvdTqdKAH47CvxVHbG7C6VMiclU8+CzJ+NtmNll0q9L9UI\nJJn4ccpu9kHeHkpH2tvbuyP2SqVSCZNMXJBuIu6GZ5d0/PhxWK1WBINBYXIprKf4fWBgAC6XC5ub\nm+jo6BDcyWq1IjMzE+3t7YKzulwufPzjH0dZWZkk3yiXrTELID09HZOTk0I4zc7Ooq6uDtPT07Ba\nrfIzEYMNh8NoampCIBCAzWZDNBqFw+GQk5Ke+rS0NClqtAfS+llQUCDyHYPBgFQqJTFiLNZKIq2k\npAThcBh5eXnS9WZkZMjnIKje3d2NyspKlJWVwWazoa+vDyqVSla1AMDAwAC+8IUv4MyZM3jppZdw\n+/ZtyUjdu3evOJEqKirQ0dEh4RuTk5PQaDSIRCJ48sknBfdkJB2XjFGGw0QlEhFMIWL3yBG8v78f\nzc3NMJvNsvKCvnCSeqWlpQgGg9i3bx/+7d/+DV/4whdw69YtHDx4EDMzM4LJEWvjCMgClZWVtSN4\nhQv8+LAxrSkzMxNWq1UeQMIADLbh1oGxsTHpfNjdbmxsSPfl9XqxvLyMGzduQK/XIxQKCYFIRQGv\nz+zsrBS3nJwcSVaiVIwwC6PwmNdAhQE7Q3ba7Mqpp6X0jlg8Y/boVCNEkUqlMDk5iQsXLqCjo0P+\nf2NjA/39/QgGg7Db7RJWPjg4KM1MIBBAXl6eXA9OIYQHaOXOyMiQ+sCCz8mBxY7PivLP/DjKvehQ\n4ufiwcCPW19fF0ychZjXhnjpJz/5yQeqaWkppRjr/6O3n/3sZzvad7/fD7fbLbpDyjl++9vfSsIS\nLyJPGZ1OJzpLg8EgkhedTofGxka89tprIk1ihqJer0djY6MIkqnpbG9vh8FggN/vRygUEkeGxWKB\n2+1Gfn6+hIrcvHkToVAIJSUlKCgowMDAAFpaWsST/qlPfUqS8tll0NNMexwJJuWISZcPAHg8HnR2\ndsrPTq1dVlaW7JeiWqGoqAher1eCIijPYrEeHx8X2YzRaJQiRoH8q6++is985jOiQPjpT3+KoqIi\nPPvss0gkEnA6nRgdHUVdXR2uX78uBdHr9WJoaAhf+9rX8LOf/Qx79+6VxXyJRAJFRUUSghwIBCQH\ndWtrCxUVFUilUojH47DZbNKBUCNMmRmJCgY2b2xsiGj71VdfhUqlgs/nkwCShYUFkV4RCqmpqcHU\n1BQOHjyIr3/966iurkY8Hpd7g7ZHdqTsVhn8QvKPrDklTnNzc8jMzMTx48dlZB0aGkJVVRUGBgbE\naky7Kgssl8S53W7BGv1+P0ZGRqTo8b4gi02yj90S8TtCR7yfWKC5SWD//v1IT9/eU09nEyEBPnu0\ncDLAg9dFrVYLGcNiyz+XlZWhsLAQOp1Olutx+VxaWpo4lywWiyhfhoeHBd/v6+sT2y07+vu7SOBe\nAAkbDkIaLKz3i++VFk/gnuVT6dHnYaLMf+DPz2dUCZu8/fbbD1TTHlqws5IZZUG0Wq1IpVKYmprC\ne++9BwAidmfqPHWny8vLmJmZQTQaRSAQkI6TEiKO4ywoxMHC4TDq6urEJ87dRQsLC6Kx4xjGcSkj\nIwM3b95ERUWFsPl0uAwPD0uHYrPZhJXt7e2Fy+VCKBSSdc203o2NjcFut0OtViMej0vc2MTEhDDu\nfFCoBAiHwygoKMDQ0BAqKiowNTW1Y/0tAPk5lf5ok8kkASNkQ5mR2dTUBIvFgtdffx3d3d3Iz8/H\n2bNnceTIEel62KH5fD5897vflW65vLwcL7zwAk6fPo2CggJ4PB6RsBBzpYrC5/OJY41dAh+0jY0N\nRCIRbG5uoqamBoFAQFKUKIinzlSj0WB6ehpnzpzB3r175cDhOhnip2q1Gi6XC1evXoXD4YBWu73M\n7YUXXsD3v/99cR+xG6HDjQxyWVmZ2Dh5L5nNZjgcDoEdmD7GMJCZmRlZlsYCxLBypfmDHROhglAo\nhMnJSdH/8mfn/cmRk50a14qzW+cIfOzYMfneKKnq7e3FjRs3JECGRCwAmYw2Nzelc6VmWq2+t1aa\nUkMlGcNDmFMJF8b19PSI7IscRigUQjAYFPiHuCZdeCqVSr4mP7dSJE9FgtLiqcRSGeLMYssCy+us\nfF9eR/Ixyj1N7H6V75OZmYmPf/zjD1TTHkoh7e/vlwd+bGwMzc3NsrxrdXUVv/zlLxEOhwWvI4aj\n9P9yNGDww8LCAvx+v4T0MkuRNxA7lqKiIiEJgO1WnpsXA4EAcnJy4HK5EI/HRTbDqDiz2Qyn04nB\nwUHBLKenpyWAZX5+XjScpaWlmJ6elgAVq9Uqazk41tvtdkxNTcHhcIi8ZnJyUpKmlpaWkJGRIUlA\nZE1zcnIQj8fhdDoFFuGuI1pMGY6bTCYxNDSE5uZm+VnZuarV28vKrl+/jhdffBF6vR6HDx8WZcTk\n5KSEmnAN9sbGBg4fPoxEIoG1tTW5Zo2NjTtgmnA4LFI0bh6orKxEZmYm3nzzTdliqtPpsHv3buh0\nOglRpvPH7XYLCWS328WoUFZWBp1Oh7Nnz+Kll16CRqOB1+uVTmZlZQV3797Fvn378M4772D37t1I\nJBJIpVL44z/+Y7z++uuSv0k5EGUzlGjxAed++/Lychw8eBDZ2dmyySEcDktyvhIqoPqE33MqlRJ5\nVCQSgclkQjQahd1uFw0xQ0eoSqDLhsWe+K4yDJoaUK7PoTRrfX0dk5OTQupwxY1y+R6/Btc4MyqS\nnRhHYSpPtFotioqK4Ha74ff7kZaWJoQhpzd23txjxtePCouxsTHJ6mXgCDvuWCyGeDwuuDhJP37P\nvC8I6yiT9glR8N/YRChrBw8Fqi34eQDsEPUD95YhpqWl/X4XUq/XKz7qffv2QaVSIRwOQ6fTYWxs\nDI899hhu3bolHUJWVpacUrypSFLxz+zKlpeXZTEa33dzc1PgA4fDIZtEGW5cXl4uO7r1er24hGi9\nc7vdmJ6ehslkwujoqNgoWVR8Ph8KCwsxMTEh2jZ2G1y2BkCWtNGxQw1rKpUSvzF3HvGBYBAICYBU\nKiUWWY5V1ObNzMzAZrNhfHwcZrNZHhoWWq12O4mdsXkHDx5ESUmJEAOpVAq7du2CXq/H3/3d30mQ\nNNntzc1NPPHEE0ilUnC73YJLVldXixVwcHAQfX19IrAvLS2FRqPBoUOH8PbbbyOZTOKJJ57AhQsX\nZPHh+Pi45GeqVCrBxTs6OlBeXo7CwkJJyOcWTS4k9Pv9WFhYwJ/8yZ9geHhYiA6TyYTp6Wk8++yz\nuHjxIiorKxGLxZCXl4eWlhacPn1aRmF232tra7Db7XC73ZL0RSLk0UcfFZaamGR+fj6Gh4dlMiCM\nNPG79S15eXmYnZ2FTqeT/M3MzEwhohiMQl3x5uam+NyVonNCDnQ4UZLF15+4HuVOdGbxMFMWHGpG\neTgriRxKjhiAzUbFbDbLdAJsOxMpOVxdXYXBYJBOl1pXrVaLYDC4432I6zJ4hJGXTNuiaoD2Z8rf\n1tfXRUUQj8fl40k0B4NBTE9PIxqNwu/3IxwOIxqNyv+FQiF5/2g0KlZt/uJEwqAfKg5isdjvt460\no6MDOp1OBN7p6ekwm824du2ahBkfPXoUPp8Ps7OzcqLzlFTKOpRAslIbtry8jJWVlR16Uso3uImQ\nQmASSrdv30ZBQYGMcvPz80hLS5PxhsEi/f39qK+vF1KFm0Knp6dlB4zP50N+fj6mp6extLQEz+/W\nSFCaxDUj/PmpkRwaGkJpaSkSicSOZXLszsvLyzEyMgKXy4WZmRksLCwgIyNDvM/E0vhw0vNcXFws\ngR3sRLnQz2w2o7S0FA6HAyqVCpcvX8atW7cAbOO10WgUTqcTLS0tGBwcxNLSEux2O9bW1nD9+nVU\nVlbixo0b+PDDD0X/SEa9s7MTDQ0NuH79unTfZIdJ7PX29kKj0eDJJ5/cMW4vLi7Ka8WRkHKVXbt2\nyX4qh8OBmzdvYv/+/Th8+DBu374tuLrX60VJSYkcNKlUCq2trQC2CTXKeeiU27t3L1ZXV2G1WmXt\n8IkTJ2A0GqXobW3d21UVi8UkG5XFqbS0FEVFRbJvisWFtsnFxUXB8dbW1hCLxWAwGFBQUCC4cDQa\nFbadH8MV5MTwlCHc7DjpsiPmzCxRYoAAhGxRSoyo3yRsZjKZUFdXJ7g9Q5+NRqN8vNFolGtE1Qxl\nb3wec3JyYLFY4Pf7ce7cOSwtLUkXzWKttHOyU2SKP4s/v29lDeDPyS6UhBrXySh/JZNJgQOVhZIN\nHbNd+RzNzs5iYWHh99trf+PGDdkbDmyDyjdv3oTdbscbb7yB6elpkeQ0NzdjeHhYAoxZeADswEIo\n+AUgNkRKQ7a2tuBwOKDR3NuGmZ+fj4mJCZHimM1mhEIhhEIhWZXMgA2LxYJEIoGJiQnU1tZicnIS\nW1tbKCwsFJ9xbm4u1tbWxKF15coV5ObminWTa2xZZBl7x8R+jUYjMhwuaOPYaDKZMDExAY/HIzc/\n033oEMvIyEAymRTMlGwnH4B4PA4AMnrT755MJsWmOTMzg+7ubly6dAldXV148cUXsbq6itbWVtlJ\nvmfPHjidTpGvHDp0CGlpaejp6RGdbn5+PgKBAEZHR3Hy5EksLCwgJycHnZ2d2L9/P+bn5+F0OrGy\nsgKbzQav14tnn30W169fl0OVOCCXthEyiUQimJiYENnX+Pg41tfXRXXh9Xrxh3/4hxgcHITBYJAH\nhPrG/v5+dHZ24s/+7M/Q3d0txUlZjPbs2QODwYBoNIrm5mZZDc7Cz/swIyND9LHU3fKQItavVqvl\nd64JJhdAe3F2djZ2794tHvZwOCywDM0cDJSm/pN44Pz8PBoaGmSTAScVAJIqTzkbixK7R3aLxDm5\nkrumpgYzMzOSfuZwOMT9l0pth5xTAUFRv9VqRUZGBqxWK4aGhnDjxg2MjY0hmUzi1q1bsrmC0xdV\nANSs8uBkA0RXEztuQjAAJCVreXlZME0lEc2Cyr+z4yYEwL8rffvEUgFIh5xKpfClL33pgWraQymk\nQ0NDwl7zRX777bfR3d2Njo4ORKNR3LlzB1VVVdDr9bKcjbglO1Jld8pOjOMAwWOC3HShzM3NweFw\nCAsbi8Xg9XolM/T8+fNCJjDCjWHO1Hg2Nzejra1NWG2v1ytYLNclaDQaCV4geeH1euF2u5GdnY1w\nOCwYDX+m27dvy+4fHgQsKltb9zZp8kUn00wtIkclBl5kZWXtcKZwTC8oKMD3vvc9Wcp2/PhxwRhT\nqRRmZmZQXFwMj8cDvV6PtrY22YGen5+PgYEBWK1WbG1tianh7t27EvCRSCTEAEB7YGZmJnbv3i0H\nTl5eHmw2GyoqKhAOh4VMmp+fFwlQIpGAx+MRDS5XoXh+F+xNYqikpEQ0qfn5+VIA+Roy1s1gMKCu\nrg7RaBTDw8P4yle+gosXL0Kj0aC4uFiWy3Gy4J52xgAyGYiifJVKBb/fL35+upSUa615LZeXl+Xn\nq6mpkX3tdrtdTB7ET5X5oSRkGHTCgHPqaTMzMxGJRDA0NCQuvYWFBdHjciohO65UJ5BrcDqdKCkp\nwdLSEsbGxhAMBqXgMsYxFothdHRUcOiNje212alUCk6nc8eGVZfLJZPFxMQEpqamEAqFJKdAmSeq\nJJf+T9mgwD3WnV0/u1Z2n5wE+L5KUT+AHR2vMg1Kyc6zjgD3gk0A/H4XUu5yWVlZQU5ODr7yla8g\nNzdXvMhpaWlobW3FK6+8gpaWFmg0GjQ2NsLn8yEajcJgMEhXylafNzoLjUqlEmZQqZfjRVpbW8P4\n+DjKysowODiI9fV1FBYWCoBusVjEP88tlXfu3EFhYSF+85vf4PHHH0coFMLa2hqKioowPDyMkpIS\nidMLh8Oy+5sSEwAYHh5GZWWlWPFyc3PFbEAnCTWVlD+RsV9bW5MxmwWM+3RGR0dRUVGBUCgkDg1G\n2QEQxQJxxvX1dbS2tmJ2dhYGgwHt7e0oKCjAjRs3kEwm8cgjj+D111/H+fPnUVVVhY2NDRQVFWF9\nfV3sipcvX0ZzczPa29vR3NwMtVqN/v5+7N27F21tbejs7ER3dzeOHz8ucAZZdpJ9N2/ehE6nw+HD\nh5GVlYWSkhIYjUZxuA0NDQnZZTabkZ6ejsrKStTX18NkMmFwcBB37tzB2NgYdu/eLXg6O5hnnnkG\nXq8Xdrsd09PTCAaDOHDgAKLRKC5duoSXX34Z7777LrRaLerr67G1tYWPfOQjiEajqK6uls/HB4/3\nFjtyjUYja0pYhFi42VHzum5sbMDhcMj2VW6QtdvtYqBg5sLbb78NrVYri+NsNpt0pVxVTdcVeQJK\nxLjDizF5ytwAYu1msxkHDhyAwWDA8PCwHNa0w1L0zzFcr9ejtLQUWq0WS0tLyMnJQUFBgUxQbFqI\nEVdUVIj8zOPxSLI+rc73S5vuzxK9X5bEN+VrwI9XbkZg0eTHkqxVxhHSHgtAeBdeF37+/18U0kgk\nItjMr3/9a7moHD/r6+tx8eJF6PV6nD17VlKZdu/ejfX1dXR3d0sx5cmj9JnzxWcnxl1HxEx5kYgx\n1tXV4fbt2wIJAJDgES4qY5HPycnB3bt3cenSJXzsYx9DPB7H5uamiNzT0rb3z5SXl2Nzc3sbJjNF\nKYeh40elUokCwGQyIRaLSdjJuXPnUFhYKPhwOBxGLBaTLFSOJ0xWGh0dldBn6g95w/l8PiwuLsLn\n88FqtYpygfbOM2fOoLGxUfZnZWZm4s6dO9Dr9fD8zqb69NNP4/z583C73QCAnp4ewQIZgLG5uSkC\n/bfeegu7d+/G+Pg49u/fD6fTiUQiIcy93W6Xg5EZsABw9epV6QLtdjtaWlpQX1+PtLQ0SelaXl7G\n1NQURkdH5XDJy8vD5OQkenp6MDc3h7q6OqysrGBiYgI5OTk4duwYLl26hMrKSrz99tt47LHHAACd\nnZ342te+JnDPI488Ao1GA5vNJhpXADIN0D0UiUSgVqvh9XrFnUUpEuUzLpdLJEIZGRmYnp6WoBm7\n3S5ZolR/6PX6HXGJ6+vr4npiNgOlRsp1IPz6zGRgt8cRl6ljGo0GVVVVKC0tlS0TFNkrLbGEz0ii\nMfiFMJDS406HGjMGZmZmsLy8jJs3byKRSGBlZQWjo6M7GHgAokCgHVOJfyrHbE5SfOP3ynxSZd4A\nnwkAMl0xu4AFm/+uLNrkW5S+e2C7M/29jtGjG2JkZATJZBJbW9vp4TMzM2hoaMDAwIAwhFrtdljw\njRs3sGvXLlRUVECv16O7u1t0XxzllS8CLxzZQL4fPcd0cTCAmR2i2+0W3I0e3czMTHi9XjQ2Nkon\nbbFYcPv2bezatQvxeBwOhwPt7e2w2+0iE8rNzYXH48HExIRY8EwmkxwEIyMjKCgoEKbfbDbL+MSY\nM7KbXM9sNpsBbONfTqdTfN9er1c6Fmr4srKyMDY2JnFy9Kaz+3E6nQgGg1hfXxcSoL+/Xwq1wWDA\n7du38dxzz2FsbAxer1dIl1AohKNHj6K9vV0cW9nZ2Whra0NOTg7Ky8uRlZWFp59+WrCx9PR0RCIR\nuZ6/+c1v8JnPfEa6A7PZLK8LO+9z584hFAqhs7MTjz32GI4ePYqysjKkpaXJXi7iapRJabVajI6O\nYmhoCA6HA263Gz6fDwcPHsTw8DBOnTqFt99+G08//TT279+Pu3fv4sUXXxRfNgOF2akwD4EPGzFX\n3n9MMmKnk52dLfgjtc7Ly8tSOIF7oySleBy5GRLDFeHMygTaKdoAACAASURBVOXERYiALDwLGDsu\ndnAspJR2ffrTn4ZarUZPT48QWZxa+MbCQ9yeWtiioiJJyiouLhatamZmphRCxvSxIBuNRmxuboq8\nikWO9zoPDXanvGYmk0k02TTG8Bnm9SK5pAwqAbBDfaAsrHyelFF7ymKprA/Kz/d7X0gnJiYQjUbx\nwQcf4MKFC0ilUjh8+LBgkQwDpieYASHDw8Mwm82oqqoS/aPFYtkxCgCQC87TlacOb04uiGPHRRlS\nX18fampqsLi4iPX1dWHgHQ4HYrEYXnnlFaytraGqqkow1vHxcdTV1cnDxMT8yclJ9Pf3w2Aw4MiR\nI1hfX8e7774Lq9WKhoYG9PT0YNeuXbhw4YJoDomz9vT0wGazieOJ3zulXdQUTk9Pi4d9aGgIRqNR\nJDwsWBx76NRZWVlBfn6+APyhUAjXr1+HyWSC2+2WxKm5uTlcuHABx44dw9jYmAi06+vrUVxcLGRc\nJBKBx+NBRkYGOjs74XA4JHE+IyNDSLZwOCxReu3t7dja2sLTTz8tOCGLu9FoxJ07d6DVauH1epGb\nmwur1YrKykokEgkMDw+ju7tbQquffPJJ7N27F3q9HmNjYxgdHcXIyIiMkJOTk5iYmEBaWhoKCwtR\nUVEhwRXEGDlJ2O12wbc55nHE5YNIiGFra0twQb5GHP+p82UW7fz8PCorK1FUVIRYLCYQEslH2qIN\nBgOmpqZQWFgIv98vMNeJEyewsbEhXenS0pIkQXHKUhZOZuvW1NTgyJEjGB8fx9WrV0XHTHacfzYa\njaipqUF9fT1cLpfcw+w6yYwT3+T0sb6+jlgshp6eHpHzkQDS6/WIxWI7ZFccudnkUInBQsyDjFAY\nO0Uy/3l5eYIpc/U0i7+yMPJQI+apTINSTqQApEYonZbK33+vCymzRA8cOCDe+dOnT8Pn84k8hzcE\nMcba2lo88cQTQr5MTk5KgC/1abz4ylgt/pnWMl40erQZisCONhaLoampCe3t7SgsLJQbicC5SqXC\nrVu3MDMzg5WVFRl9ge3kc4q0y8rKJBi3ra0NKysraGlpQVdXl5AofKhu3LghIRy0AN66dUuKRU9P\nj5BKlD/R2+1yuUSwfPnyZRw4cAAqlQpTU1MCI1itVtGPsgCmUilcu3YNBw8eRFdXF/bt2yej2Ozs\nLHbt2oWqqipEo1EcO3YMQ0NDWFlZEfH2pUuXUFZWJhhfe3s7TCaThGw3NDTg3//938VBEggE0NTU\nhLNnz+Lu3bvYv38/zp49i5KSEmi1WvFlO51OtLW1iROLXn12LwzeLSkpgUqlkjDkwcFB1NbW4uMf\n/ziampowPT2NQCCAgYEBsflyXW9paSn27duHra0tEc8zvJlMLqP0+ECx82O8HFcgszti58XsVDLs\nxcXFIsVi/kMqlZKto7Qp8/MHg0E4HA7ZxXT79m0kEgkhfqi0UKlUolQhFrqwsIDNzU2cOnUK1dXV\nuHr1KkZHR2WbKouZxWJBU1MTiouLodFoZGQngaXEg8lg85nhHvpIJCIET319vcQGUkpGOZ/SpaTE\nOllU+T0pcU1CKJxyOKUo3UxmsxkFBQUoKytDc3MzqqqqRPLH4srnQjna82tvbW0JQa2UUykLMoDf\n70La3d0tIa6URZw6dQqlpaXo6uoSwffzzz+PI0eOIDMzE+Pj4xgZGcHIyAj6+vpw8uRJ2O12HDhw\nABcvXtwRPsCLp2zxKWzmaUl2mxeUo3h/f7+4Z3hykwEvKyuDy+XC8vIy/H4/0tPT0dHRgZGREYRC\nIdTX18PpdGJ9fV2Evz6fT8azzs5OYTunpqZknCARQ+VAV1cX6uvr4ff7YbPZ5KHs6+sTaylXNrtc\nLvEs09RAMTpdJmTrBwYGxHJpMBhw+vRpHDx4EHq9HjMzM4hEIigsLMSlS5cQDodx+fJlzM7Owmaz\nweVywePxIBKJoKamBp2dnSgoKBBRPAOc7XY7KisrcfnyZQDbaf3xeBwNDQ1YWVlBe3s7Pvaxj8Hv\n96O0tBQFBQWSFVBaWopAIIDx8XH4fD643W7Mz8/j9ddfF4gnOzsbJSUlonu02Wyoq6tDS0sLotEo\nvF4vOjo6UFRUhM9//vN46qmn8N5774l7rbW1FVNTU1hdXYXb7UZubq4cXgCEoCTcwHuAchvlGE0h\nN4OOqU5QjpGJRELcSnRP8XMzWIQpZjqdTpLlu7u7MT4+Lq9fKpUS4TsjIlmIKMj/h3/4BzmYlXKi\njY0NVFRUYM+ePSLNWlhYkFxbrkK3Wq1YXl6WtSI8YCiI59/ZmZMUValUKC0tFbmez+eTOEiSvMpi\npQwOYXFlcVP+P3825TPMa8xwFcr+5ubmYDQa4XK50NjYKMVVp9PJShXg3opmJdGldKXx0OD39aCF\n9KGElrz88svIy8uD1+uVk9hut6OkpEQ0im+++aYsoeMPyFOtoaFB1iJzpPvggw9kRGRRVfptAcj4\nwy6VjgdmPhITPX/+PE6cOCFmAKfTiczMTAwMDEiSlEazndhPXSDZcEo7GBBBGUkwGJQRkDhNbW2t\nBG1QDL+wsABgO7O1oaEB4XBYHqaxsTFYrVbs2bMH77zzDmpqanDq1Clsbm5idHRUdstzxLNYLDKK\n9vX1wePxSKyb1WpFJBKRa/Lmm2+iqKgIBw8eRFtbm4RopFIpHDp0SIKkg8Gg+PdPnjwpO6pGRkZQ\nU1OD9vZ2uN1u6PV6nD59Gs8884xksp47dw4HDhzAyy+/jPT0dHz3u99FV1cXfD4fTp48CYvFglAo\nhEAgINpR7rAiHsj0oFRqO4XIZrOhrKxMrLwkIUjAEFt+6qmnJGC6trZ2R1Fi4WQnQ/0isUalBpFM\nMIXeJELIjgOQ+47EDwteenq6sOwAdhTrhYUFUQgQ0iKuHAgEZAsAV3mwuJtMJnz5y1/Ga6+9htu3\nb8NgMMjBW19fL695JBKR8VmpdHG5XAAguQjEeJXJ9RqNRu4puqcI9Si7P61Wu2OzaFpa2g6tJosj\nn0dllwjcY+SV+CY7VeX/8/qSkOLrwtdrcXFRiLbs7Gzk5ORIbsLQ0BDC4bAE1zDXVPmmPEh5vf+f\n3h5KIf3xj3+MUCiE7u5ulJeXo6mpCadPn8bi4iLKysok3Tw9PR2vvvoq+vv7RftZWFgIl8uF9fV1\n2O12RKNRdHV1YW5uDgsLC1JM6Q8mO84blL8AiNOBouisrCxYLBYkk0n4/X7s27cPw8PDYulUqVR4\n//33RajMSDuOTZSj8EFnDmgymcTnPvc5/OQnPxE7JoXD3L20ubkJk8mE/Px8lJSUYHR0VDpEumnI\nxtPG2NnZiYMHD8JqtWJgYADZ2dmoq6vD0NCQaBPT0tLg9/sxNjaGp556Soik+fl5WZOytLSE4eFh\nhMNh7NmzB6lUCq+99proWDUaDU6cOIHOzk584hOfgM/nQ11dHdra2rCwsIDGxkZcu3YNH/3oR9HT\n04MPP/wQX/jCF6SrfOedd2AymYQ4eOWVV/DSSy8JafPOO+/gxRdflG0D7LadTqdoXYlXshskPEHt\nJF9j+qSV2kI+9Pw/wjvsdpQRawBEOqcM0+CBD0Ass+yqGKzMDkvZXQH3MHsWPzLyarVaHF4AZNUJ\nH+x4PI75+XnxzXMLK/e9r62tYXJyEm+88YZkB1gsFuzduxcTExPo7e2FXq8XsTyX3qWlpYntk9ME\nhfYZGRliCGAYDH9+Fl8eJBzd+fPz+yb/wANJqQ1Vvk5KcwCws5AC9/ZdsYlisSZpBUD+Dtw7mABI\nwWYmB5835idwS8XExIRoqBkUxO+XJO6DvD2UQvov//IvwlReuXIFvb29cmpTQuJ2u1FVVQW32y3O\np5WVFZSVlWF9fV385wMDAzCZTLhy5QqSySQcDocktXOfi1qtls6UL4oyi9Dn8yEWi8mYQzIglUpJ\nrmR+fj7UajXGx8dx7do1WbWgHD2Il6nValRXV0ve5NbWFj7zmc/gjTfekPQjpgvxoWNWKkXbPAwS\niQSAbaum2+2WJXOrq6s4duyYML1cpVJcXCwjV3FxsSSInz9/HoWFhVhaWsLt27dRX1+P0tJSXLp0\nCTqdDv39/di9ezcWFxdhs9lw584ddHR0oKSkBJubmzh48CDi8TjMZjMqKyuxurqKu3fvQqfToaKi\nApOTkzKikoDi5wEgN2VDQ4PoKBcXFyU5nrgbxzQ6u9LS0iQMg/Zadl2UzHCMVqYJsZvjWK1SqSR/\ngDg6ALk3eLjxdVQWRCVRwW5XCRXxZyFBSRkQCz87PH4M19BotVrB6VkYCCFwUiA2uLm5KWtzVCqV\nxNDxAGYq14ULF2SLKENq6KDjWJ+fn4/FxUVMTU3JqGw2mwWjLygokM0GzGNVFjw+Qyw4jEFU4otK\nCRM7ReAes843Ftb73+4/jJT/riSR+XXYKLGOsIgC98Z54F7eKO2nxLW55nx0dFR03ZmZmRgbG3ug\nmvZQMNI333wTnZ2dmPjdpsOnnnoKBoMB4+Pj8uAzcIDhsuXl5aivr8fU1JTEjjFliLhqXl4eotGo\nFCk+WEqJB09f4B4Www6BEWbcD+/z+SQWjlFv/Bj6momz0g9Pqcjw8LCkrNMtVFNTI6n6FotFXqyG\nhgax6a2srIiVkBs7rVarvLi9vb3Y3Nxe3DcyMiJZnXfv3pWHnweIRqOB3+/H3NycCLqzs7OxuLiI\nqqoqsVEyVLe0tFR81slkUqRQjz/+ON544w0888wzsNvt+O1vf4u6ujoAEFkaV11zpOduJkYSms1m\nlJeXIxAI4O7duxgYGIDf78ePfvQjqNVqNDc3Y2trC263W+L0TCYT9u7dK9mnXBTX1taGQ4cOyXVh\n3uvGxgZisRhUKpVsSiBeHQgEhCBkbsP9v6gjTktLkzxTSoCUoTGJREKw+tHRUVlnTbnZ5uamYNsO\nhwNWq1UmrYKCApSXl8PtdsNgMGBtbW2HEYTQFF144+PjCIfDQuKxaLGDqq2tlZhAACgqKkIymZT7\nuqCgAJWVlcILANudLrFbSo+o8aQPnUsmuXGUDQJwz9/+fyc9UnZ0ShE8pUZKF5OS11C+n1KqxI6e\nB979kIBS8shiej/WqSzgzOblIbW8vCwRh1VVVWhpaUFVVRVWV1fx4osvPlBNeygd6Z//+Z/LPmtq\nuMLhMF588UUhVJxOp4wiW1tbuHLlClQqlYTldnd3o729XZZmcfRn1uTq6qoklysZP+WLrexgVldX\nEYlEZDS3WCyS3FNcXIzx8XE56chuswP0er3iQvF4PMjMzIRKpZKNiNwSyXULjMcrLCxEMBiERqMR\nZpaZlNQnkhVnLiv1ejMzM0hPT4fVakV5eTlqa2uRlZUlP6NyX9XMzIz8XlZWhlgsJjkHTM3hQUBc\nMxqNoqenB+np6WhoaMDi4qLEqE1OTqKiogKLi4u4e/cuHn30UckVVavVgm/SYPDhhx9iYWEBNTU1\nOHbsmARDX7hwAbm5udi3bx8OHDggq5L7+vpw/PhxJBIJDA4Owm63Y2BgAOXl5dDr9WKd5HYCs9ks\nMqp4PC5BLsyxtVgsqKiokJUYPp8PTz/9NA4dOiQ4Gt84gpNk5NjK0GWlK4+edrPZDIvFIgWGW04Z\nn0iZU3p6uqyqZgpTenq6bLxVqVSIRqMirevv75dA76ysLHR3d4tka9euXYhEIpLREAqFBNMmFEUN\nJTWs3EnFffH8ftfX10VkzxGaeCgLIeEQpbNIKWeibpbwCe89FsH7iSR+XpYfFmklfkpYAMCOj1e6\nlAAIpMBnma+dkmAiacivza+rFOATMwcg0MWPf/zjB6ppD6WQ/vVf/zWmp6dl7KV1jR0EH+q8vDwc\nOXIEZrNZHoKVlRUZwZk2A9wjkngR2erzlCVLRymT8oUg+zc7O4toNCouEeKgbrcbGRkZiMViMlLR\njpeXlyejnl6vF7dOZmYmSkpKYLPZ4Ha7kUwmcfHiRUl3ooWxvLwcW1tbmJ6eRlFREXJzcwWD3djY\nkPXNbrdbSIjJyUlsbGzA7/dDo9HI0r/Z2Vmxh6rVatTW1orAnIWYxBrxtKtXr6K+vh59fX3Izc2F\n3+/HxMQE8vPzkZ6ejq6uLmg0GnzqU5/C2NiYaFVLSkqwuLgInU4Hj8eDpaUlhMNheVh37dola4dH\nRkYwNDSE9PR0VFdXy+ju8/kwMTGBoqIiidOzWCx45JFH4Pf7kZeXh1RqO7uS5KFGo8H169dx+PBh\nDA4OIhqNorCwUPbWM8GfRXR2dhZpaWlSlFpbWyXPlK8RE5JICGVkZEhANB9oYqTEbPv7+6UrW15e\nhk6nk3SxmZkZsWQyW4ACf1p/KV8aHR0Vyy4LNgsgu8REIiGTTHp6Oq5fv460tDQJlabWOjs7Wwp8\nenq6LJhkdgGLCTWuShKX0ineX+yKlW/KJoRhOErTy+bmpnTtSuUCgB2jN4D/1X2mfucq4hs/L/9d\n2VmyO+bXUDZGyjdisEqmnr/4NZQCfboi+fNsbGzgu9/97gPVtIdSSD/72c8Ku61WqyUYWeki4b72\nvLw88e1qNBrZVU0MRHkhGRgRDAbh9/tlVOaFZIHhTcYdRnSVANtjD9lLPmBzc3MoLS0VzGRlZUWW\n8zU1NQlLT7xqdnZW7Hrz8/Pivy4qKkJNTY10yLOzswgEAkIUZGRkIBAIID8/HwCE0R8YGJDvieQZ\nx0eSZCsrKwgGg0IE6HQ6uN1uTExMwOVy4cKFCzhx4oTgQXfu3IHb7UZaWppInCYnJyUku6ysTJj8\nixcv4qtf/aqkwJeWlsJgMGB2dhbvv/++bNL8xS9+gdLSUsHgmpqa8Ld/+7eorKyE1WrF+++/j89/\n/vOSCLRv3z7E43EcPXpUit7AwABqamrEHWY0GpGfn4/Ozk6oVCpUV1dDrVZLIApHeL1eL681iQ+T\nyYSBgQHx9RPPZOdUWVkpCgO6fPhwkqXnQ0YsMx6P4+7duzKheDweeDwewTXZFbFLnp2dhdvtRmFh\noUwCFOFT8UB2n+J9ZYFm4Pfq6irGx8fh9/sl5QnYZu+npqZkvfHq6ipyc3MxOjoqE53b7YbRaEQw\nGBRCld22Uhyv0WikiSAxxjXY3FXFUHKSlGxMsrOzRZHAa8jPz8aF/w78bxxVKVcE7nWoypFfp9OJ\nzpV/Jn7MYstCrWTelRgpJVVKYouGCL4pv5d//ud/fqCa9lAK6fPPPy8AOMeWmpoazM3NYXl5GWNj\nY4jFYqivr99BFhUUFMhucp6kJGe8Xi96e3vh9/vlIim7FHZSDHXNyMgQQoPuGYfDgXA4LFgaCyOl\nTFx2F4vF0NjYKGJ7jpX3p+soxcBbW9trQ7jUb3l5GRUVFfD5fEKgcKxjwWKHMTQ0JNeBD0Bubq6E\nTOTk5MhYTSeISqUSfSPZSIZbLy0tQa/Xo7q6WlKxKCifnJwUGQtXQvMQi0Qi+PDDD1FXVwej0YhA\nIID6+nrcuHEDdXV1GB4eBgDk5eXB7Xbj2rVruH79OmpqagBswxFarRbRaBQHDhwQx0pfXx8++OAD\nPPLII6isrEQqlZKEf04aGRkZePPNN3Hs2DEhcrgrKDs7WzBndua09lLLaDKZ0N/fL4VCr9ejpaVF\nDmDio0pmmA4bdoXnz59HZ2cnpqamkJOTg7y8POTk5KC+vh6dnZ1YX1+H0+nc0TnX1tZCp9OhtLRU\nZGycIhgNScnO2tqa/DuzITiZMD+TCw/X19cxOjoq0Y8qlQpGoxG5ubkoKCgQNYNyzYfdbpfQc0IV\nXPnMewSAwAPs/LjAb3Z2FsPDwxKMQk024SiuGWGDQ3eYsqNUFi8lvKZk89kYKd+fz5GyWFInzW6b\nn5cZBHw/ZeEke6/8fu7/3pSuqActpA9lHTNPF+5VysrKwuLiIoxGI2KxGIqLi1FSUgKDwSC7qF0u\nl7TbLExra2vwer1oa2vD6uqqxLJxbCZmuLS0hGAwCJVKBZvNJunzCwsL0oEyHZsied5sTMpfWlpC\nIBBAWVkZioqKhOnPyspCUVGR6AWpn+MLwgeHTi0SQQwD3tjYEIyVbDa1fny4maVJqRSLGkOZAYjP\nnF+fXys9PV3GR4PBgN7eXrjdbqjVapw/fx4WiwVa7fYKaS7Q49fPzc3FzZs3EQwGxedPYTi7l298\n4xt46aWXBOve2tqSSL2bN2+ioaFBUq5KS0tx5swZyRUNBoN44oknUFBQAJvNhu9///v46U9/iunp\nadG9LiwsYM+ePYjFYnjhhRcQDAbhcrnk3piensbi4qIcGgwqocOI8AKv0erqKlpaWmCxWDA0NIRY\nLIbW1tYdCgqO+HwAFxcX8cEHH6C9vV1COxgeEovFBPvmiue8vDz853/+J44fP47h4WE8+uijsqpm\nfn4eHo9HoALubuJzwNf5fryRZBE7YYPBgL1790rqElcdnzlzBp2dnaivrwewDVvx+/T7/cjNzZXp\niatpWPgI/fD+YSFnMVar1XA4HCguLpYdTcRbNRoNXC6XRB1SrrWysiJdprJg8vlQql6U47mykPIw\nu5+YYggzmyJl0WUzw8+hhA7YhPFNibkqu+T/N28PpSP9gz/4A8ki5epguikIytMpQq+7Uv/HOLw7\nd+6gt7cXAETOQDsenRTsLDjCT0xMYHV1VW5ahpWoVCoR5avVamGDNzY2RIq0a9cuSeShJY/6Ou4E\nohiYBZkxXtQLMkC6qKhIlo8dOXIE/f39O5LU2XkuLS3JiW8wGOBwOBAKhWCxWGSthFarRWlpKSKR\nCACgpqZGglXGx8eRmZmJeDwOg8EAg8GwIy+ztrZWfMskj7RaLWKxmLiWpqenUVdXh8zMTNhsNrnp\n5ufncefOHeTm5uLAgQPo6elBe3s7GhsbkUwmodfrEQwGkUqlUFhYiGQyKfih0WjE3r17EQgEkJmZ\niba2NrS2tsrK3mg0iqamJvT19WHfvn2itfV4PAiHw2I0SCaTssZ5amoKdrtdMLp4PI49e/bIgRiL\nxWQ8NxgMSCaTeOyxx+BwOGSHPEdqsueUFP385z+XXfYcBZU77jc2NsTZs7CwAJPJJGtQ0tPT8dxz\nz6G4uFh0wdSTqlQqEbRTakRSM5lMyj2wtbUlBNLg4CAGBgYQj8fFJsqQn1u3bsHj8aC0tFT01j6f\nD0NDQ7I2hYJ6RuexkFAWRoyWRYvPEw9pAKKSycnJQTgcxsjIiMi/rFarZCcwo1Rp2QSwQ9fLkZ/P\nuBI3ZVH7PyW93V9slez9/cw/O27lL2WUHr/u/YX+H//xHx+opj0U+dOvfvUrAdB5+nO8pgSEdjqO\neBxRCQS3tbVJDBi7NoPBAIvFIt5yYFvqQEE2vdUGgwHhcHjHC0G7H29IAEKGbW1t4eDBg5icnJQl\ndySbiKORIeToQDCf/uitre2U/v379+OJJ55AY2MjqqurZcUKw3/j8bhoEROJhCTF8wHn9RodHRUc\nb21tDZ2dnUgkEjh27BgCgYB8LC2jJA7IvNvtdhQWFmJlZQW9vb3o7u5GV1cXioqKJNjXbrdDp9PB\n6/ViampKDicSU11dXSgpKUEwGIRarZZuNhKJCP7K8ZjrQPbu3Yvp6WnMzs5KgAjXb8/OzkpaFTWz\nLS0tEg5NXJkKAYYph0IhzM/P48SJE4jFYhgaGkJDQwPS0tJw+vRplJSUiHh8ZmYGMzMzcLlcCAQC\nOHfuHG7fvo2mpiYhUFhUNjc3cfPmTZw7d07yFFik09PThRxdXl4W3DCZTEKn00lGJz9Xd3e37JkC\nsMPHz8mEnnmy2dSRsuuMxWLiveckEo/HJelLrVZjZGQEiUQCyWQS0WhUvvfS0lI0NDSgpKREimtW\nVhbsdjsWFxelK2Vh5/dIiIqwFfXZAGSH0vr6Ojwej6gq5ubmEAgEMD8/DwBygDPhiVIyYrCJRALR\naFSu58bGxg7GXfkcKX/nn/kxyiLJvxMKIBHGrpfdMA8Nvk73T5InT558oJr2UDrSqqoqVFZWwuv1\norW1VQJ7KbrOzMyEyWSC0WgU9lDpbmlra8Pg4KAAzsQdMzIyYDAYRP+3urqKUCiEmZkZOeU5gjIx\nKRAIyNoNvngcq3lCtbS0YGpqakcKuBLkVpJaZEYjkYicdDqdDna7HVVVVYhEIlhZWZHw6AMHDki0\nGjGmtLQ0gTrY7XBk0Wq1WFtbw5UrV/DrX/9aoAalJZWLyQKBAAoLC1FeXi7EGjviixcvIhAI4Pjx\n48JsB4NBaLVaOBwOdHR0ID09XRQGxEuZCbC5uYlIJAK9Xg+n04lkMomDBw/ihz/8IfR6veSSHj58\nGGtra/B4PDh//jzMZjOamppw+/Ztwa8NBgPu3LmDjY0NnDp1SlxtFIWz2BDrZOHhQrnFxUVh77e2\ntjAxMSFurePHjyMSiaCoqEgkRVVVVcLM0wqZkZGBuro6KXS8f770pS+htbUVly5dEjWJkrjgPciO\nhvgqO865uTmxldbW1qKkpARHjx6VYkS3EmMMGWJNuIuFmxkJXq8X09PT0t2R6AwGg7LIjYvmSMrO\nzs5KAUkkEpJAptVqMTw8jLW1NdEuq1QqITZZVHh4M6mJUxcnp/T0dJGCcaLjxoJkMom1tTXBqunc\nImlKqy0Tq2ZnZ4VwAyBwHiE9dvHEuZmDQSKZU6mSxNJoNHIocDUJiVu+VkpYgylx6enp+Pa3v/1A\nNe2hFNKjR48ilUpJ/BkAyXckm84xnyMy9Zc3btzAxYsX4XQ65f34QhsMBuk8CLZzgRxDFjjWECRf\nXV1Fe3u7wAU8uTY3NyXkYWBgQBZqsQsE7r1IvOloHqAsamVlRUgsq9UqBY5ayBs3bmBqagqPPPKI\nWDPZvTKqjS84JVY8YRlh95d/+Zew2WzIzMwUq6vVasUjjzyCqqoqIdZyc3MxODiIa9euydentVWj\n0cgeIYZwxGIxucl405eVlSEajUr3zwV6zKwcHBxEW1sbKioqUFhYiJ///Of4i7/4C+lS+vr6sGfP\nHqytrcFoNOLDDz/EsWPH5DBYWloCACk+ZN8Z9BGNjaKARwAAIABJREFURtHd3Y3Dhw/LGl+LxYLs\n7GxcvXpVJEahUAglJSXwer1iJ9XpdMjLy8OVK1eEWPP5fGhtbRU7rdPpFKH81tYWfvSjHyEYDCI/\nPx89PT2yVZSdJLB96NHfr1bvjNnjuM/vVaVSYf/+/Xj00Udl86vBYJBCwS6WeCVxUqo7uKqD7i+L\nxSKjaCKRwPT0NPr7+7GysoJdu3YhkUggOztb5HGcSpaWliSA2WAwYP/+/SIR48hNdpuwAoXwdDuR\nJN7aurfuWaVSCV7J+EY+38TP2UmyC+bzwOJFOG11dRWxWEwkiYQgaK5Revbv17ZSF8zsDDYhTqdT\neBPl2M8iz+5bCRP867/+6wPVtIcy2v/Hf/wH9uzZI+M6daF80c1ms+CSvDjsNK5evSovpDLYgReS\nxY14Dbs63qAMYmC3s7m5iZKSEmxsbIgEK5lM4ujRoyJHoiSIBZPFjrgOcdJkMimp6ryReAJvbGxI\nIAfT7qurq3Hs2DH4fD4A26wqi9vCwgJCoRDcbrfs6yHOw1HEZDLh1KlT+MUvfgGVSoWTJ0/iySef\nxEc/+lHJDGWa1OnTp8XxNTQ0BKfTCWD71DWZTAiHw4J7MWDZ7/fLDUd31/z8vOyE6ujoEE0k9aYc\n9QizpKWlweFwSJh1c3Mz9Ho96uvrcejQIWGHSfpRakM8+ObNm7I3nvvqCwsLMTQ0BKvVitHRUWg0\nGlgsFgQCAVmDfOvWLdTW1kKj2d55r9QJAhDpzM2bN2Gz2WRnExPhVSqVpE719/fvEH/zIFVOOTyU\n2flQSUDiMxwOIysrS/BXrjFhZ8drTWgIgFxLpYVVq9Wira0Ne/bswebmJq5du4atrS34fD6MjY1h\nfX1dgrXZ8fE+J5bM6cVsNsPhcGB4eBiXL1+GXq/H/v37kUqldqxCJ0mjTJsnCcfNtPwFQA4N8h0s\ngMSBKWljVCFJX96PnFIyMjLgdDpRXFyMoqIiABBIDcD/Mgiw2DKwhruraK2dmJjAwMAAhoaGJMgF\ngCRdzczMyLjPA+JjH/vYA9W0hybIZ7dJQTGzBznWcwRnVxQOh/Hf//3fcrMTjOa3z9+JpVGTytGA\no0IwGBS7JbtQjgfJZBKjo6M4ceKE3NzUs7Iz0+v18Pv9ACBe+I985CMYGhqSjZ7sUsvLyxEKhdDX\n1we1Wi1MMiUaZE0PHz6MRCIhS9zIdHKMO3TokOBE7EKUdlAKqrOzszE9PQ2HwwEAOH36NN58801U\nVlZifn5eOjYSfE6nE7m5uQJtzM/PY21tDT6fT2yX09PTSKVS8Pwu6V+j0Ygw3O/3y5bUubk5UTYY\nDAZUVVVhfn4eR44cgcvlEssqHTWrq6s7Ou6cnBxsbGygo6NDOjuO47wH8vPz8dOf/hRPPvkkNjc3\nMTIygsbGRsmsnJ2dxa1bt6Q4T01NwWw2i5qB04pSjsNwa2bI0hSxsLCAr371q0LO8PUmqQlAnGd8\n6BcWFnboT3lfrq+vY3x8HI8//jiGh4dx8uRJtLa2ip6TIcrUHVNtQcIT2O7UxsfHMTAwgLKyMmRn\nZ6OjowPPP/88enp6MDQ0tCMzlhg1ZUi8fzj18D5k4cjKyhKScXV1FTU1NSgqKsLo6CiAe6s77jcL\nqNXbCwGpPFBuAWAK1erqqmQi8LBg90qohJipMp6P8BefJ34PwHZBnZqaEvKYB52yFijflP/PhovZ\nDUplBIOt+Xl++9vfPlBNeyiF9Ktf/arIgIh18M8c5ZSdZTwel62dJDBYSMlaciSltIpgMS8WxxU6\nUlis+AJR48cT2Ov1iraPmYv8nOwAGHhw6tQpuQnm5uawf/9+vPPOO7J7p6mpCevr6+jq6hKdp1Ku\nMT09jRMnTgi+a7PZxPsbCoVw5/+i7l1j2z7P++8vSYk6n0mJEiValuSDZFmOk/iQOE2aJsvSLD0t\nQFt07bZ2JwzYsO1FtwF7UQwoMGxoh619MfzRrms7BEM3rF3adGnSOrFzsJ3EsR1bsmXrLFESKYoi\nJVEnSqSeF9rn0k21z1MPeAA/DwHDJ5H8/X73fV+H7/W9vld/vz772c8af5L2TtJHl0C9vr5uE0Jx\nSoyVdvEf5tJXVlZaXzUDCBnrPD4+buNOysvLFYvFDI9saGjQQw89pPfee8/YB7W1tXriiSeMYsaB\ndau3YHV0TmWzWd26dcvGzhAdHzx4UGVlZerp6dHIyIh6e3s1MjKibDaraDSqvr4+63Rrb283Dmk8\nHtfMzIwefPBBvfHGG/L5fAqHwxYdU+Scnp6WtBONgBv6fD4dPHhQhw8f1vDwsL73ve9ZxxqHfW/1\nl2yEaCufzyuVShXMcFpdXdX777+vL33pS/rpT3+qSCSiT33qU+Y8kE6cnp7W/v377bnk8zvTRJm5\nxfiVtrY2ywwmJyfV39+vz3/+8/rGN76hyspKtbe3q6GhwURLkCIEE+SzXYMvyQo0FG/Rh8jn85qY\nmLDswy3uSLLoz+Px2N5cXV01Kpjf77comC5Ggh1pV7UJCAlDR6SK8n4gELD0G0dMh9jIyIgmJiYK\npvO6zowX544s1iXmu1lmaWmp6uvr9fbbb9+VTbsnhvRv//ZvjRPpzm8hlXD1EjOZjMbHx3X16lWT\nxgO8lwpTZzYJBxgvSOsoERNdVS7OJe0UwVCBIW1xMSCu2ev1qq6uzgxcfX29eenS0lJNT0/bFMiN\njQ2lUin9yq/8ih555BHjUGYyGesEgezc29tr45rpM/Z6vXr55ZeVTCb12c9+1nAq6Fts6JKSEg0P\nD2twcFDLy8s6d+6ceXPwVSIpRFrq6upUXV2tmpoa690vKSnRAw88YEUzpNpCoZCuXbum6elp5fN5\ndXR0qKOjQydPnjSMlgPGWrBJyQzIMBYWFnT27FkdOXJE3/zmN3XmzBmr+E9MTBQUoeigunjxop57\n7jnj3fb09Ojtt982RzE/P69wOGyUnvHxcXV1dSkajdqYFZgcroOkcLO0tGTdUJ/+9Kc1NTWl559/\n3qrUwEyufFswGLRJsmC6RUVFJs9I1JbP55VIJPTZz37WBvZ97nOfswkMzDCj8g9GuLm5qdHRUR04\ncED//d//bcEDqXpLS4tOnjypiooKfelLX9KJEydMfAcdX6JGojkKty6O6bZNs24uz7K4uFjt/6Nr\nury8bJxj1xC6cnlUydlzBDdEq3Rs0dtOMOXqGwD5sYeAEpaWlpROp41iiGPm76j40wWG6pZr5jDU\nROUuIZ//5zU5OXlXNu2eEPIBqsFIWEioEUR/VPSY1QTOKalAOBdjxOIhDkH1DtoG3tlt+QMDZLxv\nNBo1GgYYLBED4DudD0ePHrX2PSr0pLnNzc3W+ZHJZDQ6Oqrt7W2dOXNGpaWl1v64ubmpmZkZ5fN5\nDQ4OKhgMWjFHkjKZjE6fPq3XX39db775pu677z7r/8c7AxN0d3drcXFR3/nOd/SHf/iHeuutt8ww\nYdBoOmAQHpXvYDBo+N3FixdVUVFhaWp5ebmqqqr09NNP21A7njHwSCaTsQ3JIVtcXNSVK1c0NjZm\nhripqUkPPPCALly4oL6+Ph0/flwDAwNGL6uurjaZvMrKSqVSKTU1Namtrc06vqhW43CvXbumJ598\nUpcuXdKpU6c0Pj6uuro6bW/viD/X1dWppaXFsLt8Pm9iMYx+bm1tVTgctojc49lpDXYxvpqaGuVy\nOcPcwUiBkehzx2FJMkfm8/lsUirtvdls1jRHibZyuZzNppd2usFu375twufnz5+3avXc3JzeeOMN\nJRIJnTlzRocOHdKPf/xjnTx50iAZ0noyM4woRdW9BRve4xpSj8djc7J6e3s1NDSkqakpeb1ew/UZ\ndkd0RwGOMwNHlj5+cHh3H3E9BEc8A7/fbypltMZCZUsmk9a2Che8tLRUwWBQx48fVz6f1+joqMbG\nxsxJSYXiJ24nlBtcudH6L3vdk2LT4OCgYaQQ712vX1JSYlHk9PS0PXw8Jmk/ngpBXMR+pd3pgJKM\nDdDc3KxDhw5ZJbCyslK5XE6HDx9WU1OTotFoQaTIQUPpaGlpyaCAVCqlp556ypTW8fZwHCUZJMBB\nHBoakt/vN41VsClUvKG/dHZ22oHE0eBl+/r6FAgEDEooLS21jZ/P57V//355vV594xvfkMfj0R/8\nwR9odnZWmUzGWjIZikf6Bf1mcXFRiURCzc3NOnDggB599FGdOXNGvb29amtrs9HPtC9yzxRR0um0\n3n77bX31q1/VG2+8obGxMROnaWpqUj6fN24qBzYUCtmwvOHhYStCTExMGFZeVlamUCikXC6nkZER\nNTc3a3h4WPfdd59FHH6/X6FQSJOTk3aoa2trjS42NjZmKTGpLp1u9fX1mp2dtU6nwcFB9fb26sUX\nX7RoigOYz+eNl4yqFsPgJJkx4fm6WGRLS4s1biAbSHvo4uKiZmZm9O677+rq1atKJpOW2kJfGxoa\nUl9fn5qbm7W2tmbTArxer9LptK5evarTp09bSypBg0s0l2TGlL+7nTwu0d0lvgN5pdNp1dfXG0uG\nlty1tTV5PB6rmFP/gDJFVIjuLxE345y5F2A56F1+v98yNLoHoTlS0Ny3b59N43WHDrK3Q6GQDh06\npJ6eHssCkCV0oQT+7qb5dztq5J5EpC6GCcmeiI4UAU8+ODho2BxGAyiAhQY7JR0gQmKeN6A7UWp3\nd7fheizI0NCQbf69vcFLS0t66qmndP78eSs0cbgx6KTbs7OzKi4uVl1dnZGee3t75fF4tLCwYAca\no0SFG4YBQheBQMBEnSsqKhQOhzU1NaXp6WkdPnzYKt0UUKDMZLNZffKTn9TAwICGhob01a9+VZ2d\nnerr69Mbb7yhnp4emxJKZHn//fertbVVoVDIMFRoVhTqwKIorEDMv3btml544QXr6ikpKVF9fb3h\nrQx4g3IUCAQ0MDCgxsZGFRUVaXJyUocOHbKxIfl8XpcvX9b+/fsNU9vc3FRnZ6e8Xq9GRkaMgJ5K\npaz7qL+/Xw899JCl3rQGl5aW6urVqzp58qTm5uYM0gB/htLGUD1aJ2neyGQyKi0tNboQve6SjNdI\nxAVeTRSfy+VMErG4uNjUsVCRgjqGpCQ4Ig6bTjIUxZiftLq6qmPHjuncuXPa3t7W5OSk0ZLQse3v\n7zdjmkwmC9gGGFKCEtYX45XP5wt+njMEhYrnT9RO8dfn82lmZsYq9jhCDFM+n1dra6sVgKG3LS8v\nW6bH++CWEzCw/4im4ZpSKMawM9OMAnU8HrdOxoaGBjU1NWn//v06ffq0vF6vxsbGND4+bswZbAoQ\nxd2+7glG+uKLL5pRJLqkqssrm81qbm5Of/d3f6fW1laLaNh4riFGkBmuZmlpqeLxuJH16U3Gw+fz\neUu5g8Ggbty4YbQKdzIkqUJVVZUikYhqa2v1f/7P/1Fpaak++MEP6rHHHjMcNJFIqK2tTQMDA4rH\n41YBfeedd+T3+xWJRNTY2GgFgo9//OPGe3WriIza6OnpMdyMVktk7ILBoEnMuemPi4eVlpbqj//4\nj21MdCAQ0KFDh/Twww8rGAwalLL3ILk95/v27bP/W1lZ0bVr1/Rf//Vf5kyAaNzuLYwtkfT999+v\nWCwmSQWqW3BbwQw7Ojo0Pz9vk0a7u7vV0tJi0aHX67UIkMKDz7ejSYogSTAYtLnok5OT8np3hDxi\nsZjOnj2rZ5991oYC0n7J/ikpKVEikVAymVQmk9H999+voqIifetb31JNTY0+9KEP6cc//rE6OjoM\nC21qalIsFjPoiKgMzBCDzJ7CqDzwwAN6+OGHtbi4aJmJO24b/iecZJftUF5ebvqizc3NOnv2rHEy\nI5GI1RgQ2m5ublYwGDQKl7vGOEu3VXNvgcbFuqEOYhglGQwDns76MlyvuHhnHhuVcEmW1Ui7GqAU\noZqbm000PRgMFlTtyYS4RmwGQRMcajBa1zGsra1pfHzcZrQFAgGDG4DHksmkRkdHdfnyZdNjHR8f\nvyubdk8M6SuvvGJ4IsbUJQ1TsLhw4YIuXbpkUYffvzOOl+LO66+/XvDwGLFA0YBqJ0aGCJV2utra\nWo2OjtqQO6gapFz02XPw+/r6dO7cOSUSCf3+7/++6uvrlc/njSPo9/t15coVk/ryeDx69913bTBa\ncfGOEDMCJadOnbKGAxSWJGlubs6MLL3c0HQSiYSOHTtmUWEsFjM5OQo+pCsIeABxuB04RLJwGWmA\noJhx+fJl/fCHPzT2AIR9qFe5XM6uD8oN5G04imiWtre3a3Z2Vi0tLbpy5YoNE6QdleIVraG3bt1S\nJpPRgQMHNDU1ZWr7KA8lEgnt37/fDntdXZ1eeuklfeADH9D6+rqCwaAkGcyCMZienpbH41F7e7sG\nBwdteBwGfmRkxCY0jI2NqbOzU9/73veMaRGPx41+RocPB24vRQfHgnF16UV/+Zd/aZFWLBazGfWu\n2EdxcbGtjbTbmspZwBhRWd7c3NTx48cNn4S/Oz09bXsdnq6L/e0tuGJ43KiV/eOyFXgRBLAWFF0p\nCpeXlyubzZpRCwQCNvKFZ+VCDHwOhU8wVLryPB6PKZbRhs0agFvDDkGOEj1ZSVYMTKfTmp2dNflC\nYEEKV4uLixoaGtLzzz9/VzbtnqT2e40oRRMX4AWHxOh1dnZqcnKyoGDw1FNPqb+/X1euXFFnZ6dt\nOncE69LSktbW1lRdXa1wOGzjPwCt4/G4iUGAt9JqBk7LwVhYWLARr/X19ZJkqRiGkAgO3Kmvr0/n\nz5/X9va2urq6TNTi+vXram1tVWtrq202yM50w9TX19t0STpz6OemMASvEUqJ2ytdVlZmaR5YNG2N\nHo9H1dXVVhD64Q9/aAIoHDyqqPA9MdaSrLjCZo7FYlYkgP+H1ury8rJWVlY0NDRkEnqXLl0ynm1V\nVZVWVlZ069Yt60QqKipSf3+/Tpw4YdBPMplUY2OjvF6vJicnjeYTj8e1f/9+6+yKRqM6fPiwEomE\nOjo69PLLL+vUqVNaXFw0ulMgELDC0ZEjRzQzM6POzk5rfgiHw3rnnXf08Y9/XM8//7w9Y8Ylu5Gc\ni+nTuCHtGCfGHHNoDx06pLKyMsViMUWjUQ0PDysajerRRx+1tJ81JGICPgIGY02WlpZ0/fp19fb2\nWsTrUrKASxYXF60dtrm52aZKsH+lXdFm9wzu3U9wUtnjGB43DXYr4vwsqb/fvzMWfGZmRrW1taaN\n6xpxAhgoTmQL3I/X6zV5TM4c/FiKVmCz0NByuZwJqeCgSkt3RofzDBYWFjQ7O2vQDyPI7/Z1Twwp\nD4+FoOKOgYSOwrA1KnQUqGZnZ22S4qlTp/Tggw/qlVdeMWVwRq0SgXZ1ddnhZIxDQ0ODXn75ZasI\nSjvGG08nqYA3Wl5erlQqpVAoZJgnCuS0VoL3oIVJWh4MBrW6uqrJyUnjdnZ2dur111/X7/3e7xV0\nSNE2SNoH1xCA3evdkQ87dOiQ5ubmVFNTY88ETVQKHtxnU1OT4vG4bt68qYmJCWUyGaMxSbL0EQwK\njInNT+olySJdIiLgBISVqbYjrVZTU6Pr16+rqanJMoWFhQXTnqWraHt7RwMTOpPP59PExISk3eFp\na2trmpubMxFhBCvolqF4JklDQ0Pat2+fZmZmdObMGaVSKXV3dyuRSNh9NDY2an5+XufOndPhw4dN\nIFqS9u3bp9raWvX39+vJJ5/U+fPnzUC6pHbWjchoe3u7AAqanZ21gtvGxob+4A/+QENDQ0bh6erq\nUk9Pj6ampuTz+RSNRo26BM0JNX8yDZgoqVRKLS0tSiQSevDBB624BTQFj5RiTVlZmWnCwlzBAHIe\nSePdAqbbzQSt0I1qyaSIJsm+eC8ZTD6/MwkX/JPiZnV1tXGroZjx3QQIKHcRWZLlMebF1cdwsd3K\nykpL9VOplDY3N+09RJ8Up+hwzGQySqVSmp2dvWubdk+q9qQbYJx4XhZoY2ND/f39mp6eVmlpqWlp\n4hH5O73zGxsbOn36tGpra/Xf//3fGhkZ0cDAgI4dO6auri7t27fPhEtQNXr//fdNtYcKaCQS0fT0\ntFF6aFMFw0L8gM4Sj2env55DtLq6ahJtVBd9Pp8SiYQ1BTBoi4NSW1ur1tZWO5woddMPj3MhvSoq\nKlIqlVI4HDbyNxsDyTackbSzqdva2pRKpfTOO+9oYGDACm0wITCeUFZ4TuBMpGAueZzroijIYSE1\n5T1ge2QcRK1Hjx5VJpPRxsaGbVjaepEcxHER4XD4JZmiFb3w8EE9Ho9N0KQXfH193Yo2HDqw0/b2\ndjU3Nxu2x/0g8C3J2m2npqbseexNc9nP4P3pdFrRaNSw91wupz/90z+1IggGCScdCARMgg5Ment7\n20a4UDjDca+urpoADkECkxJc/BNDhtHAAdIBuLm5WUBbYm1dxI9oFYPqsgDYA24kyn4iunYZA26E\nXV5ebo5zbW1NsVisoP+ez+R7yWC9Xq9lYmtra6ZxIcmcDrxlolwgCpw0eqtAZ+wnYJvq6mrTXr2b\n1z0xpDMzM/aw3ZslFVhbW9Obb75pHFGUmUKhkEUcFBKIAkdHR5VOp/WJT3xCFRUVam5uVmNjo6qr\nq40XuL29bTOWiAAwJIztoEXOpVrR++3x7OiJRiIRq2KygLlczlIm2gbZCMjjuW12GL2JiQl94AMf\nKADf4SymUikbqoaBzefz1u6JIUyn0wUYK4eaAwBvsbW1VY888ohu3LihRCJhP0MkxQFyIxO3C4TC\niFs4gSnAC2fgRjE4AhfPvnHjhk3aZGwLGFo8HldlZaXm5ua0tramhoYGraysqLm52YxhIBDQwsKC\nQqGQ4dShUMgmv9bV1SmZTJpGAIeIz0smk2pqajJhi/7+fiPQh8NhlZWVGfTy7rvvqrKyUg8//LAk\nWVQPP5N9vLfIBDZ38OBBPfvss9aCS4SEgy4uLraBfeXl5QbjkIFB00PJjNZLPqOurs40GpgIS2RN\npofxY38AYfF/GFMcJAYRQ8g1u5/jFp3YH7BveK9rBF1KoiR7fpKsTkLDCbUNoCJXvYmInH/jFxlL\nNBo16iAMH54H55Y9yv0uLi4qlUpZFgVWjhrYL3vdk9TeBbhJnVlQjM7o6KhRLNBNZAEjkYjhoIgE\nS7ICyCc+8Qlls1klEglNTU3ZJMmysjJ1d3frhRdekCSjqPDeXC6nvr4+vfDCC5Zu0K6K966trTUD\nwYJwAGOxmDo7Oy0183g8WlxcNB3G+fl5a40DlI/H4xoZGTEJOHr63Qq8+wsMkQIRBn5yclJdXV0G\n7LuVeJ73vn37dOHCBX3+85/XysqKvv71r5sQBs+A7hAiUPfAI1ZC6o/xBZrBWYFxQQOioopTxKFR\nVOMA8mzg/2FQSkpKNDo6auNnrl+/rpaWFqvs4miAMsBCV1dXFQgE1NHRoXg8XiDdduDAAY2NjRn1\nqbOz03QfSIMRaQmHw+bMOzo69NBDD5lE3Nramq5fv66hoSGDQ6DhhEIhtbe32zwtUk26cGhVhi/p\nakKAYcM6wWlDJXMdvQuDhcNhI8FzvlxDiaPEmALJUOjZG226tQsoUaw7htI1jm6a7/4MkSv7mut3\nuaFEnKToGNV0Ol1A4HdFirgeok76/PP5Ha0FRFUYUwQk5/bYQ0GETkXnI1S6u3ndk4g0FouZd6IX\nmcOczWZ1+/Zt9ff3m2EBA4O8jqAs7Xt7vQ9Gp7Ky0nCmbDartrY2XbhwwaTliLAkGcQQiUT09ttv\nG7WHaJROH0agwHFjsigHIBQKFaQXkK0XFhZ0+fJlxWIxxeNxo7lks1kNDQ3pqaeeMsMHDcrn82l+\nft4U8t3uGlr1iOzB99jsbBI29ubmplGT7ty5o5qaGv3ar/2a8Szd1kfaGjlARJQ8Lw6cm2qxPkj+\ncUhISaPRqObm5qxyjMLXxsaGmpqatL6+rra2NqMnuXh2dXW1JicnjQ0BqXtkZMT4qPPz86Y+hMEv\nLy/X/Py86urqTBUJgWqUuqDD4ZDou9/Y2DB1pJKSkgLyOLxHDN++fft0/PhxHTt2TD09PTp8+LBC\noZCCwaCGh4dtqB1GBAfMAeZziLjcAIO9SboLKwVH5vP5FIvFlEwmNT4+bmIfFFX5LDeKxJC558Q1\nthRK3aIphtaNNPl/9zt4/94iMvvG/QxSabc5wDXgLrxAdL+1tWVKce617Y24aZzgecLgoHmHs+Pe\nJ9np9va2OV1Up37Z655EpHgqaecBuaA0A+ooBBQXFyuVSimX25EBa2xstJlCqIlTzVxZWbHvoKDV\n0tJirZgUjFhgFnZlZUXBYNA2gCulRpTk9/vV2tqqioqdufLwQXEAmUxGkUjEfpZiBFgdUZob7ZEG\n3blzR0tLSxbJptNpU/nfq+RPn7gLqPt8PjU0NGhiYkKdnZ0FHp/v5PdQKKSGhgZTGjp9+rR6e3t1\n9epVeb1e0zVlZpWbBrmHjQ3PIaIiWlNTY6kRBhjaDpsdw4EsXjKZ1EMPPaRXXnlF7e3tSiQSqqmp\nsREwyBtSwOMeiLqTyaSKi4uNXN/a2mri2hgojBnXibFpa2szR7S0tKS2tjaLAOGWVlVVKRQKaX19\nXalUytJOn29HK5Ri4rVr19TQ0KD5+XnD1wOBgEnF1dfX2+wrZOOI2IFAcIKcB4wKGPvW1pbi8bi1\nOB84cEC1tbWWneVyOY2Pj1s21NDQYLJ1fCa/E9mh6r83ZXd/l3adMi+MJufIPd/Sbg8//8Z38v/u\n57i0K+AjRIT4Huh1iUSigGfqQk6cL9cR4dRxVPPz84rFYtaKTdDj8ko5O3f7uqepPR0OeJTNzZ2Z\n9sxrb2hoMIVtUnXSRKpxrmbp6uqqUqmUMpmMiop2+se7urqsg+nmzZvW5eBy46iIwt+Dc+fSPACh\nXc5cS0uL4XnJZNLwLSInUmBpF6vi81hoRI5feuklfeYzn7HNBK5HOyipK+9lXhRdM0SriHdwMHm2\nRJGZTEbNzc26fPmyIpGIVlZWbBLnjRs3bNCVL1o/AAAgAElEQVSZx+MpEGmhMLi2tmbrwabf3Ny0\nKj26pjgr0n4OFXQVOomYQXX79m2TEayrqysQ+3AhBugv6GWura0pkUho3759hjMzlJDi0dzcnH13\nc3Oz4dqkgxiMpqYm+96VlRXF43F1d3cbf9Tn8+natWtWqWetibQpUkmyrrQ7d+6oubnZVOtRMgKv\nRS8TjQVmS5FdgEPTVsuexfiQObW0tFhn3tTUlJqbmzU0NGS0nhs3bqi1tdX4wjA0cE6cCwqcOEsy\nHmAmN0p1IzjXyGL02Rtu6u/irq5T5nNZY5cGidNAHIdx59vb25qdnbW9yrMA/93e3i4QnWY/YXs4\nf2StblbFWbvb1z1J7ePxuKWKbksoRNkrV65YWu/3+3X16lXNzs5asQK8LJFIaGZmxtS033vvPb38\n8sump3jw4EHDy3w+ny5cuGD8UQi4m5ub1v8t7cjLzczMmCQfKktEqhSR4Li54x0ggmNg0PgsLy/X\n1atXjSXApsFDer1eDQ8P69d+7dfMUFNIYvIkSjhUI6PRqBVK3A3JvB53UgCRLxuqoaFBiURCly9f\nVjAYtGgJTivK8m6BwK3wwkZw8SoKaLQ6JhIJzc/PK5FIaGRkRGNjYzbHJ5PJKJlMKp1Oy+/3q6ur\nS+FwWJOTk4rFYqqsrLSUnHuixZLq+vz8vKqqqpTNZtXS0mI83K2tLesHh30B7go+SsTMUMBQKGQ/\nC2eytLRUra2tSiQSpre5vr5us+LpJoLWBGeRYhuOA16p1+s1/jCtn7wf50IVHgGT7e1tG5/sOlio\nU42NjTbZlftkpExZWZnh+xDOiWiTyaQmJiYsCnezGwwYmZdrSMk++Hc3gpV2DStGi/8Hp+e9e6v9\nnBm3wu9iteCm8JErKiqs358IF7YPz6u8vNyokzhRKFIUqjDKTB7weDwW2RMEwDX9Za97ltrj1YaG\nhjQ5OamnnnrKAGI8kKQCwdz5+XkNDAyop6dH6XTaJkZeuXLFilR1dXV64IEH1NzcbMPffD6f+vv7\nDV90N0EoFLIil0tYJxVeWVn5ubHI0q5oLc7AxVzYRGC3KFnxXrf/GLZCJpPR1atXTQqNAwa2x2bn\nMFBUcgsCVD7RIqWq6arbwMP70Ic+ZCIZp0+fNgWklpYWffSjH9U//dM/aWRkxPBFqs00HRDNuJVc\nl0blYl6uLCIHnqhqY2NDo6OjikQiJqVI9xfcP54ZERqfx5joYDCoaDSq9vZ21dTUGP5XW1trgsil\npaWmBEWTRiAQUCQS0dzcnEpLS5VMJhWJRMxwra6uWnRC++LU1JQZJ4wpzQiMheZ63UIe1K5AIGBO\nYHt727i/pJ4uuT+dTluL8sbGhhYXF5VOp83oYCj4DgID8F0KprRrZjIZ+Xw+YwHMz89rc3NTIyMj\nJibd19dnTp79zOeCv7tRJQHD3khV2hVwcQ0m/+9CF27WtDeldqEIMFWq7BQz6+rqTLqQWkk+nze6\nGs+drJVzs7S0pFAopI6ODps0i+h5Op1WOp22sda/7HVPItK5uTlbrLKyMt13330Whr/zzjtGj9re\n3tb8/LyJ8BIxsJnhYiaTSU1PT+vIkSPq7OxUZ2dngbGqrKzUxYsX5fP5rIABnkIqCTBdUbEzhre/\nv988GSE/0yzRU4RW5fF4VF9fbx0YkiwyIqr8yU9+UsDtdNMGqs6Li4t67LHHDJt0iw7/dwaTaJt7\n4ufp1OEA8B0UN4qKitTb26vXXntNQ0NDOnTokBXwKioqdOLECW1sbOjWrVsFmLIk8+7uyBXgBTb+\n3ko+B5NJqG4nFx1s8G2ZTtrc3KxoNGoGl/uE8A/1qqyszLqCGLMMdg62FgwGbYIBWC5FHFJPyNh7\n012KZlNTU2pqatLCwoJNFvB6vZqdnbWqPMIkKIjhbGFqYPSqq6uVTCY1MjJiqT6FDaIhCipAXjAJ\nKKSwF8HbJRn3lVQcpwZfE4iAvU7zCJzKhYUFLSws6NKlSyZM7ur6uh1UrnOXZMaOLJN7cbFWFw91\njS8/50a5boTKz/C7u5/m5+eNK0ykL8mUyYBHYADBDeee6M7jXNHVl8/n1dnZeVc27Z4YUjiMbH6q\n26urq3rttddM/WZ7e9tELdyHiGdaXV21yZcHDhxQW1ubSY6BkwSDQU1PT1sBoLm52biFXq/X0jw3\nDS4rK9OtW7fsgfv9fhN/cA3IwsKCGduampqCtAaBhXx+p9/6jTfeKADh3T/zmpqa0hNPPGGRMfcA\n1oqhxiC/9957ZtyJ9tw0De8MAwAKD8B8UVGR2v9nTvxbb72l+++/39pEi4uLdeTIEVVVVendd981\nDM8lpOPseLnXJsk4o0QeLvUFeg8sAYwCkSdGDRzX4/HY86Dodfv2bRvnvLCwIK/Xq3A4bN07paWl\nmpqaMgwYHIzK78bGhjUAkNq560vaR8suBbqWlhY7kE1NTTYhlswGzDiX2xnYh5gH182+IuVncuiV\nK1eMuwgGiCEpLS3VysqKOWfGxmBsM5mMhoaGzGhSdMEQer1e+3Ntba3VGIBuwPdzuZw5mUwmo/7+\nfl2/fl1jY2Pa2NgwXVDXGLpMDhcfBRLiXGCAf1EDgLQLF7i4tVvVd4vU/Jk9jsi0pAK4qaampqCO\nwiSNfD6vw4cP27OSZJx01ObW1tbU09NzVzbtnhhS+pnBD6lGLy0t6cc//rFFVRsbGyYgK+2mdywm\nhZzW1lZ1d3fryJEjCgQC5qHLynZmur/33nuqq6szubq6ujpdvXrVNEAlmSwb2MrVq1eNEpXL5dTb\n22sGC/qLSx+pqakp2Fy53I7Ul9fr1dzcnG7cuFFQwXQrtK7XDofD6uzsNMzO5/NZeul6fnAvJpW6\nmxp8c3p6Wg0NDRYtEsVziD0ej9ra2kwr4PXXX9fRo0ctta2trVV9fb2efvpp/eAHP7DUmmt1jeLe\ng0VBj8ND1MczKy3dmdWeTqctTZZkEWJRUZFqa2s1MzOjyclJPfzwwxodHTUMG/gDCMPj8dgoDvB0\nnCiHzmVg0F6Kk+F6wSu5HgQ2SPPLy8uth//KlSvG8CDbOX36tIqLi02WDaoahlWSHV7WA4wXYzk0\nNGSD2Fg/iq1EjjQTSLKBijwTIAYmwY7/z6wtV+LPNagYbPaa3+9XXV2dTUStr69XNpvV5OSkBgYG\ndO3aNdOooNawt7JPBsR+5eUWsfhOHOzen8EBuPsNaAiDzb9DmePngcz4RbbU2tpqsNTw8LCWl5cV\nCoWMKulCdeXl5dq3b99d2bR7ZkihJDB9cWtrZ4TExMSEeVPIuO4DpMCSzWY1Ozurj370owoEAja0\nDLWYra0tEwOJxWJmPCKRiJqamow7yVwZWvHQLbx586YB2fl8Xn19fZa2oMwPdYqBdy4WRPRQV1en\nK1euaHR0tGCTSbsbjE1YUlKi6elpPfnkk4ab4eWl3amJ0D34nL0YJNHb9va2FdtIpd1IkvS1tbVV\nsVhMdXV1eu2113TfffdZ5wxY5YMPPqhXX33V5PH2HgbXmIILgzsR0UGhyufzBTQwZNOIRCsqKuzZ\n8azj8bgaGxuNJD8/P29Vdgw/3wn3FCxsc3NT4XDYZkLB4sDZUkHnmfJ3oAPu9ebNm9YymEwmVV9f\nr1gspvr6eussmpubs9lVhw4dMiI9OCeFHtYB1SwiOL/fbxGWa1Sz2axFSdls1irwk5OTpoqFc6BF\nFzycKDWTyRjP1O1CggIkyTKKSCRiRH0i3/r6eotal5aWdOvWLb3//vs2boUMA6dA5ijtFq34M99F\n1CztRpluVsXLLT6x711cHsiL6+Xn0WQoLt7RCIZfG4lEVFNTo8XFRU1OTioajWp7e9sKdLdu3bLJ\nDHfzuqeGlEMHlvP2228X8Lnon+bnqqurjXQ9Pj6u1tZWNTY2FowZQfVpYWFB4XBY8XjcWhh9Pp+l\necz2aWpqstlFHOZAIKCpqSmLKIPBoKVubHqi4Uwmo5aWFltMDi5UlMbGRp0/f17j4+MGsrupjUtp\nAaP60Ic+ZGkys955Lm70IMmaGejSwmGsr6/bRNLV1VU1NDRYBEY/M4YUfJYWxXfeeccYD+BoFRUV\n+uAHP2izg6TdYgIbfG93U3FxsaktuWmbJDNQQA3grjxzIBdadpn1QyWdlI50f2trV2cTQ8kMLbDw\nxcVFu28iYfDdVCplNKTl5WUrYCwvL6umpsYEqBOJhEniIbRRWlqqRCJhDhnNy1wup2AwqNOnT9sk\n03Q6rX379pl8HypjrC+8TwxCVVWVOZOWlhb19PSY0hkV/OLiYovISNkZvxEOhy3LiEajJobt0tF4\nP51UwA1APGDGrDXDDSnIwTh4//33de3aNYtkXRoR73X3O98vFRpKzqoLGfB3twrvfpZLn0JLgWIj\neCf6BS7uXVVVpaKiIhPcWVlZ0fXr13Xs2DGVl5ffdYvoPTGkyWTSNhBdPNlsVi+99JJNkEwmk7pz\n547hICjI+/07YqvZbFYnT55UJBJRS0uLAoGAdYpIso3hFqboUoHoTtWOkRRsRoR/R0dHVV5ert7e\nXoVCIeMtwrVjE8Bvcz0oG8zj8eiFF14w7IzIUFKB4aHKj+E+ePCg4XJU36HWYJSKiopML9T1/pIs\nkoSzybXzLIjA2Nytra26efOmmpublc/n9dZbb+nIkSPKZrPG3c1ms3riiSd04cKFAniA73UNOYdv\nc3OzgCfM70QVwCeu0hYGfG8xK5fLWfMEDiabzRZ0GUGZ4/etrS0rsIGXjYyMWPEFvLesrMyeJXiy\nz7dD/kf27fLly5by1dbW6s6dO2psbNTs7KxNfl1aWjLeKIUrumk6Ojr0xBNPGN2Le6ytrVUgENC+\nffuMb4rKlcfjUSQSUU9Pj+3VXC6nhYUFMwyVlZUKhUK677771NjYqGg0qrq6OusCZPrq4cOHVVdX\np1u3bln0zpqhhSDtNAm4egVkIKyVJMMf6+vrC9gbHs8OV/nGjRu6fPmyotGo/P6dQYEuH9it1LtF\nJXBjqTCKlVSw11yoC0wUhwTrYXNzU+3t7YYj47Bh3NChSEOJtNsuevnyZVVUVOjw4cN3ZdPuWbEJ\nQjXeIJPJ6OzZs8YXZCIkNwYJf2ZmRslkUt3d3Ta/BhwLY7K5ualgMCiv16tYLGapA9ED2oSDg4Mm\nVkKKR0rl9/ttHv3DDz9sBSla+1xFeDyvtCv5Bgl8c3NTL7/8sm0SUjA3FeZ9bK5EIqEnn3zSClYu\n55ZIheJBKpWyTh42Fhsa772wsGB4sCvI4kIAVCgvXryotrY2lZaW6vXXX1dHR4dhUWy2xx57zDRW\n9+KjXq+3gJ3g8gLdVNFN37h3huY1NjZaay296VTmXX0EjF1NTY1u3LihcDhcENVwQDi8bq823EZX\nAITmBwy+3+83nYa1tTUTm47FYoZbMhYjmUwag2BiYsJk2dziCAVVJBWJjpqamowXmc/n1dLSovb2\ndlVXV9v3um2q6Iu6XVuSLNPo7u42Ohd1CK93Z6xGJBIxbLOoqMhalaFb4UjS6bTC4bAxHkjtw+Gw\n1QRgRUgymUTOMvtwY2NDY2NjevvttzUwMGB6FUAJe43p3l976VZuNsZzZa0p4rkQ0tzcXEHLNoU1\nsjEyHuAo6hutra1KJpM6fvz4Xdm0e9bZBK+OA4XcmCSTCrvvvvs0MDCgsrIyNTY2mkL81taWjhw5\nYik57XwYBiKw6elpozsBaEN3wHC61T9SFXA6hoxhLDlkGFHeR3pEFwcL1NnZqeHhYSsskKKAs7rg\nOHQVaUddiNSTzQmgTtGD4g29862trZb6S7sUK0jag4OD6uzsLIhsMXBUywOBgA4cOGDydV6vVz/7\n2c/03HPP2XOpq6tTNpvVV77yFX35y19WKpWyDQ8WheElCocf6XJgMXLgZNCFwBpramqs64R2YDZ/\nIBAwNbCxsTHLKK5fv64TJ06YQ6LtFiI96vCMnQgEAmpoaDA83aX2SDs0vf379+vatWuW0TAriMPM\nhFTEw6urq9XS0qJkMmlczomJCSPaJ5NJtbe369ChQ1Ykqqurs8F8169ft8h7bm7OzgoTIuj0Y7QJ\nhZfa2lrTdWVUSUdHhy5fvmyNAclkUi+99JLdL/AIUAAOBGNVX1+vqakpw2xdbizTBbq6umycNNNa\nk8mkBQ1kcBTdNjc3bVZ8fX29Dhw4YBEt2hYuBOAK2lDxd1N87AlGG0obZ5T2XCJq7g9YiL01Nzdn\nsn7gvCjN3c3rnkSk6XTaRCbALy9duqTx8XHDKW7fvm14JvjhrVu3VF9fr2eeeUbhcLigIwmvRXri\n8/mMHgPoTNoEHjc9PW0gNCNupd12Tg4v83tQ3Mc4IMmGUXNxnfHxcdXX1+v69eu6deuWpF3vK8lS\n4F9UeIKoDRYGnw/IgXsCRyWNJ2rm89iA6Ay888476ujosJ+hcOXz+axp4PDhwzp37lzB+Ou33npL\nx48ft4iKwsXjjz+u119/vUBjkogTp8C1kNZxH9Cb+DmutaioyKAeogNI5lCYGhsbjaOJCHdZWZni\n8bgVtrq7u7V//34lk0nDtqH0EIFCds9md2bc19fX2+/T09MqLy9XMplUOBw2J01mAasBowEtj1Q/\nEono0qVLJvlHIYkoEsPc2dmpdDqt9957T++++6683p3uKya/zszMWCspNCkmzPJ5yMeNj49rfX3d\nCp1E9cFgUGNjY+aogDVczB2KFcyGsrIyVVVVWdcPWDNBgMtgIQqkOMw1EpxglO+//349+OCDqqmp\nUVtbm1XQGxoadODAAS0tLVkl3S0qJRIJeTweUxBzJw67ffaSrNDMjDegMaJN9plLx8KpU+BG3CeX\ny6mrq+uubNo9MaRTU1NWIKFj49VXXzWeIx0KRUVF6uvr0+Lios6dO6dnn31Wvb29RsmgIMEBpXCB\nEASgPwuClBYA+u3bt61wAFbipg2Li4uqqanRgQMHVFxcbNVT0j6KSXuxGwbYBQIBXbhwQbOzs78Q\nU3Q3i2tg/X6/FhYW9Nhjj1klVpLxSemVJoIH7yTKdF9u2kQXC50cGAUiXVKfhoYGm/TJfPg7d+6o\nr6/PepUpgjzxxBPK53dmh1PU2Sv8QFspUYO0OwiPayAD2d7eaYP0+3d1OCGdUwkmSuNg4Wxqamq0\nvb2tD33oQ5qbm9PU1JQd/KqqKi0tLZlsHPc1OztbQGGbmprSxsaG9u3bZ05+eXlZzc3NJnxCESwQ\nCFiRDupcNpu17zp9+rQVmGAJcF1+v19jY2O6cOGChoaG1NDQoFAoZHOcGCvs4uoY65qaGls/9hwt\nrG70hpOBesWZc7MoUl6cGPxbyOvUDchuwC1ZMwqY8HiJWqG0kUEBmY2Pj5voCud1YWFBt27dsutn\nPYE1iBDv3LmjqakpcxrRaFSjo6Oan583J1NdXW3tpG1tbZaB7G1J5TwA+0m7otDQLuvr6++a/nRP\nUntCaigwqKRjTDY2NqwyODo6qlOnTmn//v1aWloy7htK59Ju2ySRlZvWNzc3mwAIRQs3EpNkNBf+\njc+qrq5WY2NjgR4AqSh0m73AOSkl3n1mZsYMHlgiXtqNSF281Ov1anR01MRXMBZU6DnMeHxwVLii\nbuTrHqr29na99tprFkHRpIARoDGCKaOobUUiEd24cUPnz5/XmTNnTLmItPnkyZNqbW3V2tqarl27\nZs0MRLkMJXOdFJsbkjhrks/vtGMydxwmhstxRK0exS6/36/+/n6dOnVK3d3dunbtmuFeVPKZHwV3\n1eUqux1W7e3t9t1oGrS2turKlSs6evSoGcvq6mpFo1HbFz09PRoZGbG1YcwICkP0trNW8XjcqFLH\njx/X9PS0jR5nf9DoMT8/b5qcRJxlZWWWynIPzCLK5/MWtcZiMdPQBcqiOOMGDi7WDUkfGIZ1YE+R\ntkMBpBWVz6dIur29bYaJLIC0msDCxVPz+XzBVFIyQK4Bfjjt0TT1LC0tWb1lamrK9tW5c+ds3zQ3\nN6u9vV21tbWW4XIP7jOQdgqgOLW7fd0zQ0p1HfCdkQkUTSgWvf/++wYOHzx40Nq+CNftRvZUtaen\npxUIBIyuxFROoi88H94LrIyKNuNH4Njlcjl7HxERUIBLTMcDknbNz89bZMbL/VkMNx7TJbqPjIyo\nr69PmUxGFRUVOnjwoCYmJpRMJq0KWldXZ73bGA83vXeJyzAWvvvd7+p3f/d3tbi4aNieS6PZ2trS\n4cOH9e///u96+umnVVNTo6NHj+rixYvq7+9Xd3e3/TwOg7lDvb29OnnypLLZrH72s5/pmWee0Y9/\n/GOjWUmF00wlFcy3wlDAJYXwzliSmZkZe+6pVMrI4mfOnJHf79c3v/lNG99MtLS5uWmHnEPMGoEx\njoyM2BRaMEmir/r6egWDQVMa4pkWFRVZtT6dThv/FJ1Vn89nak4HDx5UKpVSU1OT0um0lpeX1dXV\nZa2nY2NjNnTN59vpVBoeHtb8/HxBFFlUVKRAIKBgMCiPx2MDIakVxGIxgwcwIlAGXawaI8o6gFe7\ns7rcAiLpMJEoEbZbMXf51UR/4M7Qu5i8S0st14TgC8VhsjdJBdE367Y3eHKjTYq8YKVU8YeHh62A\nWVlZqa6uLhtb5PKw3Yj9bl/3xJBKheTy8fFx8zQIAUciEb377rs6deqUioqKFA6HDV+rqqpSQ0ND\nQcju9r2jX8oCra6uqqOjw/BUPCGej6iFX8xLKi4uLqhu8mJz0RbK+yg4MVo6mUwah9KNEPG+eH4i\nSDYPnvv69esmIhGLxZROpxUIBCzChIrCpl5dXTXKjLTrYSVZ9frw4cO6fv26rl69qkgkYgaRIWr8\n7PHjxzU8PKwf/ehHNr7lkUce0Y9+9COtrKyor6/PuIY+n88G2ZWUlFj09ZGPfMQKe88++6xefPFF\neb1eO6wbGxsFxSmwOdbT5/MZXpbL5TQ3N2eiHidPnrRiTF1dnS5evKj33ntPLS0tSqVSplcKVJBM\nJm38DIUsihs4YFJ/j8djrcdNTU1GRSopKTFBGHq7FxYW1Nraqmg0qmQyacWliooKNTY2Wm//5ORk\nQZMFsMLMzIxmZ2etdx7a3Pr6uurr6w12YvQzVXY0W3t7e/X000/rjTfe0Pvvv69gMKiamhobUeP1\nei0YCAaDZuiIyFg7v9+v9vZ2tbW1aWBgwHRwiQbZ9xhhIBp+B4dHHcsNHmDUIDnoptAIFLnZGT8P\nLY1uOOyFywxxq/tg8RTNON/wYjOZjInwMD0XJ+DKecJBbW9vv2t7ds8wUiYbbm1t6dy5c0akp6rp\nchLD4bDRNmjTw2OSlgcCAet8isfjymQypkdZXl6uUChkUQlV4Zs3b1pUIskwN4/HY2NgMZa027Fw\ntFWSUhAB0Vzg8/k0ODio69evm/fkxYZxX3vJ7EQlTzzxhAHo4E84CbctDr7f3vEIfHdJSYnu3Lmj\nXC6ntrY2vfjii7r//vstQuFZEqlsbW2ppaXFJn4iQxcKhfTTn/5UjY2NpixUVVVlB6WkpESXLl0y\nr494MlQ0IjWPx2O0MTb94cOHzTiTQrsRNXgnWO+xY8eM3pVIJMzhQODP5/M2aHB5edm0Vpk4AA1o\neXnZCihutkCEBZa3sbGhtrY2o/D09/ertbXV9iL7hOdE5AyGyAHNZndmho2Ojpp+KyNFgDegt6Hb\nCkWvo6PDFNG8Xq81rTD+xKX/8P3Qo1gf1JAwrg899JByuZxmZmY0Njam7e1tg1GI9kpLS+38gMVj\nVF2yPXg254BOLM43XWz8HPgu6Tj3STGJ/eLyTF0IDDhia2tn8jCYtcuCwQH4fD4bxsj/cw0U2SRZ\nkBWPx/Xkk0/elU27Z3qk4Gerq6t65ZVXTBBCktrb2zU3N2e0EIj0UIsYu5HP500SLRQKaXl5WWVl\nZRocHLSuGrAheJRUX4uLizU4OGiVbrpQKDqxWMyvn52dtRRUko3+JdrE+NXX19uguzt37ujmzZt2\nMKXdqrxLU3L/z8U5l5aW9OijjxoWS5sllW3oGeh3QvGhOcDFbcF3UVkaGBhQV1eXDdnDwbiRSkVF\nhZLJpK0V3TiRSETf/va31d3dbbORGhoaJMmi3lgsphdeeEEjIyPyer2677771NbWZgpPLg2FA3Tg\nwAHjCVM8Y7OTLks7tKTTp0+roqLCUtuGhgbFYjGDhlzhaYpNGxsbNgaaSZ/pdNrewzMAm/R6vTaJ\nlGficg7D4bBSqZSKi4ut4s+awFmmmEUBcWpqyu4xHo/b6BWcpSv5Ju0KaZSVlamnp8dk3qBwpdNp\nk0PEGIDh836oUqxPZWWljeg+deqUBgcHlclkCrQS2DcYTNJ016ixF/1+v4kq82w4r2C3QHIUd0tL\nS83ZktUQKHCdRMoYYzjQ0q60H8aUlJzz7DaAUJeg2Ya9R4MP2SQDDaEObm1t6cMf/vBd2bR7Ykjn\n5+cNx4jFYnr99ddVXFxsVXJwrKqqKoXDYdXU1NiAOzpVvN6d+e54TPC3oqIiO6wo7FOccqlUREi0\n4ZG6UaAAHyFVpmIu7dJ5qPwSxeFtKXRduHBB0WjUyN8ufMCGdTtCWHRSou3tbYVCIUUiEcO9JJkg\nMS2K0KLgC7oUMGmXtyvJxKmnp6dVUlKi9vZ2w5HomsF7b29vKxKJ6MqVK2ptbbUKf1HRjgTfd7/7\nXR0/ftzoRYinUCx84IEHVFlZqZdeekm3b99WJBLRwMCA7QP67Mkqenp6ND8/b6pgpLWkaNznpz71\nKS0tLekHP/iB9dTz7DgMbvRCNIkxRszY4/FoaGjIxrdggCXZ86yurjbRZiJPqFmMukF9yu/3mwIT\nUQ0HdG5uTsvLy5qbmzNB8kQiYXgsUe/8/LzJTELNyuV2BHDm5uZM+xRmgNfr1f79+xWJRCQV6raS\nLREYkJ1B1t/e3tb09LSR+12M0WUJYKzcc0aU50amGDk3InazMYw8e53Ilb2KQeRFbYLsC6fryv+x\nR4gwiYIxji4WzPVSR8Aws3c4m5wbn1HrJooAACAASURBVM+np59++q5s2j3BSF1iNoaGjdnV1WXq\nUIxTJoWOxWKWstHuCN+LwhH8NarQeGQqx25VmyjFrVLCgYTihAGjcsxmoQjCpsvlcqqrqzO+HlxS\nl0DMy41AXZDb7cUn1Xn55Zd15syZn6uYEpG7ADldJWwON7IgQorH42pqarKRw8lkUi0tLUqn04rH\n4/L5fMaIgLvZ09Nj1etcLmeR/oc//GF9/etf11/91V9pfX1diURCoVBI0u6ojZaWFv3DP/yD/vqv\n/1pjY2P64he/qD/7sz+zrh94ouyBdDptxqykpERtbW0qKtoZF7K0tKTPfe5zOnfunG7cuKG2tjbd\nuXNHXV1dSqfTxuHkkGxv74wqLioqUiwWkyQTCYGgXlZWpmg0ag6Mwht7g2IVFXOKmqSUaNe2tLSY\neAddT0NDQ1peXpakAg4y3TScAZdsTtGT7+XQV1dXG58SfrPX69W+ffvk9XqNz4nRIEWmw479Rmq+\nsrJiBRUKQkRwONGioiIbcU1gAU6Jo3Jx/r21AHePs3cp7rmFK36es8X/4zzZ80SybsTN97tFMyJQ\nvoOGgNXVVcuCuX5JBe3dRLpcx13btHuV2vMAL168qLm5OTtMNTU1JtDQ2NhohHd4bIyihXw/Nzen\nlpYWLS4uqrm5WdevXzdjCaeRdAsPx6FNJBI2Ox7vTTSKEXKxRTd1ciuW/J3KIxXTF154wRZjL7/T\n/bvrpfkzh2J5eVlPPPGEPS+3dx1sGG8MvoiBd19sELhz7qwjBF6I3iVZ0WV9fV2hUMjwZBdvYvTx\nxYsXdfLkSW1sbGhtbU11dXVmyOBYPvLII5bKPfnkk3rvvfdsDUm/H3vsMY2NjdnG57nu27dPPT09\nam5u1tmzZwueKRV9Mpa9Ro4os6SkxPBV1nB7e9uKkQgi86xIJ8HyWB+YCnwnTR1g1CsrK0qlUoa7\nEqmBTboddS6MBMbM2rJ/uQYoTxgisF4Mqour4pzJTtzWYrdS71KaeJYUczAuGxsbCgaDloVhUN0o\n1Y00XUgJg8d3u40r7CP+jfPA+93P93q9htnyWZLsfohMccpE2NQsMLTQIWtqalRVVWXSmnyuJHsf\n9/uxj33srmzaPYlIi4uLreI+MTGhqqoqRaNRlZaWGuUFuTwiQrwfM2pIaZuammzhoM647aLw9ujZ\nppIPlohwg5tqE+mxQRnpQBrK4oKvuFEsGBRFAPdwSIXdTe6fpcJhYnhcOLaHDx+21JVoeXp6Wp2d\nnZaGcrhJmfZGCVzr2tqatSTSj0wai4A0otRkDydOnNBbb72lAwcOWKTk9Xr1zDPP6Cc/+Yn+4z/+\nQ88995z1bMMS2NraMhystrZWsVhMhw4dMmyVhoOtrS3DL2lBJHUuLS01gnwgENDs7KwVBsgkpqen\nFYlETAmfiI/9tLS0ZBQfSQU8Zgzn7du3tbW1pWAwqNLSnSmjRPD5/I4y/8LCghnCgYEBq1Svra0p\nGo0qkUhY4Y77cEWaMQqBQMAMJNMXJOnKlSvWMAAujcgLa7O3u4d1xjADQWxtbdlUUzBnKuY4KgpL\nboZDlApPdXJy0lSzJNmz53xwHjHMruPhrOyNIsGcgdrYa+xTN9IlLcfxkXHtzebIBLh/aE0MZgTi\n4hntPX8EQHTN/W94pHc/b/T/xRcPn3ERRBWSzBMTJZLGI74AcB0IBDQ3N6f29nbjoAL8V1ZWqrm5\n2Tqb8GwMAONzm5qaTASXKAt6irQ7aZAIlYiAXma3aoixBH9tbW216Mi95734Hd5XKtRfZOOUlJTo\nvffekyTrcGGDr66umgIQXFufz2fFODwy30t7Ip+/sbEz+bKjo0Nvvvmm/TzfjXcuLS1VOBy2lkgM\nBBHBBz/4QS0tLenixYuG0wK1UOSiD53Wwt/93d/V0tKSnnzyST388MPy+Xzm7LjelZUVTU5OKhgM\namhoSJL06KOP6sSJE2aouQaPx2PD0dwiAwUqRk5QfaYgsrm5aV0029vbun37tq5cuaL+/n5NTk5q\na2tL/f39Gh8f1/T0tFKplBYWFjQ/P289/6lUymZDuUWudDqtSCRihs9la2BMstms5ubmdOfOHc3M\nzOjxxx/Xpz/9adPbjUajWl1dNSeDAycy5XmxdzCmQGIYDTfjyuVylnkdO3asgDdJdrO5uTMrrKWl\nRWfOnFFfX5+J1sCn3ourQqIH815bWzMjj0N26wSwMHCWbrDBuXXPBxV87gmIy325nNLV1VWDmFxG\nDGeNzwaec9tm/X6/ampq7tqm3TPREgD5fD5vaREpDrPRiUbhALIRwT8XFha0vr5ulKmhoSHz7oFA\nwKZhcrD2pi8IVWQyGUtb8Ho8TFKQ5eVlk3tzIxkWgoKGtLNIYHVuuu5WRN1IkZdL6+A9KP7wHgww\nRQCiP66Zf6upqbH3u22VFRUVFumhUUq6Go/HraOjvLzcxjqzTh/4wAf005/+VJlMxoa3URh8+umn\n9f3vf19lZWU6ffq01tbWrJd9a2tLg4ODyuVyOnbsmHWrff7zn9fAwIDGx8ctCvD7/Uqn02pubtYz\nzzyjuro6Pf/88wUFyO7ubm1v74yhcTMQnh/X5vF4bK+41VyeMYUpninQCKn59PS0mpqaDL8PBoOq\nr683MfJ0Oq39+/ebs6+qqrICKBHd6OioyeK5kRXQSElJiWZnZy0lfffddxWJRPSJT3xCr776qhKJ\nhLxeryKRSMGoF7fbLp/P2yjrmpoaLS0t6caNG+rs7DTlfM4TBb5QKKQjR45oeHhY6XTaOqS4NnBU\nCmRMEqitrVV5ebmqq6vt313Yif2N8cawsi4wT6BW/aIMkEKZ20VIgc0dr+zSIHketJ2T5ey1Ozx/\nV6BFUgFrgGe693z+P73uCUYai8W0vr6uy5cv6/bt26ZowxiQUChkoTe9uuCngOi0vuGBKioqdOfO\nHVVUVBgpub+/36ZFUuHGGGH0+vv77f+gb/CwOWRgcnhdUi8XUOcwkRLPz8/r0qVLBV1LbortVupd\nTInP48CXlJSYQEt7e7tFmyw8ald8xtLSklWo3SqoSwNBL6C8vFzpdNqq7a+++qqJNORyOSvgzMzM\nWMrEJEuwTa4Dha7vf//7uu+++4y2w4x6j8ejWCymf/7nf9bjjz+ubDZrhrqvr0/nzp3TAw88oNbW\nVj311FNqbm7WD3/4Qz3//PMm9gzJXZIJgVCBdyOpqqoqO4w+n8+YCjiflZUVHTt2TE8//bSKi4t1\n7do1i4w4YLwXEY5UKmUjToAvPB6PPQsmmm5vb1t2hSFxCxxkMuyDmpoatbe3231NTk5qZGTEBL5n\nZmYskicj4T6Blra3d9gVUIyuXbtmaW1DQ4N6e3uVSqW0ublpUzOJ8imwusR7nA6GCMPFMyEIIqtx\nOZsUhdxUnvfvLYKC63JuuBYXS2Xf4kD2BiI8C1J9CkVkXm7bMYEQz98VMnEDLfffTp8+fVc27Z4Y\n0mg0qlwup7Nnz9oGRIi5oaHBpnrirfCEUKOKi4s1PDystrY281olJSWam5uzaNbv99til5SUmPcH\nK8FLUmWHRgELAMNK0cFNw3O5nHl4HjgbiQM5MjKiK1euSFJBFdGNUCUVpPt7/04qGggEVF1dbVVz\nrqmqqsqUhpB3o0URz+pGwcwlWl5etgIMRYzy8nINDAxodHTUIj4MIE5jdXVV4XBYN2/elLRbkGKz\n0o74ve99Tw8++KDhjIiYSNKxY8f03e9+V4lEQo8//riWlpZUVlamX/3VX1UgEND58+f1ox/9SLdu\n3TIsmPsiKnWnvpaXlxes80MPPaRUKmVSgy7HMZVKqa2tTX/0R3+k4eFhffnLX9b169d/LkNwW0td\nFgUFnIWFBWUyGaMk0UOfyWTsuzncLmuDfQylC9yTSA4njlJVLBZTdXW1ZU5uMQf8kFQf0v/IyIg2\nNjZ08OBBLS8vq7e3V8XFxZqYmDADlUwmNTk5aSR5Ktqzs7NG14Jq5+5J9jJNClwHwQJnhGIuqTd7\nEGNIuyiwj+vcOV/uueF9bvRI1MjP7i0Y7TXiv6hmsDdD4bxw7V6vV6dOnborm3bPUnuiNjYC2BWR\nA5sRIJoulOLiYiUSCaO1MB+G1Mnv91uLZiAQ0MTEhFU5ibwwksvLy2pqatLi4qI6Oztt3AQiu4Dq\nbrjvpoNcO4eMlJnIjZ9zvTCbxeWvSSr4P7w1ht3n86m/v18nTpwwBSKcB9V3V7WHqNgVQfZ4PAUO\ny+v1GjsCWgrqSdFoVKFQSPl8XvF4XJKMP9jQ0KAjR47ozp07qqqqMjoakdahQ4fk9Xr17W9/W3/+\n539uhw0pwJWVFT3zzDPyeDy6ceOGMSsoFt28eVOhUMiML8XF5eVljY+PW1RXVVVlcE8sFtPw8LAq\nKyt1/Phx3bhxw3RTEVteX1/Xgw8+qI997GP6whe+oKKinbEcFLwwHKyN25UEtxhnCLeTNmLwYK93\np22Yir0ki9ZJG2nzbWho0PDwsBU8JdlMpsbGRlPid/cbe0mSFU1dA8a+37dvnwmqvPnmm5axrK+v\nG0RFCyq4uNfrtYyHdtWqqiq7JjIP6IRcR1FRkWZnZ01LgYImz4oIk2iTojDPmagX2ANDx3dyNiSZ\n84eqhfHlWWAwXQiM78FJuc/QPXPSbh0DnPl/87onhjSXy9ksan7V1tbaiFtwSDwfIxi4ORTy2QAs\nHBVrKtNoDOZyOdOu5DN4eKjrFBcXa//+/TaGgUKEC45D2wCQJrXmzy79aGlpqSBtdxfJpatwENyo\n1P2/uro6eTwek2MjQmHkMH+mBRYe7ezsbAHmyu+k/Sg/kaaRHt65c0eXL1/Ws88+a1VV7sPv95s8\n4MTEhFKplKnpkDZVVlaqtbVV6XRa//Zv/6aPfexjBtvkcjkbFDc6OqqRkRF96lOf0r/+67/q1KlT\nmp2d1aOPPmq8TpovKioqbN5QNBpVWVmZ2tvbde3aNWWzWdXX16u3t1eXL19Wc3Ozpehu3/6HP/xh\nhcNh/cmf/IlNJ3WV5vfSiLhnWm7doo67bpubm4rH4xZdAZm4eKTf77d1pNkAnjTZGYUjon+aVdxe\nc6I6HDoq87ACRkZGtH//ft25c8ecJTWApqYmE6Zua2vTysqK1RDc4p4b1TFJleiMBgPGGUu7/E9o\nZtQYyBxdGhvv4Xxyfewxl3rkRpu8eC44SLBWt5nCLUBxZjlTLjWMM8GZ4+VmcP8bjPSeGVIEcSkw\nlJSUmLiya3wkWZVVkslm+Xw+81qkExSLJBnwzN8hOVO5J5VnQFwul7NiCxuFheFweb1e3bx5U6dO\nnSrgmrpYFYUYeqHdhWKzYPzdBgD3ftl0RAB8x8zMjHHicBAVFRVaXFy0IghpJ57fTZ+ocFOM2otd\nNTU1qb+/XyUlJRocHDTSvEtrkWRGYHZ2VvF43KrXGPampiZlMhndvn1b/f39+pVf+RUblzE4OKi5\nuTnDKqPRqB577DH90z/9k37jN35DwWBQ+/bt0/e//321traaIHdfX5+i0ajGx8d148YNLS8vmzBw\nJpPRxMSEAoGAJicnrW8ePPmTn/ykKioq9JWvfEXl5eWKRqOKRqMFkw6kXQdGFXdv5dhdy71OESOK\nIAbrV1paahNqcZa3bt2y9LSqqkqtra1GEaMOQDsjxsPr9VqgsBenxEB3d3ersbFRRUVF1mgxNTVl\nNYnR0VFtbGyY0hUTHHhOYIxQ2zCQfAcZENxRSXZtGF7um/nx1D14RsAlZExExJwDXi5BX5KdV54h\n2gRkgS432G1AoOhEBsfaUUQmAuZniXZdtbK7ed0TQwoHEq+PvB04B958eXlZnZ2dtrBFRTvD3jo7\nOy0d42ZJ8VkAjA+4x8rKilWy8bCkievr65qYmFBPT495NHA/jC6eEwgCjMr1pBg+t1tH2u2Q2BuV\nugUgjJm0W11ksYkGkbDDkXD9yWTS+rXBPcFJ8dYdHR1Kp9PmuPh3F9CngFNSUqLbt2+rq6urIKKH\n8bC5uam2tjbNzMwolUoZqZkCiN/v18GDB3XmzBlNTU0pGo3aGjU3Nxs/r6SkROfPn9dzzz2nj3zk\nIxofH9e3vvUt/cVf/IUeeeQRzc7OmsGprq7WiRMndPjwYf3kJz9Rf3+/EomEGhsbVVtbq+7ubs3M\nzGhyctIO6szMjP7mb/5Gt2/f1r/8y7/YNNDp6emCwW88cwymS/rm2biOE9FiusmkXT5rbW2ttSN7\nPB4TIeeg5vN5i4Ih78fjccXjcdsfbtGSa3APu7t3SEM7Ozs1/j8TJqA5UVMIBoOWrre2ttp7Njc3\n1d3dbfeMkLYLL9XW1qq2traA6M5Zo8CDGAljRVZWVpTJZIwbyz2RirP+yP+5E3BRBnOvAWjG5Tej\nYkXUyVkjAOLfGXwnFRpnzraL4bJHgclcQ/7LXvfEkK6vr2t6elrpdFr5fN6q5USjy8vLtpHhfILx\nrKysKBwOW5QFxkRKTWQgFXZLEH24kSvRnSurBkuAMRj0J29s7Ix4hkHAYhPNrK2tKZVKmaFgEdPp\ndMF1YcgxlkRBbhrBoeH6+C5UxMHcELrGw2IccU6Li4uWno6MjNi/Sz/f/gZxnFZIv9+v27dvq7u7\n++f60IkGSK/r6ursOiKRiDY3NzUzM6OrV68qm83q7Nmz+u3f/m0VF+/IEra0tNgIjcXFRd26dUvN\nzc0qLi7WkSNHrMgXDod1/fp1NTQ0aGNjQ2VlZWpoaNBnPvMZvfjiizbjnrG5jY2NOnv2rB566CH9\n13/9l/7xH/9RS0tLeuGFF0w0ZHx83Li37A03ncdhS4UdOPwMDiMQCKilpcWcKsYDiTtXY8HNBlyM\nzl37vVg5Bs2NmHByOF4Cj/b2dt25c6egxRNowOfzaXJysgDewelz76w9HGT2KVEizQ18J//n9Xqt\nq4iItrq62lTYKGLW1dWpvr5e29vbBtFx3giSkOGDusRZZTRMVVWV0QBJ6d01dKEF/o9n77I53FZx\nl5HDz5J5/f8itYdITlrIBoEKwSKFw2HDm/L5vCmO400xGqlUyqIQt9fWBYx5UGwSNhwtey7uwwbx\n+Xz22Rh4NiDRmZveE5FB16mvrzdnwWHkutyomF8uM0BSARUrm81qZWVF8/PzCgaDtumoxqMkToTK\nvCE2i9vtRTQNVcQdEAZuxwGMRCK2KUnxmYPU2tpqSvUnT57U/Py8bt26perqalVUVCgUCimZTOrx\nxx/XhQsX9Ou//uuamZlRR0eH4vG4beqRkREdPXpUAwMDOnLkiMb/Z9y2x+NRfX29qqqqbJRFOBxW\nSUmJfvM3f1Pnz5/X5cuXlcvlNDY2pmQyqUOHDumVV17R3//93+vNN9/UW2+9ZTDQ3Nycfa5byGAd\nXNoOBqOystKG2MFjjEajisfjmpmZKWgK4CBiHN1nvNdxuU7+F8ELOF93z/I5/GxFRYVqamo0PDxs\nRp/PwIhjtNxKNk7XdfAuBxoDwr1ApXOvl5dbnXcLyG7RCWK+2xLL2QSeY4+7302mWlZWplAopJqa\nGjU0NBRMMWVfk2HQQo6zpFkHNgIRbS6XK6A/wZogk3TX5G5e98SQTk5OWkWeKj3GJRAIaHl52SqK\nVOlyuZxisZg6OjrMaBEhMLAMagwejgNDZwkdF3gwMJOGhgaNj49ra2tnuiL0E0SPpZ2NH4/H1djY\naF0wbAiMH2Rl3geHkdEcHDSXlyqpwLPyuRxi19B6vV69/fbbVvXmPisrKy0a4nMg0bscO+6bNApH\nhGHNZrNqamqyQhUpfnd3t30umz2X2xke91u/9Vu6efOmvvOd7+jo0aP2+eCDzA6fnJzUjRs3FAqF\nNDc3p+PHj+vixYu2uY8ePWo4eSKRMKM9PDyso0ePmq7o8PCwDh48qMXFRZ0+fVqlpaW6dOmSdQLd\nvHlTP/jBDzQ4OKj//M//VCgUMooRxSXWExwU7VP2BL3YKDPF43FNTU0ZRxk1KJ6JWwhyMXv3GbuS\nb24EzLWQvv8ies5eR+v3+9Xa2qq5uTmNjY3Zd/DZbuESI0qU6/4ce4/vc52L62BcvBTDy3twFK4T\n4XmwV7gWngERJ3uPe3WdARkj1Kzh4eECByPJ9hn1CPivtbW1ampqUnV1tcLhsEEMCPHQeedGoEVF\nRVbcdmdM3e3rnhhS+pGpGpNOYazoyT569KgtJtVOiOC5XM6EeF2eJwvIYkmFosmud5d2vDoYELgL\nMn2lpaUFqQ6tju7Gl3Zl9Vy8jA1CUYdoFg+N98PAcZ2ut6dDB6Oyubmpd999V08++aQB/nStzM7O\namVlxURMcEIcbveQcx1uxI6H5t5d5oTbjYIzYuzxhQsXNDo6anSyxsZGcyRgTaurqzp27JjOnj2r\n3/md37GD1tTUpK2tLQ0NDWl0dNTGphB5DAwM6Atf+IK+9rWvWRZCxnLkyJECjdqBgQHNzs7qa1/7\nmiYmJvTFL35R7e3tmp6ettZWyPtuNZcDXF9fb2ns/Py8ycy5+wUOqbv+7EU3NYQF4BqRvWIf7t50\nK8VES/z73gi6paVF2WzW+K+k1ZwjN6XlxT5101icVnV1dUErM7CWx+OxtNs1ju6eIXrj2iSZA2Z/\nEQHyHGAGuP/Gvqd9mGfIZ7skegygtEvYR7CGa11dXdXExISKiopMtpFiM/hxfX29HnzwQbW0tJhQ\n0uzsrFHXSktLC5oUftnrnhjSmZkZbWxsmLKTK2NFvzWRJYs4Oztr87UxLIiSuF0M0i7twTWefD7C\nvNIutgIrgGFvRHL03RNRcBDZVG7LXy6X08GDB1VWVmaKQFwH2CsbGrqKJPOG0s9HJty/17szd3xr\na0upVEqLi4tGp8Hrb21tWaSczWaND8ugNxfv4UC5BoVe/fX1dVVXV9vwNI9nZ+xGW1ub1tfX1dnZ\nqYqKCg0ODlpRq7u720YJw1nEkEP9WVxc1IkTJ/T222+ru7tbiURChw4d0tTUlAmYHDx4UNeuXbNp\nCFVVVXrnnXdUU1OjZDJpEQKCHYzrfu6559Tb26uOjg6FQiF99rOfVVdXl1Vfl5aWbHIlkairYwnU\n5EItPC/XQfP7XloZL/f9ewsVRKFuUcT9fGAf9zP4TNego/IvFQ595HN/0Xdzne59sF/gyLIfaEMF\nq4SSuBfHpwK/twLu8XgMx5+bmzP9CxdOczMsaFJukRe2jKsfTETM9zH8jyiX63fv3XUcRUVFdma8\n3h164quvvmqZcC63Iw/Z0dGh2tpaNTc3/3+/au+KWrjUIYwmHkPaTScTiYSOHj1qC4U3jsfjVqEm\nlWQzuJEnEabrCTFg4KSxWMwmU2Jk2NzDw8P2nRhzNw2j0yibzVp0hZHn81dXV23jU10FK5UKdUqJ\nQNmgpO3l5eVG9aEZgD7vxcVFm6hIdJlKpQquUyo0DlwP0f329rapvZM2eTwe9fT0qLa2VpcvX7ax\ntxQIUTOiINfS0mI4qptxNDU16bXXXlNfX5+qqqqUyWTU0tKi9fV1i/SIkDo7O3XlyhUlEgk99thj\nunbtmoaHhzU9PW1rvbW1pcbGRiWTSYVCIfX29uqTn/ykGhoazDkzYx2hDbBtt/uG/cGzYD+6FeG9\nabhUmBa7z9U1WKS+7BH30O+NRDEaZGdkK26U6nY0uUb4/2rvXIPjvqu7/91dre6r3dVdsmTJlm+J\nLcfEScBJIUADhDaDKenwjhRelHaY8qbtdIZmptNp+6LDUOgLhpZ2Op0BQilQ2kK5DRlCmotDSIiN\nbdmyHUuyrruSdqVd3Sxpd58X28/R2X8ccMfPjJ55Zn8zHtvS7v/yu5zL93zPOUEh4oW8j/4jzBBc\nFKFh37e2thqmCdYKJxtXGwyZs+tJ/aFQyM5ja2ur2tvbdf78+Yp54x2knSBnLBbTfffdp4mJCS0v\nL+stb3mLJiYmLGDmITHeyXtqUmUNVOYIvinQhg8geiscpXDx4kXDWNfW1vS7v/u7v1yY/c/YFUHK\nAZZkG9sPotIAyXNzc+rq6jLNiHVHPj059/Dc4N95rInh09ZwcXBHaDxGoQ1/eCA1+0Z53qUCh+P6\nvigDGRngZj5ggHWA9kOZ4F5D+UCQRiIRvfDCC3rggQcUj8ctBRNBSj1QXCq0rc/TlnbqBnjsDUu7\ntbVVZ8+eVWdnp37zN39TBw4c0E9/+lNls1nD6ChPiHU0MDCgq1evanFx0bBiPodQz2QyevDBB3Xp\n0iUdOHBAy8vL6u3tNXw6nU5bQIfSgfl8XtevX1c0GtV73vMefetb3zLvpKamxqr6v+td79I//uM/\n6p3vfKdu3LhhRVAoyN3W1mYejJ939oF3f73g8VgiIygsOcxewPr9FsQ5/TnwASL2FfnrCIhbCU/+\nj7BGEHvhjqDhvgjmIK65vr5uXR0SiYRRmzzswDOhcJkr9oNvAxIK7SQyrK6u6h3veIfGxsY0NjZm\nkJb3Epmn5557Ts3Nzdq7d6/hlffff79mZmY0Nzdnxat9IAjF4L1RsG/veSFvwMJRkgR0fdxFktG+\nbnfsiiD1mKjPB2exEZgsOulsWIRes6ysrFgfdiJ8CARvDfE3gkWSWXsQybGUpZ1K9ERlV1ZWNPg/\nbTlwR7Bsgq4ZBSqgZHA/rCgsC4/d+uhvNBrVoUOH1NXVJWmH5cCBmZiYMAuLmgItLS1mkfI8PntE\nkgHpWDj+gHNICcB94hOfUENDg65fv66/+Iu/UE9Pj7UlBqfiGqRhkh45OzuroaEhLS0tqVQqmQUv\nycoQgvHW1NTo0KFDGh8f19zcnFpbW3Xt2jU9++yz+uAHP6j9+/crn8/rJz/5iS5evKgnn3xSn/vc\n53T16lW1t7frxRdf1B/+4R/qlVdesWpWiUTCqsl3dXVVVBeTdizDIF+R4RWvT1rAag0KX/Z0kC/s\nk0u8gvTY+pt5I+xDrifJGCMeqsHl9Ti+fw4Eov/bR+B9QGlpaUnT09NW04GSe1wXaIUoPgqE60iq\niE2Ew+UOphsbG9bB9cKFCxWBtm+/QAAAIABJREFULM4qP8vn87p8+bJ1uaBkZm9vr/L5vG7cuKFc\nLlfxnj6bCS+SKD1dHgYGBqySFXMFwwejIBipD0I3v2zsiiD1Gw2aCYIHTeEFJQIDQbi8vGzUGm95\n+sPBpvfAPeY77pO0UxmcBnJYcWhtNjiRQYSot+gQgFQ8IoPKWzcsEgE2/yyeMFxXV6eBgQH19PSo\nVCpTQHCNJFlwJZVKqb+/3/rv8O4UAw6FQpZZwnP4+fUH2lup7e3tampq0szMjH7wgx9odXXV8u5H\nR0fV3d1tz+6F8erqqnp6epROp1UoFKxmazqdNr5jMpnU0tKShoaGNDU1ZV1I7777bk1PT2t+ft5w\nXagta2tram1tVTKZ1IkTJ/TNb35TH/7wh/Wf//mf+sEPfqC/+Zu/0eLiovWFz+fz6u/vVzKZ1NTU\nlPL5vPVqQhDhiqIMONSsE+vOXHnLhr+DVmsQ6/SMDgSFF2Ze+Pn7IZi8ZemtWoS6378eQ+V5/fPw\nmeC/ERT19fVW2YmAzNramuLxuOGnXJcsQKrze141Hh7eEMLRc8FPnTqla9euaXJy0r4jyWh5vDvl\n8s6cOaN4PG4p0EePHtXNmzd15coVS/v2ygrrmWchBjMyMqLh4WG9973vNSW+sLCgq1evKpVKWXWs\n+vp6q1jmg2i/auxaiiiWHdqXyBwvD/6CW89hpKNibW2tJicnzWVGIPE9/h2Lxd5A9QimfQIjUDWK\ng4arPjc3VxEI4KAQ2QOXlGRE/lKppI6ODouOwgCoq6vT8vKylpeXLTMIdzMSiejQoUMV+etXr161\nyk7STt7zxYsXdejQIQsIkM9O62QsxUQiYV1bfXAiGJCg5Uo2m9W5c+csrY90Vzh94+PjVizEW+Gw\nKOj/hAAjcov2J/89lUpV1EwdHBzU5OSkHdRIJKKRkRE99NBDmp2d1YEDB3TlyhU99NBDWltbM17h\nXXfdpX/4h38w672xsVGxWMw6RFLlCPYA+8wryqDw9NYmgs3vIf9/LES/t72l6g940Br084fi98/g\nv++xUPLNfevtoAECcwVhFSSe80wwYTweS80GAsIIWizTra0ty0rirPp6uPzfR705B9vb2zp48KCG\nhob08ssvV6wD18dN53fESAqFctU1mv3NzMzo2rVrxqGWdnLqJZlARznMz8/rK1/5iiTpfe97n4aG\nhoyFw/utra1penpa169fr2g/86vGrgjSYAaGz6P1QR5S0ijXhqZik83OzlrVIVxlCL9YTD6bxG9e\nb1WQDEBFcaK7UIKmp6cr8o8lmQsvlTcxVYwg8JdK5bz7F1980SwTD7LTOZJ6lJLU3d1tgaKmpiaN\njIxobGzMNph3F0dGRnT69GlzgTKZjOLxuBXb9WRjClyAZxHZB0ZZXFysIDhT+YciJOPj4yZIX3vt\nNfX19Zk7hOsulSGIzs5Oy+4h4kumGve+efOm0Y3q6+u1sLCg/v5+y5PncC8sLBhU8Za3vEXXr1+3\npIMHH3xQjz76qP72b/9Wzz77rJ544gltbW2pt7fXhATYHevmuYMeY8Ra8ri4h38Y/nN+n/oAVZD2\nxLWCnGHvkks7RVFuJcyD8AO/86Xngtf3mVS4un7vEuz1RbG9d0fCx8zMjGKxmBkFQE+4+gheOgBw\nD0+X47m2t7ctJ35zc9MK1NATLegtRSLlVN319XWzFhcWFoy1Mjg4qEceeUSzs7O6cOGCFUDC+/AK\nQyrTLiORiLq7u/Xyyy/rq1/9qh544AG9+93vVqlUMkhu3759GhwcVCwWu22ZtiutRoIbWpKVIaOn\nDMWbIXQHTX4CTh5j9O0KpJ2uhXyWRfb3ZwM1NjZa4zc2NfzUyclJ23Q+AugBbGhM9KKKRsv93ynJ\nh0XoXfTGxkYr+ktXz2g0qmQyqVdffVWTk5P2bmwGFMbKyophkAhu4AYv8NfX183Kl8rCrlgsqq2t\nTQ0NDVpfX1dLS4sJ/lAopLa2NhUKBSUSCXOt5+fn7dDBBEA4+cNBUgMKCXCfOWWAlXqMlZKBNH27\nfPmyubGvv/66mpqaNDQ0pO3tbQ0PD2t+ft7qz/7zP/+zUqmU0um08QHJc29tbVVzc7OVpoO9AS+V\nf3t3mgMdDOJ4gYdg9Tind7NRZP73/mc+0BT0EBhBgeqhK/aGpyLxHTB8lJ2nR3HefOERrgU8RSsT\n1nt8fNyMBFgorCuCDo4mBkNtba1ZrbwjCgrOaF9fnx555JGKz0Fb8+mixWLRUlXhZf/iF7/QmTNn\nVFdXp/e///168MEH1dPTY7RKz5dGsEuy9OSDBw9qfn5en/3sZ/XVr37VgsLUoiXAeztjVwQp/DWP\nHYVC5You9IpfXV3V4uKidTBkA0HFYFLBTRGiQUvDl7rzgtTn04KZsLi1tbX2jLgVCCPvhpETLu1g\na5DRgSna29sNRyKby3MJ9+/fr6GhISOv19XV6b//+78tQML7eJwuFCqnTtL+FzjCB1MIymUyGTU3\nN5vA2LNnj5qbm7W8vGxVf3yRB6zZbDZrhHkELvM8OjpaQZKmsRx5/OC76XTangm4BNeU58ViWVlZ\nUWdnp1n3xWJRhw8fVj6fN+EKM+Hw4cPav3+/fvSjH2n//v166KGHtH//fn33u9/V2NiYlUZ8/fXX\nVVNTY4crmUxaYNILSc+i8LgxCte73z5A4wUcw0fV/X70VrC/RjDgEhzexfd722OdKDQfoOKZPF2P\na0E3Iu7gr0dCAnARc0D/rOvXrxsUh6dYKBTMwyL3HsMoFApZ/j334roewnv00Uc1ODho88C7+bJ5\nwEDsG4TqhQsX9OMf/1jb29t673vfq0ceeUTxeNwwXOIYeK4UZ8nlcioWizp69KgSiYS++MUv6q//\n+q8ti+1/E2zalQr5X/rSl+zggk90d3dbpgUHuVQqWXCDBVhZWdGePXuMYE32TyKRME0UDocNHwmH\nw5qentbg4KBZblhRCFuoG4VCuSwd2Mz29rYmJia0uLiooaEh4256NxC8F1L/+fPnrUhxJpOpyNVH\ny5ZK5bze48eP2/s2Nzfr/Pnz1kUSjV8s7mRuSbIGXa2trQqHwxoaGrJgD9b1zZs3K/pRsZEHBwe1\ntbVVIeCwVH3Aa3t7W7lczrq7Mqe46GNjYzp69GgFfw9BSeYKyQscKGmHsE6BadxGft7Q0GCBpsnJ\nSW1ulruGUkilqalJqVRKDzzwgEZHR+2gYFlGIhG99tprunDhgt7ylrdoampKuVzOslxwdWtra28Z\nyZdklpm0Yyl6hY9g8UGiYMCIfeeFFJ/xlqgfWIX+2kEB7INaPKv/LLh+UNj6YBpFejA8vNBiT6+v\nr+vAgQO6ceOGXRtDIJvNanFx0Xoo+eIhnAVvDeNBBQO0nrECVEAblHQ6bQEj3on1YPjUbIK08/Pz\nGh0dVUNDgx577DG1t7crk8lU7G0Ps2GtQ3s8ceKEEomEzpw5o6efflpzc3P6+Mc/flsybVe7iLLI\nNTU1SqfTkna6Z1KeTdoB5qlWXiqVdPnyZdOIEMTpcsh3yI7wmFawlBnWEcLCW16lUkmzs7Oqr6+v\nIHlvb29bcYRisWiEbzSzB/LRhE1NTRZ9Hhwc1JEjR0yrT01N6Tvf+Y4mJiZsw4K/0k/KH8h4PK5o\nNKqFhQXDdcC04GuS2ppIJBSLxdTY2GjRUn+QERocRGAQuLT19fXW5sOzJObn503be+yOz3d0dCgc\nDld0aPXUr4aGBiWTSatKtba2pmg0WtFrKBIpdwbAkigWi4rH45qbm9PZs2cNkojFYjp06JCOHz+u\nkydPqlgs6hvf+IZRsVACk5OTFf2U2H/BNE0f+LmVxRd0xT2cFBxc0wd7gq4+OKYPZCG0vfvPOv2y\n+0g7qZv+GQm+YjEyp3h0lKVcW1vT8vKyeTTSThYTz1MoFKy3lM9+IjpPmiXCCjqjJAsUcx2EOAZO\nOBzWhz70Ib397W9/Q2COs7q5uWnuN54pmH9TU5Pm5+f11FNP6fXXX9ejjz6qd73rXerv768of8mc\no9hqamo0MTGh1dVVfeADH9CDDz6o6enpN13X4NhV+pOP1NHHvr6+3to0kwOPRtraKlc9h1oD/hYO\nV2YtoaXQkESqoULhTiJ8WEAOO9hRNBrV7OysWX+hUEiZTEaFQkF9fX2GAyEApJ1WtZ4SwkGrq6tT\nb2+vWaCvv/66CU/v1iFwQqGQ0YdqamoMu4LsTuk2AgAEr+DDUrloenraUj+j0ahZPwT8/Gbmb64H\njYiDIpXrB1y6dEnd3d22np5TGovFjMC9srJipHnI+fX19VpZWVE8Hrdc6LW1NSUSCSsW093drfHx\ncS0sLGhpacnamgwNDenMmTPq6OjQ/Py8+vr6LFiYTCbV3t6umZkZrays6PLly9qzZ48R/6Udmg1U\nKR9g8vMv7ZC7vUDygs0HRryrz+eYT7A5PCJPG0OYeMHCtYKZOt7t9VZpkIWBl8W+YJ05a7BHfJAM\nwcLeAI7id1i63spMp9PKZDIaGhqy/mlYl6QYQ5MCO/VcZl+j1MMl8/PzGhwc1P79+/Xtb3/bMgKl\nnSQAhCDuvv8Z0f1isagXX3xRsVhMx44d0+bmpq5cuWIZeJwFLFPW+uWXX1ZjY6M++MEP3rZM2xWL\nVKosmNvW1mZUGaw9ypYRsKCYbE1NjbkWFGzg4LNxMOE9z417SqrA6aSdhl5oYShPtHsmwwG8kNqW\nPj8bfIngDsIZ4dPQ0KA9e/YoFospnU7rmWee0ezsbIXrxcH0c0Ox3M3NTWv65t99aWnJ5jQSKdeT\nPHr0qLEZrl+/rhs3bpilKN2aokN02wczCoWCuru7TUDiYsdiMU1OThrtyxO+aYAnqSKI5Q8A1j+N\n/bCe19fX1dzcrGg0alDN2tqampubrUBLLpfTP/3TP2lmZsbWoa2tTb29vcrlcrrrrrt0+vRpdXR0\nqFAodz0Ih8NG9qfJG3vMu8Fe6TEvwT/e+kbpMPz/PT7qDzi/8xawt1iDP7/V8HiufyZ/ba7j6UWs\nwc2bN63BHYI+uO6kH6MAfcDGP/Pq6qpGRkb00ksvWWEhr+yxHDmbnh1CU0L/LljJROc//OEP633v\ne18Fno1xREGdmzdvWuILc4YXgQF19epVTUxM6L777tPJkyetToOvM4BnguJ7+eWX31R+vWFNbvuT\n/xeH1/i4ch6zyGaz6u7uVi6XU6FQbhiWyWRsYki/RNtSVNhrcK7vNxQa1UdqEZxYkWjU+vp6jY+P\nG4MArI8NwIZAcHNvcoeBEOrq6rRv3z41Nzfr4sWLevXVVzU3N2f3C+KHWBdw8bBi6KMej8crerRT\n0q1YLFqHykgkoqtXr9p9JFXkRXPwgnib36i8J24Pc4cFUSqVND09bS4kAa5wOKx0Oq1IJGJ4ru9W\nyed5v46ODuVyOYXDYVMKyWTSqFR1dXVWnzQSiSiVSimfz+uFF17QxMSEJOnatWvq7e3V2972No2O\njmp4eFgf+9jHdP/990uSuZpzc3MaGBiwFhe8G3i5d/c8nehWGKhfM4bHPxGgHi5gBANVuM4+8MVn\nvNvPmvln8EwQ/0zeu2APBylBm5ubb+hlj8CDdsj3Cfh5vB/hL5VTQX/+85/r+vXrFV4h60yHBTwb\nvAiwVs4+ApFzOD09raamJn3yk59UX1+f8WMxVmAM4OZD0ucafs5CoZCef/55nTt3TidPntTJkyfV\n1tZmsRXOFAYVQvZ2xq5apNIOzQRLb2lpySaLLCZJxlPje1iDaMkg1iVVFtMlQkd+tm81AVWHPG9w\nwhs3bqiurs4EIymf5HFj9SIIyLfnfWABPP/88xodHa0IXnh3jeG1MkLLR+uxyH2WFwE4cKNisah0\nOm1YoFR2xbPZrCkwz1rAYvEHj8FG7+rqsuARPeNpSEe7F9IH8R7g9DU3Nyufz1dsdgZCHzoV71pf\nX28tItra2pRKpRQKhQz/pRj4yMiIHdzR0VFtb2/roYce0ksvvaRcLqejR48aZrq9va1MJmNUNpIW\nWltbLdjo3Wc4yKyT54d6AYrA8N8NWrZ+zb3F6oWuv2bQ8uW7wWybW1muQSwVYcDZCGKsHlLwPwMn\nZS+CKbPnpJ0AmX++S5cu6ZlnnlGxWDQaHAJ6Y2ND8/PzBqcg3BFeXgF4yzqXy2l2dlaPP/64fuu3\nfsu8AZ4DfJc/CNhg3dFkMqmDBw+qublZL7zwgkZHR3Xq1CkNDw+rq6tLnZ2dFZXZ3swjuNXYFUHq\nFxmgmih1JpNRd3e3CoVyg7xUKmWHCkGFoC2VSpbJ4i0MzHM2fzQateyGuro6wwpxOXEnEFxYimtr\na1ZejsOFlQU9BOsNt5NDRKJBqbTT+oBNfqvDxsB64f7+4EGPYqOB7y4sLFjPH6KUNMBjjuhIiRWO\npYNAZbMVCgUTdhSBgdgu7ZT9i8Vimp+fVyaTMYpNLpezojF8NplM2vzD60Wgg1ExX8wZ1mwoFNLg\n4KBmZmYMEiB4BCXn0qVLymazKhaLVmKOnvN1dXVWXg9Xk7qktbW12rt3r7WFCa4LnkEw+u3nyrvu\nQcvRr68XNv4efMf/8QEuf1Yg9Xvj4FbuPwKN+ZL0BiwyOG4FDZCZhlWJUeAz/vyzkJEmlSmA3/ve\n9/Tiiy+at8az1tTUaHl52bBJ2pF4/NVb4wjcmzdvamJiQnv27NEf/dEfKZlMVgTV2D9bW1tWLHx7\nu1wOkL2XyWSUy+XU0dGhPXv2qKWlRWfOnNHZs2d17733GgOGdud+Xn7V2BVBirb3WUnRaLkHETnt\nVDx68MEH1dbWpnC43EWRBSa9EDI3uA6Cgk2E8AMDhfAfj8cNdOeARCIRKxz8s5/9TKFQSMlkssIS\nlHY2G1Wm9u7da6X7wHTZAFzfu4ceB/M0DmnHNeP/3gKhqpIky/SAi+dbVm9tbVmDNmlHYKGMeBY2\nis/vBmbB4i4Wyy2hwcywhHmXxcVFLS8v2/sXi0WLdra1tZli9IU2OHC+zgC9l9jEpVI5Y6qzs9MU\nxszMjFpaWnTgwAF7lrW1Nb3yyitKp9Pa2trS5OSk7r77bhPuHR0dGvyfLJVQqNx1YHV11WqpUpjD\nY9NSZV59EMdk/nzQ6FZwgFeKQUvWC2auw1xgDPj7+2g+7rl3671wDoV26j/4Z/T7iftijfqgl6cl\nsvd95N5DZXiUnvjP3M3MzOh73/uebty4USFQYdJgePhgFMFISRUF27EU0+m00um0PvrRj+qJJ54w\n+Alh6hW+x0+hyK2vr1vR7kgkYv3Gzp07p7GxMb3tbW/TY489ZjLpdseuCFK0PUEHrA9acoCNUBCY\nfkVUsi4UCurp6THhiEXjCzGzQGA93h0B9IY+5TEaBBEFh8FBeUasOKwG3MLg9aWd1FMP/gfxLQ9H\nsNHYGFg6fJbuAATo4KHituOChULl7CS4pcVi0QqReKvGU27Ap3g3Dj3zQuDIH876+nqrDwpmzLWW\nlpasqDQJDv6gIYxZA3id1GDwPFrWOpPJqLGx0fpDcZjX19d1/vx5ZTIZgyoOHTpkAvPee+9VT0+P\nFZxBGY2Pj1tA0g8vPIPusxc+wREUREGLVNpx1T3m6QNxfN5f06du3ioo5qEHqZJZ4K1bbwUjFIM0\nKZ7fB23Zs0Fh6p+Ra3grFa/hpZde0g9/+EPrCksMgnq5pP3SUZQYCIEorEsUBK2+m5ub9Qd/8Afa\nt2+fURNLpZ2OpV64rq6umnXKvoAN4CtNUY/09OnTeuc73/mGNX6zsWuuPdFdBFVNTY0mJyetG+c9\n99yj/v5+5XI5s0gRomBbaEIsRa/R+UMkmcVgo9BvG3yTjew3jS/gzL3RbhxgX6A5m82aAGDReUap\nMjuFRfdBJm9d+IIPRLh9Hvzm5qZGRkZ07do1E0BeKVFIGqFI8RYfSUUg+HnhGRmxWEyFQkFdXV0V\nFiTrQK8oAj8IVW9x++6ktxIC4XBYqVTKAoFAM+3t7QqHw+rs7FRtba0WFhaUSCQqsm6AA9bX13X5\n8mUtLCxoe3tb165d0759+yww9573vEf33HOPfb6np0eLi4taXFysCJwEgzfe4gximUFIILjH2VNB\nb8T/3isy760wvJAKWql+LhHwQQHOfT2cgwvMfmZPe4u7oaFBq6urJpB8JqBXJkHh7RWJn9Pl5WX9\n9Kc/1auvvmpzsra2ZmnB+XzePEkUHgLVF4XBkMBVn56e1gc+8AGdPn3aeKI8L+cTXBdvEZffp5xG\no1Ht2bNHR48e1cjIiH784x9bG/HbGbsWbMKSzOfzqq0td96cnJy0vj+Li4t67bXXTJhyyKjs49vA\nsnCQ5NlkWFP19fVaXl62Ir8II6LcRC6xqMbHx21BcW2wjtDW0WjUrsvmwqpCiFPpaGur3HjNWxy3\nisRifXgXkXeLx+Pm0iK86KyJG4PgIkLqC3bg6iJ0uSe4sA9GhMNhq/DDM7a2tlZU+OHAslmlnXJv\nVKICG6UtNCXWPJ5YV1enRCKhlZUVy/WHRgamCv2JakRYKggBniubzerKlSuamppSPB7XzMyMVaqq\nq6vTqVOn9Mgjj2hiYsKezQc2WAtvwfn18pa6H97KvBVm6TG/4Jr7+/H/YITfQzH83luRXNvjix63\nRVj4Z/SBTy+smQssRyw6BJDnunrIgvcKJo94pVMqlTQ+Pq7vf//7evXVVysi9kG8HmyWs+bLBko7\ngcqVlRVdunRJiURCn/zkJ3Xq1Ck7e7Rqx3DAml5fXzcclf1PJ106FScSCfOQb2fsiiCFP4Z5j1u/\ntLSkwcFBNTQ06PLlyzpy5Ija29vNaszn81ZVKBKJWHoowgcqBJoQDmd9fb3m5ubMSoOj1tbWpv7+\nfhOoBCHgXXo+aigUquDWIaSIPMLpZBNweH1edy6XM9eT4YWX17z8u1Ao6Pjx43rkkUe0sLCg9fV1\nS39FuLCh/PNubW1ZzjpZJqRgUivVwwgE7/g/gTnwK8oMAiFw2OLxuFXVCZZGXF9fr6Dc+K6ovB/K\nrrOz05QSz4tFRxZXNBrV9PS0IpGIDhw4YG4hWBjsgampKcuUQ2gybydOnNCTTz6pTCZja3wrS5AR\nZDKwZlJlibug8EMoeKXDPHihzfW8sLwVpBD8DD/zAox7e2HkrUwvxP3/2Xs+hhBM1GBPItT8XmUQ\nG+Cani/MO6Mor1y5oq985Ss6f/684fD8jniHP4PemPHwEzhuKpXS6Oio3vrWt+rjH/+4CVriJ2QL\noshREOvr69q3b58WFhaUzWYtKB2NRq2I0e2MXXPtybFOJBIKhcr0lYMHD6q3t9e0wp49ewz3whWA\nRAtOiDXi83jZJN71QqOyKYju+l7WaK9cLmdWr6doYEF5l81DAfPz82bN+ZxniiuXSiWLICKQceE9\nPgr1qb29XR/4wAe0Z88ejY2N2Xve6p3AhSSZQGloaLAoPi4/FjXWmMe0pB0X0VtPRNJ900Asfrid\nKBeCdT6dj+cFi8QqBqNraGhQW1ubZmdnrfoQlBZgmGw2q/b2dg0MDGhra0sf/ehHrbYrlhIJB1Qr\nwl1EaLJv2tvb9alPfcr2no/OByPYQSjCD2+J3soK4729i+2t2lt9/1b3DlrJBHh8Vhbr6ulxKFuE\nDQEfz9sGH8SwQbGFwzupq95q57tcxwt3oDQfLEOpcBa91VlbW6sXX3xR3/72t60QDnxt4CaCvUCA\nJKMEmQ2c0dHRURUKBX3iE5/QqVOnTNYAFSBA2ePk1hP44vec39sdu2aREoWrrS23yshms+rr67OD\ned9995kQoyshQgzci9YdQZcjiGGxybyFxEQhSCWZe4724zlpscEGrampUXNzcwXOuLm5ad9FOLGp\nKBCBu8Qm8YfEZ6BEIhHt27dPb3/727W0tKSpqSkTZj4q6zcxjAHmlL+p8NTf328HwFtLwc2CS8UB\nwPLc2NgwnJTvcVAlKZ1OmxUK59C7jOCYRGyx6GtqatTZ2akrV67o7rvvrpgLqnxhpXL/2tpaxeNx\nnT59ugL/5RDU19crk8lYw8K1tTXNzc0ZxQ1I4nOf+5zVMuBZbmVp3UqQerffY6RvJkh9sCooSINQ\nQvA6wc9gJbIH8Hy8IKWOA0KI/YNCxEhoampSc3OzCVMMAe7p8WMfiIK77d8t+G//njB1OFvgnASk\nnnvuOT399NNaXFy85ZkiW8rn6nt8HwVFx4gLFy7owIED+shHPlIRKOUMFQrlrL2FhQWFw+VC2Chw\nT6m63bErgpSq1KRvzs7OKpFIWPCnsbFRXV1dymQyxvMDL5FkVh28SJ+bjkvjhRTajBx7Fmhra8sI\nwris09PTRqb3KXG5XE5ra2uWqopw37t3r8LhsFW999FLFsgXpi6VShV1Fvksf8fjcd1zzz3q6enR\n9evX9fOf/9yEq+fj8U4UBYEK5A8YVfmj0ahSqVRFhSagEK5HrQLvCrLhmLvW1tY3KC2pDKHMzs6a\nhe0tEP4moMG7kD1CvdNIJKJ/+7d/M2yX+wwODioajWppaamicV0kUibrf+hDH9LExIQ9C/hXoVBQ\nNpvVyy+/bIJycXHRcr9LpZIymYw+85nP6OGHHzaF4OlmjFtZjMGfw0Lwz+fdfoQQUXDcVPZtEGph\nXXzwhnt6Bei5l1j/CChpxx337xYUTLjga2trBoFIO9xQH7AJWuw+UMY9wGz9ZzwkwJniO7w77W3O\nnTtngUn2ONWgfHYjZ5xAK/eNRCLq6OjQpUuXlEql9Nhjj+ntb3+7PQs88Hw+bzKGd/S4sE8e+VVj\n1yxS0h8jkYiuXbumQ4cOKRaLaWxsTMPDw2bZZDIZsyS2t7fNRfUbjAVG23gwHEujWCwa3QELByFE\n/cW1tTVrZYLV2djYaG5wLBZTc3OzcSzJvAJzYfOTSodW9dkSwcXHmmhsbNSxY8c0PDystbU1vf76\n67p27ZokWY1WbyVub2+blccmQOmwYcEXya0mcQFskywQqGNeoLOJGdBSUH5Bjh2Boo2NDashyrV9\nEAVhWiqVDLfd3Nw0OtreyGmXAAAgAElEQVTc3FwFzW1sbMwa//k5ZqMnEgkdPnxYc3NztvFXV1dt\njXK5nM6fP69Sqcx9BGtl3nO5nH7nd35H73rXu0zReGGKAmP8Mnc/GMDx1ifDW5d8xgsk1sBfg/vy\nN8JU2imEwu8IvjH3KGyuhzWIy4+XxZyy10kf9RgpljyxCE+vQoEj1Lmmt2KDhHveD4XCHh8bG9N3\nvvMdjYyMmHsPtIeSQhng/Xg3n3U9fPiwotGoxsfHtXfvXn30ox9Vd3e3FfBZWVkxhU56qa8q9f+8\nRUpLj2QyaUGSUChkvXV6enrMpcMVy2QytlieOsJisAh+cbxrgQWGQCXizaaKRCJG1CW67AM7YHBE\nxCG7Q63C4iPKjzXnawl4egqHtlgs8yQPHz5sQvrGjRuamZnR9va2EolEBe2mWCwarFAqlazKDlYx\nwgQBBcl9ZWXFslNCoZClbbIJvRWDa8N7ABNsbW0pmUy+gUeJFYXl4NPyuJ7H9YA6NjY2FImUkyAG\nBgZUX19v+Pjq6qqWlpasQtfq6qrm5uYswLS9va14PK4bN27oscceUyKRUDqdth5Y4LOs689+9jNb\ne/YZh3JpaUmnT5/Wn/7pn1Z4NF64BV1t6Y191Pm9txb5vcfA/Wd99J7BPn4zge0DlAjrYH1R/xw+\naORxcu+iM2dYyijdYEDMU+SCz8G9faSdP34efVzB720GZ/7ChQv62te+ptdee001NeXSigh5IJjm\n5maDJLDs8Q4ymYwOHDigffv2aWJiQsvLyzp9+rQef/xxTU1NVXgMnC0MLM9GuZ2xK4KURmuFQkFz\nc3Nqb29Xa2urxsfHdfDgQbM8IeOjBRsaGio0Jpve54t77emDIkADWGnRaFRzc3NaWFjQ5uampqam\nzJIJhUKGHaEJuS8pkr7qUSgUsl7q0LI8HcVHq9lQbLATJ06ot7dXbW1tWlxc1E9/+tMKPCwej0va\ngQrQwrhhWNhcG6HKz9vb260FbTRarqqEhQ9EIakCd+JgcA3vind2dtq7eUFTV1enkZERy13f2NhQ\nXV2dHQofbUWhSbK1JiBAq2k+J8kSCXK5nLLZrMETwD8TExN64okn7HmgsVGOkULhv/jFLxSNRpXJ\nZJROp03Qwa09ePCgPvOZz1Rg0G8mzG53sB8J2HjB6RVSkMR/q/v652F/e3ycNeR33NdbsKynV+75\nfN6sTO/eUlcChRpUAh5m8Psh+MdTj7y1Fwx0ekXAe21vb+vMmTN66qmndOnSJTtfBCJ9rAPrmOtu\nbW3p8uXLSiQSOnHihDKZjMbGxtTb26s//uM/tspjnnLI2cE6v92xK4IUl46KRu3t7WYddXR0mCtM\no7tkMmltfslKQZiSD873PY6GgCHI4t00YAMspFwuZ/U8EX64FJRbk2T1UKEdgS1By2JDBQ+MhyOi\n0agGBgY0PDxsUdJnn31Wo6Oj5opz6OjmyeYgYpnNZk1jIvR4Z2gfPusqGo2aKwMvk2BUKBQypeXd\nTp6X+cIKxFNgTrBoVldXTSjx7jwTcACQA0IEgYlngntFtB2ByHeBX9LptMLhMqUqm80qm83qT/7k\nTwzfRhiiHBGmZ8+eVUdHh3URQKHhhbS2tuqv/uqvKhI9vADxfxBczJe3Mv3PvBUWPAd8LuhGBq1f\nhFSQfsQ+YeBdeWs5eE0sS9I0/flhnYrFogV42aMIUxQrUBr/J4gFxOAL1YB5AxngLXhmDfdHiXmD\nYn19XT/84Q/15S9/WSsrK1YDY2trS21tbZJkjB5PC5Ok0dFRra2t6cEHH1RTU5NeffVVzczM6Nd/\n/df1xBNPaGFhwYSpP6NBQf/Lxq7RnzY2NrS8vGzEd4r0EgDB6vBuFgtHQQ4OABaOx4JYBCKPtbW1\nFtVmAGSvr69rdnbWNicHjEX17guCl/JgWMxEF3k/DgZ4JMojGo3q+PHj6uvrU01NjS5fvqyXXnqp\nwoKQypYaAo+f8xxra2smeHwd0VConGmEhmaeEVC5XE6tra1vcCNp8hXEAoP4GLBFS0vLGwjSHKyb\nN2+aa04CBYoB64HreipMMplUd3e3otGoCUkEMwT7UKjMMyRRYHl5WT09PZKk6elpLS0t6dSpU1Zt\nn8NAoDAWi2l1dVXPP/+8mpubdfnyZcPpCb6QTPD5z39ePT09txSm/r35t7cSvbt6KzfdW2sIDe/6\n32r473v2iHe5UR4EYrA6PR2K+5N2jbfnaU7d3d1GY2OtMBq8cn2z+QieQw+34aF4LrLHe30QyXsx\nWL2lUkn/+q//qu9+97tWVhL+MWfXs05451QqpbNnz6qnp0ePP/64JicndfnyZbW0tOj3f//3NTw8\nrPvvv1/333+/7rrrLmvVc7tjVyrkl0rlcmzXr19XMplUS0uLxsfHtW/fPsVisYooGlaFr6DE5oOa\n4SfcC1EWBG0JkOyDIGhHsM5YLGacO7Aior0IWAQ5Fgn5u21tbYbPsOi491jSdAvN5/NW+m17u1y1\nHCIyG7S7u9sEOBVySqWSFhcXLRjDBuMQk18PlAFOu7i4aOmVExMT1n2Az7IuZHl4nJk5p/lca2ur\nbty4Yc/JvFOuLx6Pa2lpSQ0NDVaFiRoEVEiHisahTqVS5o1MTk6qo6OjIqWPpAx/QJeWltTb22sJ\nFJOTk3rrW9+qmpoaXblyxdx88Fsqf62vr+vcuXM6evSoQUuk3fpqVE8++aS++MUv6sKFCxXBlaCw\nC0IAQQgn+B2PHcMZZp6lHYWGJ8N3EJisFz9HAHpMFggLyqC0UzKPc4MA9YyXUqmktrY2TU9PGzXR\nezdBJgKeBXvRC04wS79mKC7+cG7Zbw0NDert7VVvb28Fjs3vsUJra2s1MzOjhYUFNTQ0qL293eAk\nvAXvrQLZnTt3Ts8995zC4bBaW1t18eJFayXEdyORcsIHRsztjF0RpGyE2dlZHT16tKItApPtS38R\nuQ+FQhXdCcH5MpnMGwIlXqsVCgWri8miclhCoTKJt6WlRaurq6qvr1dLS4uV90qn0yZA0cx0FwW3\nnZ+fl1SZXodGBJMbHBy0lLXZ2VlrtYxVgrXGhgFcl2Rc1EKhYMEoNinv4cnuPAMYJcT89vZ2C7iw\nBjT7I5iE9cpacB+eaWNjQ+3t7bp69ardk+/X1dXp3LlzGhoaqmhVkc/nLWdfksEv4FEIB2hxc3Nz\nKhbLLaOxhL1ljBVO8Wegm42NDf3iF7/Q0NCQstmsUdnAuZeXl00hYPUODw8brEEzNzyVQqGg3/u9\n39PXv/51PfPMM1ZFLIg7+sE8+f/zWS+IWEusxiBpHUHlhTB7ygtVL4QQNOxR7yH58+E/7/F17nH8\n+HFdvHjRWoJsbW2Zh8YZ4Lqe28zz8Wy49l7RE3yl/GUikbDkF59CzNyRwsm7YThsbW1ZM8pwOGwp\nxShu5sGzg3hmCsGHQiEznDwuztyA0d/O2BVBSoQ5FoupoaFBKysr6ujoUGNjo5G6vYufSqWsxa+3\n2NhsHEyv+byrDI4DVQkrAUuAwiOSKrKKSqWS1UzFqvFNvXxqKM/iQXzcaizN9fV1XblypQJD9BuU\nTUowh+AVG6hUKhnNh40lyRQKWV4IZe+qTk5Oqlgsan5+XkNDQ2b1Q91qaWmxefA1DLyVgYvoM2B8\nYEPaEXQtLS0qFouqr6/XSy+9pHe84x0VCi4SiVgQbmNjQ3v37tXMzIwdQGABKkh5iymY9NDV1WVK\n8ubNm1pcXNTDDz+sH//4x8pms5JkiRfZbFbRaFStra1KpVIW8EulUgbD0OWA9NOPfOQj6urq0pe/\n/GUju3Pw2HcoBT88bhoM+LAvEUbetfaf9zg0P0c4oSSASTxPlbPDmgSDXkFMNuj2DwwM6OrVq9rc\n3DRvkH3NfQgSRiLl7DOEIvi7VC564xM0wPXD4bDi8XhFNiLKkb5oCNWGhgbF43HDzr2C4N0ZTU1N\nFXhrEOrjPpwthGyQ6fNmEMubjV0RpMlkUhMTE9anaXl5WXv27LFDTHX1ra0tswLYVAQ7wCHR7kyq\npyz4DUUva0+PYFMiiMFcWQwwVaAI8CYEMK4qfe89M0CSKQYE3ujoqCkItLYXVKFQyDYdPWW4HsG3\nhYUFEya4b57/GIlErNsqAgdhvbm5qUwmo3379r2hjBqYLCR5rEC0useGCcrxLt7l7ujoUCqV0p49\ne+zQAqnwrnA4FxcXzaJAgcXjcXP1Dx48aNCLt4TYD8ViuX4Bbh3rCy/44Ycf1te+9rWKjJ9Cody6\nJhotNyycm5vTyMiIhoaGzE1samrSysqKpa+urq7q0UcfVUtLi77whS9U7DXeh4PpAzlBwcge88El\n4CuCL0FYCoXjOzp4KxJKm8fwsQw97Yg1ZngrlfPDv4eHh/Xnf/7nampqUmdnp2KxmDo6OqxIN2sV\nhAzYZxhDMAKOHz9uMBaCqrGx8Q0xCxQ4FiV1bJkHzlepVLL2NcVi0QKUnBG8Vaxfb5ECgcBH994g\nOLVXQrc7dkWQbmxsKJ1O6+DBg+YigyFCjeDwMiloUTQjG5i6glhlaHYf6WZSqczto5Pj4+OSdmgh\nHDCsUNxGfu9dFzC1ubk5c1+KxXLtT/AnLCz+9u4yB1uq5CTiPhMwYo7m5+crrFEOHpuWwf/ZHBSH\noUQdyolrwd8EQwQv9qRqLPG6ujrl83n19/fr8uXLFVHXYrHMcR0ZGbHDvLm5qUOHDmlkZETHjh2z\nOfIBKOYuEomoq6tL8/Pzunr1qu69914tLS2ZK4YQx2IIhco9qwYGBpRKpSTtZPVcuXJFw8PD+tCH\nPqQf/vCHNj9e+bW3t6u5uVnj4+MKhUK65557lEql1NLSora2Ns3NzZlHsra2pocfflitra36y7/8\nS4tQI6DIKkIZUtnI46dg8z645KlwCDofoUewcw+EFoLYB5K8lcue4rNc01v2/g9MD8oL3nvvvdb4\n0GPV4Pne6gyHw0YH9PsZV35kZMSMFE+zY99gYeIBIGhJjoGZEXTxw+GwFVkhhdsrb8/g4VlQIHiL\nKDBkQjCoeLtjVwQp5exisZhSqZQSiYRlzczPzysUCllwhGpFaCJcK4JRkUjEhClaBsyVTes3nxdk\noVBIExMTVgQZreeDVEwsFhxQAJ9ZX183CwdsdG1tzbKjsJyDWttXzveHELiAYg30psrlcpqZmak4\nKD7PGAvFuzpADWRypNNpDQ0NWfAEDJZgQjB45HEzrs/7A87zPGBZWI8+6rpv3z59/etf1/HjxysU\nDIKCMntgyNFoVPPz8wanEEH1TAgs8GJxpzcQc8F8jo2N6a1vfauGh4d15coV5fN5+z5BOansIaVS\nKZ0/f14nTpzQ1NSUYrGYhoaGTPlsb2+b0P785z+vJ5980tIMWXfvHvM975pjGfn9jCWNlUeAjLmm\nmhYwkHdTEWzSTntov2Zcz8NgWMpNTU3au3ev2tvbzQtAWV69etVaZrNOFHjx7AAvcFDsPgDKd1E6\nKA7gA/aqh3wwqBDOJMZIO50DENgIeQQr2Hk4HK4owcfcTk9PK5fL6f777zdvzRtnW1tbFlfgPW93\n7JogJcKNmyjJctU9BkTPpiB24bXv1taW9WIJgvO4URTLQPgiTFdWVqyiENifpArBywJ6V5lFXlpa\nqihQi5uHFcqhQEBLsk3IewQ35aFDh8wihpdJb3pGEH/jmdGyYFtYl62trbp+/bqGhoZsjggirK2t\nVVQIYpPybw4v2GE0GrUUXmgy4FE3b97U4OCgcrmcQQVS+aDduHFDPT09FesIn5OgGEEp3i+fz1uV\nLw4IwjgcDltN2Hg8XhHZ5x6vvfaajh07JqncbRSqDGu0sLBg60kh32PHjml2dlatra12sFgjrKQ/\n+7M/07//+7/r7NmzFYcOgebhGtYIAU/WHlXhwTqpyYpAQIh6peGDUJIq4ASEL+8DpEGAhYAgZwPc\nGGFEllAoFLKeSB6fxnL0Qp3f+f2L8JJ23HXeCcucOfMMER+UQ4kGhZnnZPM3+5R38wE9rgvrBqGL\nEUHB95WVlQo330MOtzN2RZDm83n19fUZ1uX7llNkA7d6eXnZeIt8xpNuvZstVfbLQZhRdchjSI2N\njcb9JPpMmTjAdDQvi87k4oqSw44V4TmnMA+wnmn5GqRHeRentrZWyWRSAwMDtkmKxTLNh0CZH95l\nRMjgKhE48lqc+/N8N2/eVHNzswV2fHCCeWXwrJDnW1paKkqNeYu4q6tLc3NzOnLkiB3+RCKhiYkJ\nDQ4O2hrwPbwHqEpYMlK5QE1fX5/BEESd+V5LS4sVkKFYiQ/ObW5uKpvN6uTJkyqVSpqYmLAKQyiE\n5eVlJRIJ1dfXa2pqSjU1NRoeHtb09LQGBwdNafJuKysram9v18c+9jH9/d//vfFRPbbGc3gBy7rz\nTF5Jo/TYA7AYsPTZn7jxxAIQUCgf6kl4amAkErHW3KyppxciPE+ePKna2lq98soram5uthRjGCz0\nDKNTA9dm7XO5nJH4YYf4Aj2cNb9n+Jtzw7oDg/hAkCSDw4DZUCDeI/HQF16eD87mcjnrEYZSxVhj\nDb3HcjtjVwRpc3Oz8cCkHdcSLNQ3raIGKZgoLoJ3Nz1+hjDhMPkJBdRnscbHxytI77ghgN3eovDX\nw/Kqq6vTjRs3KrAiAjI8gz/YCGCp0vXymNaBAwfs+diAqVTKPuufieFdaX4HMZ5Ia3Nzs9Ggurq6\nTBBKO8GGbDartrY2my8ygnxACapVQ0OD+vv7rZsAB5sNfePGDe3fv98UTmdnp+bn5w0DQ1Fi5WKB\nt7S0qL293XBv8EmsXxSBd+9qamqMYN/R0WHzi3AZHx9Xa2urDh8+bMo0n88rFAoZV1KS9Z2ied/d\nd9+tCxcu6K677lJ9fb0JXQRbOBzWxz72Mf3Xf/2XfvKTn9he42B75ev3K3uN9cW9xCCgFGAul6vA\nOVdXV+1z9O/C4sK4QMBgACDg2dOUi0PQei7vkSNH9Hd/93eqr6/X+Pi4XR8jgf/jEaAQ2b+tra0a\nGhrS3Xffre7ubjU1NRlnGLedoBACC6XuA5a8o6cc+nMoqQJ68wZG8LMo3GAQTtqxRvHeMOrgWwdZ\nGL9s7IogBZMheIFm4ZBkMhmrzhKPx40mgxvjNYWfeKwfb/6Dw7DJV1dXTdtC6OY6uEIee0QISjtu\nhbc6MpmMbTSu4zcAUX4fOWSBOECFQplwf/jwYdO4QAJoT64tVRLAef9gFNb/nANAwK23t7cimFRX\nV2c0I56L9w6Fyo30tra27DmAGwimeCwYAclzYknee++9+sY3vqF8Pq/u7m4TCmBb29vbam1ttTqa\npOWurq6qpaXFWAKeA4nVXyqVrGtqS0uL1ScFE4zFYjp//rze9ra36ciRI9ra2tLU1JRlgYVCIYOV\nurq6VFNTo7GxMUnSu9/9bj333HM6fPiwRfARbkT1f/u3f1vd3d166qmnTKB5vJS58LCUt1TBmAn4\nsA9ZY684mH8UdHt7ewU2Le10V6itrTVlSgBXksEznlP6wAMPKJvNGh7JXHvrPhKJGJsBC9Jj9tls\nVmfOnNHPfvYz23OhULm/2t69e9XX16fBwUHrtADEwf7xlaUQpJDkb+XOS5VFnT1+LO3gtt7789la\nGCUeQuG8QWO83bErgrSpqcnaevjunD5KDj2G32FV4a7iVjKBniaBgPLYDhuTzQGJH2vSYz58luvb\nZLl7sLhYNtIOQRmhjjbnncmuwrphQTkQXV1dFdp6a2tLqVTKcD2PQ7FJPY7J4JCzIflMbW2tZmdn\nKwIybD6wX0++5rD4Ah8Iv9XVVfX29lYUkGBut7a21NPTo5WVFQuqkVniS7AxZ1g3VH4iM2ppaakC\nJ+PA+sg3P8/lcravcJGZ262tcnvqV155RQ8//LDdL5vNmgLB0spms+rs7FRDQ4MmJib04osv6q67\n7tKVK1d08OBBy4wClsKaOXXqlIrFor71rW/Z/kCB+n3kvQcP7bDnMBYkmYvsg6bg7nAwUVTSTrAS\nHq4vZOIForRjrYEPHjt2TF/+8pe1vr5uSo5rAhNxnjx8diuLkO96iGt0dFSXLl0yxREKhdTV1aV7\n7rlHR44cMc/Jw2Q+gOkDshTegTXBCIV20pC9Ww9+7z/nDQ2oWN7C9nDC7YxdE6QEfrAEfaS9VCpZ\nGiXR4VuB+AQqvEvFIfF4FRNC9lIkUq7CT+ooE86ml1RxeL0F6PFDIvZsGHAuBBEKAdoFFlypVDJr\nSJKlxXlXCmt0amqqwoLxgt0rGd6VDUIBElzx7e1ty2Lyleo9T7WmpsYsdt7TKyy/AanEBY7nPQKK\nmywvL1u1qGKxaGuaTqfV19en5eXlNwiZUqmk/v5+pVIpbWxsaGFhQYcOHbLUUopSB8vGFQoF9ff3\n6xvf+Ibe9773mSvLmm5vl+u3vvDCC3rnO99phVBKpZIWFhbsejAI4vG4mpqadOHCBUWjUZ04cUIX\nLlywtF1/MMHCH374YXV0dOib3/ymstlshRD1n0dBcR0Ovqf1BWEBHwwqFAqmvHh33hWDAEUIr5K1\niUQi5gFIOz3B6GV2q7WWZB6kx/T9HuTf3gviZygcIDh+ns1m9fzzz+vpp582WG9gYECHDh3Svn37\nDKbBcvWW6erqakX1fLLSOFNYqsHgHO/Mc6NQgwHf/+3YFUG6ublp/D1a7voFQzhIlYV1Mbf9IrNZ\nvQvu6UCeWgGFaXl5ucIiLhQK5gJ5DIbBNRBYtItFe5PaiOVFUMBzW6H1oCF5z9raWu3Zs8dSNL0G\nnZ2dNfxOemPhDJQLRZU9NlYoFAzH9a47LnBtba3VNfAYL4eQ50YBYOEy13AJOzs7rY0Hgpd1unbt\nmnp6euzQ9vX1KZ/Pq729vaL7qhcqxWLRghrFYlELCwu24X0kuLGx8Q2FNXp6elQoFHThwgWdPHnS\nlGw8HrfAYCQS0YULF3T06FFzY0OhkAlTMFPw02QyafUwDx8+rHQ6ra6uLuVyuYq5ksoHfnh4WJL0\n9NNP6/r167ZPPZOD90ZAYokGLSwfoAI68QFBLFsEqX8eqGker/X48srKijEx3v/+9+sLX/hCRVow\ng+eUduh23N+fL4SVF5x81rNIONMe+mAewuGwpqenNTc3p+eff96MnsHBQf3ar/2ajhw5YpzqZDJp\nfO9CoaB0Oq3p6WmDhTo6OkzZMIfeKPAMCD9XPFNwHn7V2BVBymZobm6uCAZx4GpqapTP5ysAbq/R\nOTwIFbhoLA7uDtQLDiFUC4r/Qnoni8p3lfRBAawZH5zBIvXYFJ9nYaSdfHK0cSgUsnqbpVLJAPkg\nxpnL5YxL6Rf0Vi6KD9RJO7ibv14oFDLyMtQeijzAhvBKbGVlpcJNDIVCFtnkM0SysYY4DEALLS0t\n9sybm5vq7+/Xyy+/rEKhnBN98OBBzc3N2TohCJaWluwg5HI5ezfu74NbXlEWCgUNDAxoampKfX19\n6uvrMyGKV7O9vW042OHDh3Xu3Dl1dXVZAAphDXskHo+ru7vbKnT19PRoZmZG3d3dts9QsqVSSaur\nqzp8+LAaGxv17LPP6ty5cxUQBGsClY69hPL1goU9DcfXZw7x7n7OUfKhUMiSVSDSl0olownmcjn7\n7okTJzQxMaGlpaVbWmQe5vEWKkIJYYklGmRV8N7828cXgq6zh3uwyqkV/C//8i+6efOmYrGY7r77\nbr3jHe+wFuGwT9rb261V9+rqqjU9ZI+jbLygZP4wFKSdwPL/xrXftb72pFVCGEewMNH5fN4yIdhE\nPmDjAX9pZxGgfwSj2H6TgWv6qkQA+AD1Hivle+Fw2Fo3h0Ihoz75TeOtJ/iB4IhU8gYvrK2tVWdn\nZ4VbjGKYn5+36vfBze0DbBwg7+J6HI5N7Tm03sqD5hGNRi2X2X8fjNkHkIhu8r5BloIkw9VQNHgh\n0HXW19etHqyHEWBqdHR0GNTgC+zC1/XeB2NhYUEnTpxQIpHQSy+9ZNXwCT5BKYpEIrp8+bJaW1s1\n+D/0pv7+fhO6rO/y8rK1OaFB3+zsrJLJpLnBcKB5fwjlAwMDes973qPf+I3fqIi2+73sv+NdUUlW\n4o7DTdQ+nU4bbkzABkvV7wMfE6Aw+cLCgpVMRAk//vjj+trXvmZCi+t4uAghCvzljR/+jWeI4OL9\neB//7vyf9fPeCIFDSXY/9iBzff36dX3pS1/Sk08+qc9+9rMaHx83Iwhed1tbm5LJZEXXifn5ecNC\nPY7L9eHZst95xtsZuyJI2dz0GPLYKBiYrwKDRci/WUCPL3kshA3lgW9wPSwyUs88cO43BwsMYZ2N\nRYvfzc1Nzc/P28H0mU1oZeg6ZChRyAMXPJlMVgSDECbLy8vWTC4YZfSRS57bB4a8tgVb8gqCzDCi\nslgc/Jtn8AEvMluAC/whxvWXVKFQJFkbZX8gcV9ZBzwCrBDvBgO5zM7OmnIEy/RzwPqur6+ro6ND\nmUxGzc3NevXVV1UsFq3urT8oLS0teuGFF9Tf36/u7m61tLRoYGDAeKm8C0WjWYOf//znWlpasmpi\ntbW1hl3itXgoY//+/frUpz5lOLLv0YVrSkAOF3htba0iYLK9vW3WOXsagcAoFAqGzzOH0J3AEzEy\npLKlee+99+rs2bMmQH0Q1XszzK8v1sy/EeRY53hpBBRRBr6gM/vNKwBGkBbGc3l4D8HX0dGhSCSi\nH/3oR/rsZz+rT3/60/qP//gPXblyRYuLi8bZJfU1kUgoEolofn5e09PTWlxcrFDEngeOxX67Y1cE\nKTgiZd3ADEulkrm9WKLQhygczAFCgHigW9oBpvnbR3rZtJIshQxLwFu7uNzwHP09pZ32zqlUyoSt\nD/rw3Fi9PB9E38bGRsXjcStWzKLR3mB6etroON7d8fiUVxIIfo9beeHLPGAhx2IxK37C3PtAAoqI\nA7a0tGQV+Tno0WhULS0tKhQKFWR+aacJHFkzCOWNjQ2r4kOhiYGBAVNM3JdWJWDPqVTK3HmEPe/P\nvGJtk1zB2lGXVK2WoLIAAAHGSURBVJK5i4lEQlI5NfTixYu6//771dbWpnA4rL6+voqeYaVSSdls\n1oRbS0uLzp07p6WlJdXV1VUwGlgb1qlQKOjYsWNqbm7WJz7xCWsP4+ueRiI7TQJxd/n/9va21URA\nAOIheZfeY5NAFMAxrAdCnDbMtbW1uu+++/TMM8/Y/zkT3Mfve/YV1+Oc+OEDWP47XpHyXuxPXzyH\na7JveG7OCOst7dCzOLv19fVKJpPKZrP6/ve/r8997nP69Kc/rW9/+9t2TtkziURCAwMDVuwmnU5r\nZmZGuVyuovZD8P1+2QiV/jefro7qqI7qqI43jF3DSKujOqqjOv5/GVVBWh3VUR3VcYejKkirozqq\nozrucFQFaXVUR3VUxx2OqiCtjuqojuq4w1EVpNVRHdVRHXc4qoK0OqqjOqrjDkdVkFZHdVRHddzh\nqArS6qiO6qiOOxxVQVod1VEd1XGHoypIq6M6qqM67nBUBWl1VEd1VMcdjqogrY7qqI7quMNRFaTV\nUR3VUR13OKqCtDqqozqq4w5HVZBWR3VUR3Xc4agK0uqojuqojjscVUFaHdVRHdVxh6MqSKujOqqj\nOu5wVAVpdVRHdVTHHY7/A2eoQRZQIdqIAAAAAElFTkSuQmCC\n",
-       "text": [
-        "<matplotlib.figure.Figure at 0x4d475d0>"
-       ]
-      }
-     ],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "plt.title('CPU')\n",
-      "plt.imshow(cvimage_cpu, cmap=plt.cm.gray)\n",
-      "plt.axis('off')\n",
-      "plt.show()"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAVIAAAEKCAYAAABACN11AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsvVmPXOd1Nbxqnue5a+h5IHviJMkSSVu2lNhW7MSxAyS5\ncP6Ar5KbAEGAGEEQIDdGrhz4KkEQx3CcIPLrSbItmRookSIpkk022ey5urqra57n8bvgu7ZOK877\nCdGLUN+XegCBZKnq1DmnzrOetddeez+q4XA4xGiMxmiMxmj8l4f6SZ/AaIzGaIzG/9fHCEhHYzRG\nYzQ+5hgB6WiMxmiMxsccIyAdjdEYjdH4mGMEpKMxGqMxGh9zjIB0NEZjNEbjY44RkI7GaIzGaHzM\nMQLS0fjEj3/+53/GhQsXYLPZMDY2hpdeeglXr17FN7/5Teh0OthsNrhcLly8eBHXrl0DAHzzm9/E\n17/+9f9wLLVajd3d3f/uSxiN/5+PEZCOxid6fOtb38If//Ef48///M+RyWSQSCTwjW98A//rf/0v\nqFQq/OEf/iGq1Sqy2SwuXbqEr371q0/6lEfjf+AYAelofGJHuVzGX/zFX+Db3/42vvKVr8BkMkGj\n0eC3fuu38Dd/8zcYDodgYZ5Wq8Uf/dEfIZVKIZ/PP+EzH43/aWMEpKPxiR3vvvsuWq0Wfvd3f/f/\n9b3tdhv/8A//gFgsBo/H899wdqMxGh+MEZCOxid25PN5eL1eqNX/+WP6L//yL3C5XIjFYrh9+zb+\n/d///b/xDEdjNB4P7ZM+gdEYjf9seDwe5HI5DAaD/xRMf//3fx//+I//+B9e1+l06Ha7J17jv3U6\n3f/9kx2N/9FjxEhH4xM7nn32WRgMhv+UZapUKvxnzctisRj29/dPvLa3twetVotwOPx/+1RH43/4\nGAHpaHxih8PhwF/+5V/iG9/4Bn74wx+i0Wig2+3iZz/7Gf70T//0//jZL3zhC9jY2MA//dM/odvt\nolAo4M/+7M/we7/3e/9HqWA0RuO/MkZP1Gh8osef/Mmf4Fvf+hb+6q/+Cn6/H7FYDN/+9rclAaVS\nqX7t53w+H372s5/hO9/5DgKBAJaXl+F2u/F3f/d3/52nPxr/Q4Zq1Nh5NEZjNEbj440RIx2N0RiN\n0fiYYwSkozEaozEaH3OMgHQ0RmM0RuNjjhGQjsZojMZofMzxRAz5P/rRj7C/v4+dnR0kEgnodDqM\nj4/DaDRKZ55GowGNRoNYLIaxsTH0+330+31UKhX0+32Ew2FUKhXUajWMjY0hn88jk8lgYmICTqcT\niUQCnU4HzWYThUJBPuPxeFAqldDpdLC9vY0XX3wRarUaxWIR5XIZVqsVrVYLqVQKZrMZtVoNc3Nz\nSKVSsNvtMBqNKBQKsNlsSKVScDgcAIBOp4NWqwWz2YzJyUlsbm7CZrPBZrNBq9Xi/v37WFhYQLlc\nhsFgwPr6Oj772c9ib28ParUaGo0GbrcbzWYT3W4XbrcbGo0Gdrsdh4eHSKfT0Ov1sFqtmJ6exs2b\nN1EqlTA1NYVut4vBYIBWqwWfz3fi3A8PD9FqtWC32+H3+1GpVOD3+1Eul+F0OqFSqWA2m9Hv92Ew\nGJDNZmEymdDv99HtdjEcDjE+Pg6z2Yzr168jGo1if38ffr8fU1NTuHr1KlZWVjA9PY319XU4HA6s\nr6/DZrOh1+uh2+1KZl2r1cJoNCIWi6FQKKBWq+Hg4AChUAhWqxXpdBrT09PI5/Oo1WowGo3weDzI\n5/OIRCLY29uDz+eD0+lEuVxGqVSCVqtFt9tFIBDAo0ePEA6H4XQ6Ua1WodVqUSgUoNVqMTk5idu3\nb8NkMsFkMsFsNsNms2FtbQ1utxvRaBTr6+t4+umncfv2bYyNjaFer6PRaMDn86HdbqNeryMSiSCV\nSqFYLMLlckGn06HT6cDpdOLg4AB+vx+9Xg8mkwm1Wg12ux2dTgfdbhdarRbtdhtGoxHNZhPhcBg7\nOzuw2+2o1+vwer2o1WrQarWo1+swmUxSjKBSqeTvw+EQGo0GnU4HdrsdpVLpxG9mtVpRr9cxGAxg\nMBigUqnQbreh1+uhUqnQ7/cB4D8cS6vVyuu9Xg8qlQq9Xg8ajQY6nQ79fh+DweDEufDc2u02BoMB\ntFqtvD4YDKDRaDAcDtHr9WAwGOBwOLC5uQmfzwe1Wo16vS7Pf7vdRrFYxEsvvYTXXnsNWq0WNptN\njkXfsEajwWAw+A+4wmvr9/vQ6/UyL4fDIVwul+ABvw8ABoMBarUa3G43bDYb8vk8stks/H4/lpaW\nfm0HsV83NN/85je/+V+HxP/aeOWVV/D6669jenoaXq8XwGOztF6vx2/+5m9idnYWExMT8Pl8ePTo\nETqdDgwGA3Z3d2GxWGAymbC/vw+tVguDwYCtrS10Oh08/fTTGAwGePXVV2G1WjE3N4dYLIbx8XEM\nBgNkMhmYTCbo9Xo0Gg2USiVMT09jY2MDarUaoVAIdrsdw+EQFosF0WgUhUJBHvpOp4N0Oo1gMIhu\ntysAk8/n5SFVq9XweDxQqVQ4OjpCOBzG+vo6VldX0e12BdS8Xi8SiQTa7TaSySR8Ph+Ojo5gNBrR\nbrfhcDiwvb2Nra0tnD59GvPz8/D7/cjlchgOhzLJIpEIrl+/DrPZjEajAY/HA4fDgcPDQ7nu06dP\no16v4+mnn8bh4SE6nQ48Hg9cLhdKpRLeffddLC4uotvtIpvNwmAwwGazyaTc29tDs9lEp9OByWQC\nADidThgMBly8eBH379/H7u4ubt26hUAgAL/fj8FggFgshna7DYPBALfbjZmZGezv78NoNArwu1wu\nTE9PQ6PRoFarIZFIYDgcIhaLwW6348aNGwAeg/DU1BTu3LmDUCiEvb09GAwGDIdDaLVaDAYDAenN\nzU3s7OxgeXkZ+/v7mJycRDqdhsvlgtPphMPhgNFoxNWrV7G4uIhCoYBGowGVSoVKpQKNRoNGowGz\n2Qyj0Yjj42N4vV4kk0n5DUKhEOr1Oux2OzKZDJxOJzQaDRwOBxqNBvr9PnQ6HXK5HCwWC9RqNUwm\nEzqdDvR6PQaDAWw2G9rttswL+lsHg4FcF99PgIhEIqhUKqjX63C73SgWi9DpdFCr1QKs/X4fKpVK\nQG0wGKDf78NoNKLVakGj0aDb7cJgMMh38R6z+kulUsnzrNPp0G63Bag0Go0AKAABWL7O6yDgDodD\n6PV6aDQabG1tIRaLodfrodFoyG/YbrcxHA7xpS99Ca+//rosdhqNBv1+/8T3KY9NoB4Oh7JAcEEg\n2BqNRnS7XbTbbQFRJSir1Wp0u100Gg1UKhWMj4/Lc7ywsPCRMO2JAOmdO3cwMTGBZDIJjUaDxcVF\nAbCNjQ28++678Hg8uHnzpgDQ3bt38cwzzyAQCKDf76NWq8HhcMBut8Pj8UCn0yEej6Ner2N8fBxb\nW1vY3NxEtVpFsViEVqvF0tIS8vk8CoUCDAYDDAYDnE4nCoUCLBYLcrkcNjc3kc1mEQwGUa1WEQgE\n4HA4cPv2bayursJsNiObzUKv16NaraLdbssPVK1WEY1Gkcvl4HK5YLVaZRL0ej20Wi00Gg0kEgms\nrq7i+PgYKysrsFgs8Hg8sFgswnx1Oh2i0ShsNhsODg4AQACDrJUT2uFwwO12IxAIoFQqIZFIwGAw\nQKPRYGxsDIPBAJOTkygWi2i32xgbG8NwOESz2cTU1BRmZmZgsVhQrVbhcDig1+uRTqdhMBiQTqeh\n1Wqh0+ngdrtxdHSECxcuoN1u44033kA6nYZKpcIzzzwDg8GAfr+PZrOJSqWCra0tec1isaBUKsFm\nsyGbzWIwGMDv90OtViOXy6FarUKv18tzYLPZBKA8Hg+y2SxCoZCAb7vdlkk/OTmJnZ0dmM1mxONx\nuFwueL1e6HQ6GI1GNBoNNBoNGI1GhEIhXL16FUajEZOTk2i1WjAYDGi1WvD7/Wg2mwgGgyiXywL4\nZEb1eh2hUEgYf6lUgt/vR7fbRTQaxfb2NqamppBOp6HRaKDX6+X7LRYLstms/IY8V7vdLqDQ7/cF\nzLrdLux2u/zZ6XSg0+lQLpclejAYDAAgn9Pr9cJ+la5GgioBFsAJgCSYMXrgOXIx4HfzXpBZk9V1\nu13o9XrodDoMh0M5Bv9uMBjQ6/UQj8flnpMh9/t9tNttdDodXLx4ET/96U9hsVhgNBphMBjQbDah\n0WgE/MiSlQsFAV+j0ZwAZqPRCKvVil6vJ6BJYOZrjPJMJhN6vR5sNhuq1SquX7+Ofr+PF1544SNh\n2hMB0u9973tYW1vDl7/8ZeRyOfziF7+A3W5HpVJBJpPBhQsXsLm5ic997nMSQgQCAeRyOezv7yOb\nzWJ/fx/NZhMTExM4Pj7GYDCAxWLBzs4Out0uYrEYVlZWEAqF4PV6MRwO8eDBA5TLZSwvL6NUKj2+\nAf87rCkUCjCbzXjqqadw6tQp7O7uotFooFqtwmw2Y3FxETdu3IBGo0Gr1YLNZkOxWITJZIJWq8Xc\n3Bz29vZgMplQrVZl4jLcSiaTmJmZQb1eBwCYzWYUi0W0Wi3o9XocHBygVCrBbrdDr9fDYDDg+PhY\nZIFEIoF4PA6v14uNjQ0cHR3hxRdfxN7eHh48eIDl5WXcvHkTBoMBU1NTaDQaaLfbODg4kFDzzp07\nWF1dFfZls9lw/fp1xGIxvP7662g0GvjiF7+IZrMJj8eDBw8eYGxsDJ/97Gfh9/uxvb2NS5cu4c6d\nOyiVSlhcXJRwyWAwIJVKoV6vw+VySYjt8/lQqVRQLBYxNjYm4KbVanF0dAS1Wo1WqyVsK5/Pi2wz\nPj4uvwvwuK1ePp+H1WqF3W4XkO71emi323C73cLMyZ5LpRJcLhfq9Trq9Tr0ej1qtRo6nQ6AxyDD\n8+Ez1ul0MDk5iVQqBZ1Oh0ajgWazCZvNBp/Ph0QigVgshmw2C4vFgn6/L9fQ6XRgsVhQLpfR7Xbh\ncrlQqVQwHA5FWun1eieYEYHUaDRiOBxKGG2z2TAYDNDtdmE0GlEqlaBSqST6IagyjKXEw+Pp9Xp0\nu11oNBoBDn4fgZWsjexOp9MJ2BKwlPIC8DhcJiiRUStlALVaLezQaDSi0+mgVCohEomgVqsJQHe7\nXfn75cuXBQe4QLRaLTm2RqOB2WwWZpnL5ZBIJJBIJHB8fIx0Oo18Po9SqSS/b6vVQj6fx2AwEJmm\n1WphOBxiMBjIAsu5QtavUqkwMzOD06dPY2lp6SNh2hMx5L/88st47733cHBwgOeee04ewna7jV6v\nh1KphGw2C6vVioODAzSbTSwuLkKj0aBYLGJubg7hcBgqlQoHBwdQqVQoFArY3d3F/Pw8er0ecrmc\nPDC1Wg3dbhc2mw1msxkLCwvI5XKIxWLY2NhAOp3G0tIS+v0+hsMhjo+PMTMzIw/vwcGBTPJcLofx\n8XFZ0flgkPVduXIFsVhMGF6v1xNNDADOnj2LV155Ba1WC1/4wheg1+vx4MEDCfU9Hg82NzfRarWw\nurqKwWCA8fFxpNNpDIdDvPXWWxLmcxLxQcnlcmi1WojFYtDr9Wi32wiFQshms8Iwx8bG8Nprr8Fq\nteL8+fOiBxkMBtTrdaTTadF1w+EwMpkM4vG4TCiz2Qyr1YqxsTFUKhUBCY/Hg3v37mFmZgZjY2PI\nZrPIZrNotVpYWFhAt9tFIpGA3W6H3W5HPp+HTqeDwWCQkJfMvlaroVAoYGVlBaVSSdi8TqeD2WyG\nVqtFNpsVFn98fIyxsTG88cYbuHDhAmq1Gvx+P4rFouhwPCcyuXq9jkqlgmg0KqzbYDCgXC7DZDLB\n6XSiXq9DpVKhVqtBr9ej1+vBbrdjZ2cHFy5cQCKRwOHhIWKxmISKZDbVahU2mw2NRgN2ux3ValUY\nlsvlOhFq8nfU6XSoVCpyDOrxJpNJmC2ZJ2UFatqUAUwmE5rNJhwOh7D8TqcDlUolrJKsjO/jswl8\n0NCFjK7b7Z5gpSqVSn4LhtRkdgRYAEJsarUaWq2W6P/UX6mbqtVqPPvss/jJT34Ct9sNvV4v97rV\naqFarSKfz0Or1crC7PF4YLfbYbFYYDAYROvtdrvodDoYDAYnFiyG7ZRXlEy1VqshmUyiVCrJ4uV0\nOmGxWDA1NYWvfe1rHwnTngiQfve73xUdRKVSYWdnBwAQDocxNjYmTFCr1eLy5ctoNBp48OABFhYW\n8PDhQwyHQxweHqJcLsPr9SIYDKLT6aBer6NcLsPhcGBubg4GgwHtdhsmkwmTk5O4f/8+NBoNSqUS\ntra2sLKygnq9jnA4jPfffx9jY2MolUqSfFGpVBK2HR4ewmazycOh0+mE4RgMBlSrVbjdblgsFrz9\n9ttYXV3F+vo6Tp8+DZvNhlarhXfffRdPP/20hImbm5s4e/Ysjo6OsLi4iJ2dHdy+fRvnzp1DrVZD\nr9dDNptFLpeD0+nE3NwcLly4gGw2i2KxiKOjI7lGo9EIt9uNfr8Ph8MhjKdcLssDNRwOUa/XEQwG\nJdR0OBx4+PAhLBYLEomEsHwmiphc0ev1mJ6exrVr1zA9PY1kMolmswmfz4dOpwOz2SzX/9Zbb8Fq\nteLUqVPI5XIwmUx49OgR5ubmUKlUkEql4PF4oNfrcXh4iGAwCAAyKR0OB/L5PGw2GyqVChqNBkKh\nENRqNdLpNNxuN0wmE/b29lAoFPD8888jlUqh0WggGAzi1q1b0Ov1mJqagsViQaFQQD6fl6SO0+mE\n0WhEPB7H3NycSD9utxvb29uYn5/H5uYmPB4POp2O6J6dTkfALRKJ4Pj4WCQcslMmiwqFAoLBoIAv\nwZpgq1KpUK1WhX3y9VqtBq/Xi0qlIqxxOBxKEpSgVavVYLPZ0Ol05E8mVpQhM79TmVhSMi+r1Ypa\nrSbhMQffS1Y6HA5hMBgkCTgYDCSBxKhLp9NBq9Wi1+vJ91YqFZFrqHXyXHU6HZ599lm8+uqr8Pl8\naDQaKBQKsvBR2gIeAzxJQz6fRzKZxPHxMVKplNyfYDAojJaAznMhgDebTfR6vRML9+TkJEKhEEKh\nEA4PD3H//n0kk0k4nU78/d///UfCtCcCpAcHB/i3f/s3HBwcwGKxSHY7l8vBZrOh2Wyi3W4jn8/j\nvffeg9/vh8fjgd/vh8vlkh9jYmJCHvbhcIh79+5hd3dXHtBIJIJwOIyf//znUKvVmJiYQCqVgkaj\nwRe/+EUcHR1hbW0N8/PzUKlUSKVS8Pv90Gg0ODg4wOzsLA4ODjAcDrGysoJHjx5hb28P58+fx/Hx\nMcxms4QbXO0p6BuNRpjNZuzt7WFychKPHj3CpUuXcPfuXXg8HqjVanET1Go1bG5u4g/+4A8wGAxw\n9epVeL1emM1mlMtlRCIREdXJpPP5PObn53Hjxg186lOfwve+9z1Eo1EBTbJkt9stjJ2Tvlgsolqt\nIplMYnJyEm63G+VyGTqdTrLmOzs7cLlcEppTC2XCplAoYGJiAqVSCcFgUFh0qVSC0+mE3W5HrVaT\nc+C9yWQyovFptVosLCzgzTffRCgUQiaTEX1MrVZjbGxMFlQey2q14s6dO7h8+TLW19dhMBjg9/uR\nTqcRCoUwHA5Rq9Wwt7eHU6dOoVwuw+fzodlsyv3rdrvi9AiFQkgmk8L68/k8xsfH0Wq10O124fF4\n5Nr9fj82Njbg9/sxMTGB7e1tuFwu1Go1AR66DCgdOBwOVCoV6HQ6LC4u4vbt28KKuSAPBgNhcHx2\nm80mjEYjjEajgBddAO12GzqdTiQbAhMASSAR9Kl1EqQtFgsajQZ0Op0knbrdrhyHchTDXyaYqD0y\n+UUQVWqYBEqdTif3z2w2o9frAYAAOknHxMQEvvvd78Lj8WBsbAyRSAQWi0Xeq9Vq0Wq1sLu7i8PD\nQ0nQmc1mqNVqWK3WE9FUuVyW34LAzUiDQMzIigBrNBqRz+dRr9dRKBSg0+mwtLSE1dVVzM/PY3Z2\n9iNh2hMB0rfffhvXr1+HTqcT+0+/34fT6cTu7i7m5ubg8/lgNBpxeHiIXC6HcDiM27dvIxgMYn19\nHU899RSOjo7kIbHb7WKJOXXqFKrVKjY3NxGLxRCJRISpabVa5HI5PHz4UMBKq9UKa7Lb7UilUlhe\nXsbk5CS63S6azaYkyMrlMjKZDE6dOiW6G7OLTFz0ej1kMhl4vV50Oh243W786le/wosvvoh4PA6n\n0ynJqp2dHVy8eBGtVgtvv/02nn/+eckSM/NPjfjg4EBAym6349q1a1hfX8dXv/pVhMNhlMtlYWzU\n33K5nDzYZrNZQkyCUr1eh9VqRSqVwurqKnZ3d1EoFDA1NQWv14v19XVUq1XEYjEYjUY8fPgQNptN\nJlelUoHZbJZ7pmR+rVZLQisACAaDsFqtEi6TJTBxVK1WYbFYEAgEkE6nEQgEsLW1BbPZLKGsyWSC\n2+3GxsYGgsEgnE4nstmsTHg6LZxOJ5rNJu7fvy8JQ8oder0e2WxWmJnFYjnBJpkYq1QqWF1dxTvv\nvIPx8XEJZ8vlMoLBIA4ODhCNRkWO4LEZltdqNZGPer0eVldXUS6XcXh4KL+XTqcTOxeZH+8ZWSSz\n8bVaDT6fD+l0WkJThvkqlQoWi0XCW4bo1Ff5GhNKPLZy+nOxUwIfs/1kb3wf7yW/h8DK4zMx1ev1\nRAdVq9WyqLhcLkm28hzVajUSiQR2d3fldzEYDMKwuZAz8spkMigWi5LYs1gs8r08z8FgIOfJZ4SL\nHhd2q9Uq10bHxtHREWZmZvDXf/3XHwnTnkiy6eWXX8YPf/hDlMtlTE1NYX9/H4FAAJ1OBysrKzCb\nzdjZ2UG1WoXL5RL7iN/vR6vVwqVLl7C1tQWj0ShWona7DZvNhpWVFdy8eRNmsxlnzpxBOByGxWJB\nJpPBvXv3cHx8jF6vh9nZWTgcDnkANjc3sbKyglgsJkmTg4MDsTxR+A8EArBardjc3BR/Gl0A9C8C\nkJXdZrOhVCrh4sWLuHPnDsbHxyWhEI1GYTabodPpkEgk8JnPfAalUgndbhfb29vCCmw2m1i/uGJv\nbm5iamoKL7zwgrDAu3fv4vz580ilUjg6OkIqlUIgEIDJZILBYMDPf/5zhEIhBINBCS21Wq0kUh4+\nfIhQKASj0YhqtYqtrS30+31MT09LxpnvdblcqFarGBsbg1arxaVLl5BKpQTM6Ko4f/488vk8VlZW\nUCgUkE6nUalUkMvlhMnQKhUKhaDT6WCxWCShEIlEYDQaxZdKhsHFJZ/Py+TN5/NoNpvC8nndvV5P\ntM/j42NZCJxOp3iOJycnTyQhVldXkc1mRYtnqMgJz9+F8kir1ZIQkt7NXq8Hp9MJtVot9iG9Xi+2\nqqOjI4RCIUl8Unqha4HAzYQaoxIlYCttRwQKl8t1woJFZkatk2E3Q3dapshymZAimFP/JDDa7Xa5\nXgIxj8Xr4LnznjUaDcTjceh0OsRiMRgMBszMzKBareLhw4e4c+cOkskkzGYzPB4P3G63yFNGo1HY\naiqVkryG1WqFzWYTpkntFYAApvKceC/NZjOGw6EkLrmAkb2r1WrY7Xa43W5cunTpI2HaEwHSSqWC\n6elp6HQ6PHr0CNFoVETsjY0NXL9+HWq1GlqtFvl8Hj6fD7u7u9jb28PMzAyuXLkijFWv12Nvbw9O\npxODwQC3bt3Cl7/8ZZRKJaytrWF7exuVSkV8bOFwGHa7HblcTgT5QqGAcDiMRqMhjIA2CLvdDgAy\nuePxOE6dOiUPL5keRe56vQ6HwwGPx4NHjx7B4XBga2tLtEYC7PHxMfb398XkbzabJRzS6/UwmUx4\n9tlnYbPZYDKZMD09DbfbjVwuh42NDZw9exZ6vR7lclkyxQxT0uk0nnvuOaRSKXi9Xsl+fuELX4BK\npRLzdzKZhMfjgc/nk0kyOzuLBw8ewGKxwOv1IhQKwel0AoDYrCwWCx48eIDx8XEJFYvFIjKZDMrl\nssgJGo0GDx48kHPqdrtwOp0IBAKYmJgQVkRGmslkkMlkxI7GjCrtMna7XZgms7LlchmBQAButxvt\ndhvj4+OSeDOZTMLSCPxzc3PY3t6G2+1Gt9tFuVwWWcFutwszKZfLApTMvJPRkcVzsjLRw0QpgZI6\nM/3DBNx+v4+DgwMsLi4imUwK+DI64rFpqqenl1o7J7+yaGI4HIqnmVlvtVotCzWZNPCBHYpJoFwu\nJ1onw16laZ3Zfn4HJQmCD/BB1h+ASAZqtRrlchnJZBJerxdnzpzB+Pg4Op0Orl27hu3tbcnGu91u\nsYLRCeB0OqHT6VCtVpHL5WQBcbvdcLvd8r1Klk1ngdICpvSN0snAecvFQOlM4J8GgwGXL1/+SJj2\nRID0xz/+MV599VWEw2GMj49jY2MDXq8XU1NT0Ov1WFlZwcTEBMxmM1wuF7a2ttBoNPC5z30OiUQC\nU1NTEp5ubGxgdXUVvV4PLpdLtFKj0YhgMCgifjAYFC3l+PhY7Blkc9VqFR6PB/Pz83j48CH8fj+A\nDzx6xWJRMuiHh4diVYpEIqInNhoN6PV65HI5eL1e+Hw+GAwGeDweAS+r1Qqr1YpOp4PTp08jn8/D\nYrFI4kWlUqHT6aBYLMJut+Nf//VfxdZ1fHwsuuTu7i6sVqswqmQyKYyDmXCdToeDgwOUy2WxlmUy\nGbTbbRwdHWFqago3b96UBF0qlRJmF4lEoFKpsLe3h/39fakqazabePvtt+FyuZBIJNDtdhEKhVCt\nVnHu3Dns7OzIZNdqtYhGoxgfH8epU6ekMTOZyebmJoxG4wmDOBMnLpdL/s3ssVarRblcluQCQ2gC\nea1WE1M8w2FaW6gDF4tF+Q2YFSaoMpOeSqXgdDoxHA5RKpXgdrtFn+T9IQA1m01JCrndbpn8hUIB\nDocDxWJR3ADT09NIp9OySB0eHgpIBYNBcR8w4cLFezAYiKbZarWkmGF8fFxYldK3qlar0Ww2BZQq\nlQpsNpswYrJHSmpKbZQASfb767Lw9JlyUKKhptrpdCRZOjc3h+npaTgcDpRKJbzxxhvo9XqIxWJw\nuVzCGOkq4HV0u11UKhUAEEdDs9mU5C7BkyG/0pivTDBxsSYx6/V68two/bu8Tp4LceMTDaTUue7e\nvYv19XWGWXWIAAAgAElEQVSMj4/DZrPhypUr0Ov12NrakmqaZrMp4ePdu3dP3IxHjx7h8uXLGAwG\nSCaTKJfLUgrJpIrNZsPk5CSAx4Z2JocoMI+Pj2NhYQEWiwXb29tIpVInkkX0EDJhY7FYMDMzI0mF\nWq2GUCiEYrEIvV4Pp9MpIa7X65UkDH2lN27ckBWQSYlKpSLMh6bz8+fP48aNG/j0pz+NyclJzM/P\no1arwWq1CovUaDQwmUzweDyIRqOwWCzQaDTIZDIIhUK4efMm/H4/lpeXTxjZW60WpqenJYQ1Go3C\nuAjCZIhkpQyTfT4fLly4gMXFRcRiMXQ6HWxsbCAajeLOnTs4d+4crFYrNjY2oNfrkUql0G63cevW\nLQEYp9OJfr8vlWHHx8fweDzCaqjpcYJ2u114vV65xyqVSip6Go0GXC6XgDEN1jabDYeHh6KbMcRt\nNpuSTCIIWiwWiU44fD4farUazGazWLyUYDMYDER24nEZYfn9fpFVKpUKgsGgRFbpdFrub6/Xw9jY\nmMglWq1Wkip0FlDDI4NkeEqnCMNwelkJJFxQyXDJRqmX6/V6sTEpnQMEEWXoTzLB6iNl1RPwgc+T\nzE+v18PhcIg7JZvN4sGDB2g2m5idnZVzpJ7Jc2C1E4+t1+tPXI/FYoHVakWj0QAAAW7lljNKRsn7\nQoDmPFYmnXgMpWOBx7NarZ/s0P7WrVt47bXXcOHCBczOzko1ztTUFHq9Hi5cuICzZ89KPfydO3dg\nMpkwNjYmFga9Xo+ZmRmsr6/j4cOHAra00xweHkKv10vIlslksLu7K6zU5/Ph/PnzuH//Pra2trC1\ntSXeSa1WKyGlxWIRKaJSqQhDoz6ay+UQDAaRTqfh9/uRSCQwNzeHg4MD8QNSM2LlDOvzI5EITCaT\nhHY2m0301p2dHZhMJtHWEokEWq0WCoUCjo+P4ff7cXR0JAk2AFJxZbfbkUgkEI1G0Wg0pAaciaCp\nqSkUCgUBcZYcMtTRaDSy6ND+U6lU0Gq18OjRI6TTabRaLWxubmJyclLAhgzs6OgI586dQ71el3CY\nv53NZkM4HJbkEnVkMhOldYa/szIsIzMxGAwwGo1iQavX65iYmMDh4aHUwVMPI3tS6nsEIYvFIuDG\nxITf7z8h87Tbbfh8PqkL12q1qFQqMBqNKJfLUi3GhJhycz29Xi+LFH/fYDAovkZO2O3tbTgcDtHB\n4/E4fD4fAAijJtBzceA94XkyHOV9V1Yg8bVyuSxMkNfCMJifUYILFyFGBAyBGdERsJTAxXtdr9fF\nLUE3DBdIfjePRQ2Ymjn/7HQ68oyQ7SortAjsBHvgA72WsgurAQmovKd8LxcOPmc8tslk+mQD6YMH\nD3B8fIw333wTOzs7os8Mh0MEAgEUCgWx/XzqU59CJBJBvV6X2nQ2qdjZ2UEoFMLly5fFq0aQoFjM\nB83n84k3cWlpCXfu3MFwOITX6xXButVqwWQyCQtQWn5MJhPm5uawuLiIiYkJ7OzsYHd3F+12W2w7\nHo8H7XYbVqtVvouZZzJCZYb/8PBQPJzUV2myzmaziMViKJfLiMfjSCQSOHfuHKrVKi5duoT79+/D\nbreLx5VaK/Vis9ksYRBr6202G2q1GiqVirA3v9+PmZkZ9Ho9mM1mZDIZTE5O4vj4GEajUfyyGxsb\nsFgsmJychMvlwv3795HP54V9kwU3Gg1MTExgbW0NwWAQg8EA5XJZ6u9TqRQ6nQ6sVqskhj7MKjiJ\nCOoEOOVzwnB/OHzcF4FmcLJLlnFycSGoEICYPOQEVPoOeXyydyWA05eq1WplAjN5wYIRk8kEr9eL\nhw8firOBidL9/X0Eg0G0Wi1hYExK0ZDPjDWBEgCOj49hsVhkkrMXAHVUZrYLhQK8Xq9onUwUeb1e\n1Ot1Yb6ssKOWywYndAnwPhGUCHr8N7Pg/A4uOMpBjVYZYSiZK7/nw6E5rVR0wdjtdvldmAxSfoey\neQqBnDYsfobnyGhQWYGlrDADTjLSixcvfiRMeyJAev36dVQqFczPzwMAzp07B5fLhWQyiUwmIxU2\ne3t7WFtbQzabldpor9eLiYkJqXZot9tYW1tDoVBApVJBIBDA3t4e3G43Dg8P0Ww2kUwmpbxve3sb\njUZDtDdWDM3MzGBvbw9GoxHj4+OYm5vD7Ows5ubm0Gw2cXBwgIcPHyIejyOdTsNoNOKZZ56RIoJ2\nuy3ljKyYuXLlClZWVmQV9Xg8Ut1hNBoxNTWFZ599Fvl8XsKmcrkMjUaDYDAojVRYbbG/vw+TyYTt\n7W04nU6sr69jdnZWHlb6Wh8+fChM32KxYG9vD36/H3a7HY8ePRIvnkqlwrvvvgutVovd3V150HU6\nnTBiaprPPfccrFYrBoMB9vf3EY1GMT09LXXop0+fFuDpdruYm5tDPB4H8PjBZIRADZo6JRcWjUYj\nvQtyuZwAHI3lXq9XQFFZYmi326WCiV5TTnJWstCTydeU/km+RkAngBMUOCEJBMpSSmb+eSz6Jpmk\nbDab0g1KWbfu9/sl6vH5fCJVENAptfD7aO1RGugJLqx04t9ZTksAJQDxuRsOh1LxxOY99KP2+/0T\n/4/3j8+mMonE/gT8jXgMZcMVAiLvs1JvBfAfmpwQVFnV5HK5RC/lcZWg+eEFWPn/ed60fSndD2Su\nSg34w4OL23PPPfeRMO2JAOnOzg5u3LiBYrGIp556Ci+//DKy2Sx6vR68Xi+i0Sjm5+fh8XgQCoUk\n80hryDvvvCN6HY25DPnJxBjGm81m8ZUeHx8jEolIXa3ZbIbP58P6+jpcLhcGgwGCwSB++tOfolqt\nYmNjA+vr6zCZTNBoNAKwjUYDDocDb775piQd7t27h4WFBRQKBcmw8ofz+Xzo9/toNBrI5/OSYCkW\ni9ja2pLqLrJGTsbj42PY7XZotVppA5bJZBAIBBCLxeDxePD2229jaWkJBwcHIk2YTCbcu3dP9KBk\nMonp6WmZoEyCzc/P49SpU5K1np6eFpCn15IevGKxiGKxKH5MAgvN4teuXYPdbofVakUymZRJFo1G\nxdsYCAQAAIFAAPF4XB76ZrOJwWAgCbJwOCxaNosvmLVn7wOlrcVgMMBqtaJSqSASiUgLxr29PdEg\nle38mJ1mYob3qdVqCViVSiXodDpYrVbRxvmdACSJRCas9E0ScFiiS42P4fNgMBB5Znt7G4FAQKqQ\nmLRidJbL5aSrVzabRSQSwWAwkPNThtL8flazsVpLpVIJqGezWQQCgROlnmTc9HoCkDwB2y3SR6oE\nPQDCmLlYMGlE8ONiAOAE4/t1lVQApP6eXlH++8OaLPVNflYJosQKLkIEdOCDDL7yu5Vgyt4RVqsV\nMzMzWF5e/kiY9kSA9Ec/+pGE3u+//z5eeuklafnGUJmJHLIU9mdsNBqipTK8YWJndXUVa2trmJub\nw8rKClQqlWSsVSoVfD6f6C5utxuZTAa1Wg3BYBAulwsAUKvV8MILL0h/VDJfTkQmjhhm6nQ6eTgb\njQbS6TTm5ubEXM6scKlUQr1ex/z8PNRqNSwWC27fvo1Lly6h2+3iqaeegkajwcOHD1EqlRCNRuFw\nOKT927Vr1zA+Po6lpSUcHx9Lh6dsNotqtSoP/PXr1zE3NyfmZ2aKzWYzXn/9dal+2t/fl56mNIX7\n/X5cvXr18YOh0YhNyWKx4NSpU9K/NJ1OY2FhAbu7u4jFYrLIpFIpmEwmSUJFo1HcunULTqcTsVhM\nWC+9uyqVCh6PR4oGyuWyGL2r1aokTMjuGH5SX1PqdMpqlcPDQzgcDtHEeBwuAGS1AKR/ABc6JsJ4\nnsBjrcxqtaJarYpliH9SK2+1WsJ+mFUmQBGgm82mJO04YVlIQlN4q9USd0YikUAqlUIsFkMul5PE\n1eHhIUKhkOh+SpZFJseFgv0eWBzAyjKyWAI8z49hP61aBB6WWnMBZYjMz/J9PAdeOyWZX5cUomcV\ngNjg2E+Blj2y1A8nwvh3AiKTU9SvuTBQqqAUw6HUQslWmSdglOHz+bCysvKRMO2JAOnNmzdFiG61\nWrh79y50usfNnavVqoBmOBwWsZy9F6l58oGLx+MIh8PS95NgxlLQYDCIYrEIj8eDYrEogFgqlYSx\n0n6VzWalvPDOnTuoVqtSe85EUT6fx9HREbxeLxwOB5aXl6WQgJqqzWZDuVyWjCUrhl566SUcHByg\nUqlIaKRM5jCEtdlsiMfjePToEXQ6HbxeL8bHx6UhNSfJ2NgYnnrqKWxubuKZZ54RRnFwcAC9Xo9w\nOCyWsqmpKWxvb0sZJau66vU69vb2sLOzIw/f8vKy1PFvbm5ia2sL8XgcrVZL+mvu7u4K22KCLBqN\nYjAYoFAoYG1tDadOnYLb7RabE9k7FyTqkOVyWdqzMZttMBiEmabTaTgcDrlnlUpF2A6zvr1eTxKD\nrNhS6ozUQ5Uljfw8ALEBKS05rHJR1pwzeUW2o2wJx94GSq8wtXmGmsw681pjsZgkC5mZp8xBiWJs\nbAzJZBJjY2PSgIegzOoxdmJSOh1yuZx0lKJjgBopFzB2GwuHw1J1R6BkWE1JgqG7skqIiwaZJwGN\nVWPKBY/gxdfIzimL0AZIWYVAqUw+KVmpUl/nedDjShDn+SpZKwGUFWRk5lyAqAGHQqGP3P3piQDp\nzMyMlNfxgWJ54+zsLMbHx6X8y+l0itmbZYsM51wul7RmY1dzNhPmSqu0zNCEy2RCr9dDOBxGMpnE\nwsICjo+PEQwGEY1G0Ww2xVJEUEwmk5idnRWrTr/fR7lcxs2bN5HJZBCNRpFMJqVxsMvlwuzsLCqV\nygmb05kzZzAYDKRJAmvJmfHt9XqYmJjA5cuXMTExgXg8Dr1ej+PjY7H0GAwGxONxvPfee5ifn0eh\nUMDW1hYCgQDGxsZkwYnH4wKGOp0OzzzzDHK5nJQqRqNRXL58WZhCu92WBh2JRALhcBhzc3OYmJhA\nNpvFcDhEKpXC2NiYGPCZIV9fX4fH44FGo8Hy8jLeeustaLVazM7OSijv8/mkysjlcomux96tZKD0\n+7JyqFQqIZPJyLWxPR6LLYDHk4saHwsU2u02arWaRAw0qw+HQ2kxR2sNmZvSzM1Jx0WHlVIEW7Yc\npL3I4/FIyTIrv5iAoouDiSc2H2E/AmXlGK+JUYAyMcOIhlokz1Gn00lvBK1Wi0gkImyVXlEA4hyg\nDquUV5QhNmUKLjhM9PJ4vJccBEqCH8+LbJVgyPcyOhwOhyfM+B92AiiPrWS1BFXaFOkPpRykXDCV\n7FXpd6Vzg88Bv4/WtE80kP7t3/4t3nnnHVy5cgV2ux1LS0vSwDgej0sbu6OjI6mTXlxcFEDQarXI\nZDKSBWeFDlmuWq2Gy+WC0WiU7UCU4jctR3t7ewiHw7Ji6vV6YVesv9doNKhUKpicnJSOQVarFePj\n47h37x56vR4WFhZE0F9bW8Pq6ir29/fh8Xiwvb2NnZ0dLC4uYn19HYlEAiaTSbLeZK+9Xk+6w6tU\nj2vR9/f38f7770sGk6Vz/JG1Wi3Gx8dPNLc2m80wGAzY399HrVZDo9HAc889B6PRiEAggHv37iGd\nTiMSieDMmTOoVCpyz+mBJagsLS0Jk7p27Rr0ej0mJycRDofh8/ng9XplAuj1eoRCIWFnpVJJMp83\nb96Uzk+UHGiCp/VofX0dtVpNEm+892xS43Q64Xa7kUgkJAlH5scqJIIa7+vh4SFmZ2el5R6TlrQu\nMYS3WCwoFosCNLRfURqg64BOAF5DMBjE0dGRVPuUSiVMTExga2tLFnzeT4aP9ByTmZIpDQYD0a/Z\nd5TPATtL8Z7QuUBmqwyRqSmazWYcHh7C5XIJOBP8qBGrVCqxRdE1orRWUfYggLKJCj3RKpVK+igo\nHQZkmwQ9ArJyUMagvq3UQpXsUwnOyrCe/5lMJtTrdQFRMlyCKL9LGcqTaBEXlPdPWdn1iQfS73//\n+wiFQvja176GQqGA/f19EdTZZ9Dv9yMWi0kT3QcPHsBoNMoWBDMzM2i1WtKejODJlYga1OrqKobD\nx02dmWhiCM6QudFoyHYf9KtxD6Jeryc194FAQPyPa2trOHPmDI6OjnDq1CmYTCYEAgHMzs7i8PBQ\nBG9m6mmNWllZQaPRwMzMDLxerzSltlqtsgeQ1+uVpsIU/KPRqLRw4/5AoVAIR0dH2NjYQL1elwbV\nt2/fxtmzZwWEdnZ2ZEVmx/lCoYB4PC7Nmy0WC3w+H46Pj5HL5XD27FnxZHo8HiwvLyMcDktIyXvM\nc1H2vaRH02QyiSOi2+2K7kaNkCG42WyG3W5HKBSSFnkEZw5mYlkTz1JSLjCsglFOfgIKG4oYjUac\nPn0a29vbYn8icDDjrtRalaZ39oSgBMG9vAqFgkgl3W5XWvGxvWGv10MwGJS+tR6PB1evXkUgEEC5\nXBYGz8o4ghQz106nUz7P1xieUgpitRfJAksumWRj03FeL1kf281Vq1VoNBqpwmMvVd4XpSeV8gPt\nYEpphbICXRCU0ZQNuAlYlAooGyitT8AH/k6C6ocz89Rgi8UiAAgY87dTslml95UVdOzfwcVUWZDA\n7/7EAymZ4o0bN5DP52X1CIfDWF5exvHxMX7xi1+ID/PWrVvCuNh+7P79+2LwJhhyvx2GbWRY9Xpd\nSs+4Z5LD4cD+/j4Gg4EkNvr9PpLJpDAjVulEIhGpkiqXyxgbGxNdkw9BPp8/0X2qVCqJTYQhHADp\nbhMOh5FOp3H+/HlkMhmoVCoBxqOjIywtLaFYLCIQCEinqX6/L1UqFosFt27dQiQSwalTp+Dz+TA3\nN4fh8HGT5ePjY7z33ntwOByyLxaZ9sbGBpaWlrC4uCj2Jb/fD5PJJF2X7t27J1n3e/fuodlsIpFI\nIJfLQa1WY39/H9VqFbdv30YsFhNmSMZGMGBjFPY3IDvjhmPJZBLAY5M5JxXtNgyh6fWjNYq17j6f\nT/yobrf7REMOLsx0ehB0mNBkVplRCIGHJn+LxSK1/CwXTafTiMViAlBcFEwmk2yadvHiRTx69Eha\n9zE0Z9URWTrBn2yYjIyLByvzCFLUI8mgmHSjHYr6OFtQkvUyKqIfulQqQa/Xn2jmTF2eG1EyCdXr\nPe7MxQiFCSqlFxT4YI8pLpwARGekBk39lvdAqbMCkHCcerYyoaSUNPjZ4XAom/5xEecCQYZNiYHa\nOIkYh7KsVZmI4ohEIlhcXPxImPbEau3JAs+cOSNidyqVwnvvvQeVSoXPfe5zKBaLSCaTkmGn0d5u\ntwvAJJNJxONxeDwemaB2u13sKNRO5ufnpR692+2iWCxCpVLhqaeekhXdZrOJXYTNbvf29jAcDqWD\n/v7+vlQDeb1ezM/Po9VqIZPJYH5+Hmtra1hfX5edMjkBstksFhYWMDU1hVarhUQiAY1Gg1QqJfIC\n9Rq32y37GiWTSWi1j7uDU/7w+/04ffo0VldXce3aNaTTaaytreHo6EgSE2y4wK07DAYDvv/970tC\nKJVKIZVK4ZlnnoHFYsH+/j6uX78uK/Xy8jKmpqakRyzZLcttNzc3EYlEEI1Gkc1mRe9mLT9LXvng\nMrnEyWm1WjEcPq54cTgcJ7K2yslFlsVdXhuNBvx+v4SYrHfv9XoSLjN7C3zQSk2lUkm/AafTKcyF\n0QxDVP5e7CtgtVplK5JKpQKn04lOpyOFB5lMRhga+3OyfJcNVXZ2dmR7FO5qG4lEpFcBdUpqujwn\nHldprfpwCMp2hEw4ESB5zeywT5ZG8AUg+jIr26h7K+vQufAx6UviAECkBQDyuzEq4TVw0SJjBj6w\nTCktTL1eTxpoK21WfA7ITtmEhm6Yfr8v+5wFAgHRmQmOPB6bnfP7yE4/7EAAPtDFw+HwJxtI19fX\nZSvkX/ziF1hYWMDOzo5kGxcWFk5YoFhe9vTTT0u3pna7ja2tLaniIfBx61ydTifNfgOBgKyyg8Hj\nNmnUpHgzM5kM3G431tfXMTExIavX2NgYfvCDH2B6eloYFnsD2Gw2vPPOO7JCu1wuaUJNx0Aul0M0\nGkUqlZL9qZ5//nkJ+81mM7a3t0945hKJBEKhEDQaDUKhkOhzLL3sdDrSHXx5eRk2mw0LCwtQqR5v\nvUJTtlqtlkqifD6Pz3/+8xKenj9/Hu12G1euXMH+/j6mpqYQCASQzWZl76MrV65gbm7uxHYRDGVP\nnz4Ntfpxx3reU2V12vj4uIACrWrKbbFpd+p0OkilUifYvTLUIjOhBhsOh2Wb6WazKRp6tVqVZA7w\nQQjIklw2h2FWnkCh1BwZsfh8Puzs7IhOz25MzJKbzWYkEgn4/X5JVOzv70urwOFwKO4B+mkZKXEj\nPIbByuIBArEyolKa2cnECWrKLk/8fKPRwOzsLAqFAgCItKDVakW3pq2PfXHpeGCDFyb/2ACax1Za\n1xjh8Ts+3AiFWXReO1kkM/a8/wQ8foaLKBc2ZaZeWerKXTS482+lUkG1WhXA5Ryn24OFCbyfynJR\nLkKUTHhe0WgUp0+f/kiY9kSAdDgc4ubNm7h69Sp++7d/W/YEKhaLWFhYwK1bt7C8vIzTp0+LDvL8\n88/jO9/5DlwuF5aWlkTEp/GZbbXYcou61tWrVyULzTCXN99gMCASicgmYj6fTzY9Y0WQ3W5HMBiE\n2+3Gzs4O1Gq1JEoASFOIqakpvPrqqwgGgzAajXj//fdlPyBOKvpaw+GwsC2WG3Ii+3w+OadIJILD\nw0OxZZ0/f146Pd28eVMSLu12G/fu3cPBwQFmZmbQ6XSwu7uLhYUFuS52u2dlkkajQTqdxrPPPovh\ncIhXX30VFy5cgN1ux9raGhKJBD796U8jnU5jfX0dTqcTjx49ElG/33/cCm5lZUXaz/X7fek7EI/H\nUSgUpHu92WwWLbbX6+HevXswmUyixTGLT/1UafDmvW40GtIbIRQKYW5uDvV6HcViUZox049JkGJN\nPicjfZ0EUAICk0H0iA4GAykg4PYk1WpVul1ZLBYcHR1JFRDBgronIyP+9rT3UKulDYsJLp/PJ2yQ\nUgJwMvzk58ikOfkZ2ioXAwIyXSfxeBwOhwNnzpxBJpORXALZI+UMulpY305vL6M4luMqgY73j4se\nk038/ViAwvcry0+5CLOohuE92SNdPUajUUp/lfuZ0fXC/hBMzPJZItsk7ii9qMpCAf6bixITmp9o\nIP3ud7+LeDyOL33pS7h37x4GgwEODg4EOOfm5vDTn/4U29vbUnp4+/ZtfP3rX0e1WsUvf/lL+Hw+\n6PV65PN5nDlzRnYP5ErNxMqpU6ekYoi+TTIh+szYHIM9SqkXUdtiSD0zM4NyuSxbGlCopltgZWUF\nDocDu7u7mJqawnD4uPafyQ6TyYRnnnkGzWYTuVxO9ElmeEulEnK5nJTb7e/vSwmlzWbD+++/L35M\nhmH0f164cAFHR0fY3d1FIBBAJBLBr371KzidTrhcLvzyl79Er9dDKBSC1WrF4eEhLl68iN3dXVy6\ndElY7mAwwNjYGMxms7CrhYUFHB4eYnFxUbx6tKO9+eabuHv3rlTccNsL2oVYbUTDd6lUkmQb2Q31\n52KxKM1U6G8EIL5E7q9Fpnj79m1YrVYEAoETk4ITmLXxLMAolUqi4/J9ZCpMKn7605/Ga6+9huef\nfx5vvfWW9MrleSp1XO5x7/f7xa4VjUZRLBbR7/cRCASk9JPsjEZzRkLsu0DjOrdr0el0J/p+crIT\nPNm4msknsmyG4cPhEJFIRCrB6EHlTqz0WpLVVqtVATUOsnsa+zmnyBoNhsc7x547dw67u7si47Cd\nH4/LnXVpjmdSjyXVRuPjrZfv379/ooE3AKleZBHK6uoqNBoNNjY2MBgM4PV6ZVFi4pKLIX9fZQSi\nDN+VDgH+m0DPaPATDaSvv/46Ll++jCtXrqBSqSAUCuErX/kK3n33Xdy9exftdhtnz57F3NwcNBoN\nbt68CafTiUwmg/v37+OFF17A/v4+Tp8+jXA4jJ/85Cfw+Xxyk0jla7UaHjx4ALvdjr29PWg0GiST\nSTH9OhwOaQ7CSqHt7W3JwBYKBalzN5vNskHexMQEnE6nNOtlKWU+n8fm5qY87AcHB2i1WpidnUUm\nk8HS0hJu3bqFw8NDzM3NSZhICxctLmq1WrrnAx+Uz4VCIWE8BoMBy8vL6Ha72NjYQDgcRiwWk14D\n7XYbzz33HNrtNjY2NvDss8+iWCzi1q1b0j9Ar9fj2rVr0gmfdf9KLyP1wcXFRdkvfjgcypYey8vL\nsgVIIpGQ/pihUAg+n09241Q2DOF2ufQCd7td2TU2EolIdyxqdZwILpcL6XQa2WwW586dw2c+8xm4\n3W5hfUoNjx2hyFSLxaK4IbhfPABhdx6PBzs7O1K44Pf7Ua1WT4T1NIqT5TmdTmkmotFopLMUK45K\npdKJyhyLxSIlwsq2fgaDQQpEgMchLPsc0P3Bf9Ngr6w44vNB7yr30SJIEFSoibKKj/OgXq/LOVGr\npIWN0RHDe4JNp9ORNnncsZXnwYITpSzD5BcXhlqtJo4WNgpaWVmR76HcQjyYmJhAJBLBG2+8IZrv\nxP/eg41zhA3I+QyQYSoTSbwGpQvgw+DKEQqFPtkaqcFgwMsvvyy9HO12O37wgx9IbSvNyy+//DLu\n3r0r2xZvb29jfHwcOzs7eO6553D//n28++67+J3f+R0cHBwAeFzHzc46ZDTRaBS5XE4qF5j5DwaD\nUgzADlMGg0EM4EtLS8Jmms0m5ufnZb+g27dv48yZM7h58yYmJiYAQLaKZQcldtzhdx4eHkqWmXrw\n1tYWisUiQqEQJicnxY5CzyLDHL/fj0KhgFAohFdeeUV0XVYXXb9+HZOTk3KdbrcbDx8+hNFoxPz8\nPAwGA5LJpFi12Nxkbm4ODocDCwsLuHfvHqLRqIRZPJ98Po/19XW88847GA6H4nhQglYikYDL5UIg\nEIDRaMSjR49kArO0kuEZk4aMKNi8hLoVt9Ll5wFIiD82NiZbvTx69EiKBJjoIHiwg1K/35dGzy6X\nS2YypVkAACAASURBVAoImHTkpHY6nWLyV/bqVO4AylJStsnTarWIx+OYnp7G7u6uZOopV7hcrhMO\nAIIxk2GsUGNyKxgMwmQy4ejoSCxgSiaqbN9HkGXITN2Vix8ZM8N49ldgdVatVhO2TKsWj8ciBmrO\n1G4pwTSbTVQqFQmfE4kErFYrYrEYjo6OpBKRzYKq1aowVHYoY9KVdjU2aqe3FnhcmjsxMSG9Yd9/\n/3185jOfkQo2VgOydytlEGWdPwfvpZK58zWG8h8O99kH+KOMJwKka2truHHjBoLBIMbHx3Hnzh0p\nZfR6vSgUCjAajZiYmMDTTz8t+4cvLCzA6/VCq328BUmr1UIgEIBOp0M+n5fMPa1QfBi5bxIA0YDI\n7JjZI7gytKWvlFsUx+Nx7O/vIxKJwOVyybnTjsRmITs7O4hEIjg4OJDmErSQUDs7d+4cLBYLgsEg\nJiYmoNM93k6Bvk16ZAeDAYrFooAQEztTU1OyG0A2m8XS0pKwPTKbhYUFTExMYDgc4saNG1CpVFhY\nWEC1WkWtVkOtVkMkEgHw2JLFjljXr1+HSqWSXqevvfaaeEzpgWUxBPt2ajQa8bly2O12CVtpbSKT\nZnaW9h9qiwCQy+Wk1pqZX+ADrZD2pVgsBq/XKwwtn89LPwOCE72h2WxWMr56vR7xeFzCULPZjFKp\nBI1GI8kdnU6H/f19YbV0U3CSAhC7nNlsFs8xze86nU6Sfky40SfK/rV8xnntZJg2m002MGRShQDM\nxYevM/FEpsxtULiPGHdKpTdUqXeS3bLnrFIbpeaozNhzYWLrQ9bdO51OeW8+n0ev10MgEMDt27dh\nMpngcDgEgPP5vGwLQ9eMsliB18rGI1yEaWubnp6GSqWSRUvZ3IS/jRIcCchkpcpFSWn4Bz7Y44mL\nCQs1zpw585Ew7YkAaTweFzH8nXfewW/8xm9I09p8Po9cLid736RSKZTLZSwsLGBra0ssGdxdc2Ji\nAuvr66Llvffee7BarTh//jxKpRLi8TjGxsZwdHQEp9OJRqMh5Xjdblc0nnq9jtXVVVy/fl32fb93\n7x6CwSDm5uaQyWTkBt++fVsa9ZbLZQlL6R8kmJ8+fRrxeBxnz55FMpmEyWTCw4cPkc/nMRgMkE6n\nsbOzI00iuC30gwcPZEVk2Gs0GrG+vi6drGizaTabEqoVi0XpdXn//n3cvHkTZ8+exczMDF555RU4\nnU7cv38f4+Pj0mpQrVZLS8Hj42O8+OKL0qOUJYfcWqNQKODo6AiRSOQE6HCPJJbR8nUyJ07+ra0t\nyQpTx242myKlsNGLxWJBKBRCvV4XO5WyKUcoFEI8HkcymRSTO49HxwQjASbBuODxeur1OpaXl6FS\nPW6abTabMTk5iaOjI1nwKN8AHyRJaO/JZrNYXFyUkJaaJhuc7OzsIBaLQavVIpvNSqa71WpJE2ij\n0YhQKIREIoFAICD19bwPZLMEWDJHNg4hqDPzTmDOZrOin9JpwuiMoEjJhefOhBNzDNwwMhgMIpFI\nYHx8XJrL8P3MglssFuRyOWHY0WhUtl1hxRhLorPZrBAXnjfr8plMU1rhGK7zWjqdjpSFp1Ip+X2V\nXlMAJ8J1ZfcnZeiutF8p+zbwvUajEU8//fRHwrQnBqTb29sYGxvD3Nwcrly5gtXVVWxsbKBUKuHC\nhQui1zCE4B443H6BjIdG9lOnTuG1117D0tISzGYz7t27J5rMwsKCOAP4YChtH1tbW2g2mzg+PsaZ\nM2fEWnXp0iXZJoM1+LRS+Xw+rK2tSfKDjHZ6elo6NbGumjuicn/6SCQiXlOu6IFAAIlEAjabDbOz\ns7DZbPj5z38ufUnj8TjOnDkjXdTJpKLRKH784x8jFAphZmZGJqjNZsPY2Bh2d3exv7+Pz3/+8yLO\n6/WPNxBL/z/MvWlv22d2Nn5x0S7u+06KoijJ2rzIW/Y0k2knEwxQzKAtin6BfqS+S1+0wKDT6WQy\nWRonsSd24kWybG3UQlEkxX0XRUmURIr/F5rrhMrTB80D/IFEwMAex5Is8v6d+5zrXEs+L4R5pVIp\nuVZUyxCHVqsvMqvId+WoxSVANpuFTqeD1WqFzWaDXq9HJpMRzi9J1iwE2WxW5L2MWyGNie/x7u6u\neC3YbDa5xNiROp1O+TlzuZwsSUj+5+jcbUhssVgE587lchgbG0O5XEa5XIbVahUcN5PJYH5+XrK4\n1Go1LBaLFCRKKzm6E/55/vw5bDabeEm43W550Ek5ImxEbI669U6nI+Oz1+uVjpyFiJcKKUlms1kE\nKFyKkp/LC4TdVaVSweTkpHSs7Nbp7ZBOpyU2mmm+vACNRqP42XIJxmeTMAzxTi7QlpeXoVarpeEx\nmUxSCHnhcREEQDb1wHe4+ODgIGKxmFygdHHj+8z4GcppyUvmR3cHClx2e+J/53tA5gUxZ8JuAwMD\nP20/0mfPnmFwcBAfffQRkskk/uEf/gGff/65YJCPHj2StEhiHwrFhQsOs+29Xi8SiQTOz89FUTQ9\nPY3l5WXJ9/F4PNjd3YXBYLhktKHRaAScLpfL8iL6fD5EIhGxYOPmlUmndEDiuLK3tyfbbm5qCa6T\n4nPnzh1xSOIDfXp6KiMv9emtVgvRaBRarRZfffUVtFqtRH/o9Xo4nU7BBEnDUigUePjwIW7fvi03\n/PPnz3Hz5k3hbALA7OwsIpGILLaeP3+OdDoNg8GA0dFRxONxYSd8/vnnePToEXp6ejA7O4vf/e53\n4jJF6CCZTArm6/V6MTExgZ6eHrF9Ozs7EwL/wcEB6vW6UJOGh4eh0+lQKBSkwyFlrNVqYXl5Gevr\n69KVsVsmkZ8wTreLF6EHq9UqXq7c2nNp9vTpUzG77uvrg9VqRSqVkoKjUFxY+imVSnm/19fXMTU1\nhVKphL29Pfn8Wq0Gs9ksPzNtBLPZLMbGxpDP54X1wS03+bTdm3qFQoFSqQTgQslE/JGTEuEEjsb8\nWbhAajQal+SONHvR6XSSg8WlFw23+W/iKExlFYUVVCdx1CUeyU715ORELhAWPHboVMYNDg7C5/Nh\neXkZU1NT8r2B77xgOdExKI+UN7JhmDJA5gKzxbr1/AAE4ybE1K2rZ7cJfFc4u7miXOpR/ko4jd2p\nTqfD7du3f1BN+9EI+f/yL/+C6elpXLt2DZ988glGR0dRrVaxtbUFq9UqGec0JDk/P0ehUMD09DQO\nDg6ws7MjRPfr16/j9PQU29vbEmymVquRz+cxPT0tGFQmk0EgEBCTEEo3GdtLiajNZkO73UY0GkWz\n2cTExIQcEDoJ8dfT01N4vV5ZLmSzWbRaLeGfrqyswGq14u7du3j58iWGhoZgs9ku0a14kKamprC1\ntYWZmRnhwjEPfGhoCFqtFsFgEFeuXEEsFkO9Xse1a9ewsbEhZH5GVdhsNrx8+RJarRb379+Xbf7G\nxgbm5+eRTCYxNjaGtbU1eDweOXxutxtnZ2dIpVJoNBp44403EI1Gsbi4iOXlZXi9XrFTI0ZXKBRE\nrufz+USVw4WNXq+XokCJIkMKSa1hLLFWq4XP5xOI5ODgAOVyWcbe7m0xu3OOu0dHRxJJQ8I5cOF2\n5PF4JPOKSZ1Op1PwbV4mXLTRBIXsBk4NwEXyLOEEunL5/X4cHR3B4XBge3sbExMTwmskrkxFlUaj\nQblchsfjEdMXACIqcTqd0qGSvRGNRqFWq+XfQvco/p77gkQiIdEenU5HYsZbrZZQ6Wq1GqxWq1DV\nWNR1Op0UGXoY8LIjNYtKK3bBZMgMDg7K5GAwGBCLxTA5OSkUOnaazL0in9lut0tMkFqtloVbf3+/\nwButVgupVEowXX5f8rI5xXDx1o2Tdv/KZROnI3bmpEWygBIeGB4exp07d35QTfvRMpvu3LmDZrOJ\nZDKJcrmM2dlZZLNZXL9+HXq9XkxK1Gq1mC5QyuZyuYS39+abb0osCSWJh4eHMpI4nU5ks1lJYiTo\nzY6W4ySXHa1WS+SOHE9Ii4lEIhgdHUWtVhPeHX1K9/f3ZezsxiCJ9ywuLmJmZgbFYlH4p+T1lUol\nnJ6eyraWwgHmMIVCIfT29mJiYgL1eh2rq6vw+/14+fIl6vU6ZmZmxFnf5/Pht7/9Lebn54Xgzy3u\na6+9JlDIzMyM0MN4UZF/yl+TySTS6TRmZ2fFlo6GJ9zAb29vw+l0XoqFoESPlCBa8w0ODspGu9ls\nolqtir1bu92G2+0WRVqnc2GV6Pf7ZcHIcYsPO/E1/tvoQRkOh0UkQCWRQqGQ0ZoXHs8DZZL0A6BY\ng4WNnXGhULjkncnvFwqFZNmVz+fh8XgAAOl0Gp3OhfnF6ekp3G43MpkMwuEwUqmUeME6nU6BWFQq\nFYrFovgCFItFABfFQavVigUeO0BCA5Sscgyn0qib20t/CE4GnB44oVFiSooSlzLdYXoch7npNhgM\nIsz45ptvYLFYEIvFMD09LW5fNN45OzuT5oN+uqenpyJ0aLfbKJfLiMfjiEajglNzSUeeOKEUQgXs\ncoHv5KR8zfhvJYzQ09Mj8AfZJN0wCD8PuFhE/qRH+1wuh//6r/+SB4ZpnjqdDtFoFMlkEhMTE6hU\nKgiHw6L37unpkeA6rVaLO3fuYHFxEUtLSxgdHUV/fz/S6TSsVit2d3cxNzeHTCYjLz63yvV6HRMT\nE9jd3ZXNvP8vgXbsqB49eiRdMjsgOuvQJWlgYEAs4ZhDT/6dRqORiA0+5NlsFuFwGENDQ3j06BHe\nfPNNkaIxMYC+mcSLe3p6sLa2hlqthq+++kpuy/Pzc/ziF7+QDXipVMK9e/cwOjqK69evC+GZZH6q\nyfR6PVZWVhCNRtHf34/Z2Vk4HA5EIhHxKGWCKqV0jx8/hsPhENI9sTOlUimYMYnXVL8MDw+L/LM7\nRI7Fj1EijDRhkB7HW5VKJSMuLy0q2UiQZzGnOTQXLaRCER4gbYkLGH5OT0+PZL4TF+Tf5VkgbYl0\ntHw+jzfeeENeczIyuJmnFwIv0kqlgkAgICbmnU5HpiwAsFqt0hmRjcCx/eTkIr2URYxTD7s8wk/U\nl3u9XkQiEczNzYlLGACRjvJM8MwMDg6KuxcxTCqdiBcGg0EkEglhSDQaDaGHsTNNJpPodDoSNklu\nLwAJ2ePFSgrf4eEhksmkTIRsILxeL6ampjA3Nwe/3y9c48nJSZhMJrx8+VI68Wq1ilQqJW5kwOUl\nE38lwZ/P/+HhoXxfFmJisbykuYT9SXekDx8+lNFwYGAAjUYDLpcLw8PDsNvt0ulQg7+2tga73Y7j\n42OxjPv5z3+OnZ0dAIDf778U80C6BIF9h8MBAAJUU3ttNBqFEmI0GrG6uorZ2Vns7u6KtE2v12N3\nd1dkotyok+QfCoXk+5VKJXGBZ3fc6XRQqVRw584dnJ6eYmFhAXa7Xdx9crmcFPRWqyXREiaTCXa7\nHe12W3KsGPTG4LP19XXZwLJTtFqt2NzcxPHxsYgNyuUylpeXEQqFYLfbodfrJbhuc3NTsoXYWZpM\nJtH+dzoXhi283Xt6eoQWxI7u+PhYHIzo98lCrNFoMDw8LM5F3IKzUyAvVafTCUap1WoBfGcuTCUR\nN8McUcklZCfVbrely2HnxCJvMpnEm5bjJTfwxCVJV2LHxiJPc24ugwAgmUwK3Y6FjMsP8lS7qXGk\nmLGLZdopMfr9/X0pqOwISdCnjpwyVXb1tL8jlskFXSgUwoMHDzAxMYH19XUxUBkdHZWCw8Ra+sEy\nSptFiq+b1+tFKpWSZoQKLS7eeMF1v2cUGVA2WyqVRIF2enqKeDyOnp4eMRnpxrtpplOtVlEqlYQW\nyPwyLtmGhobg9XphtVqFN8oumh/kE7MJo5uXQvGdxeP3Sfs856RW3bp16wfVtB+lkP7Hf/wH6vU6\nZmdnRW6Zz+dRrVZRq9UEcyKBmg48NIG9evUq9vb28PXXX1+KI1EoFMjlcjKCvnjxAuPj4xI6R4CZ\nAH06nZbRmNQldhXBYFAOayAQEFqP1+tFo9GA2WwWLJQ4klKpRKlUgsvlkkJMpcb29jZarRZu374t\nqqrT01MEAgF5WHmAt7a2ZBHCrqdQKCCRSOAXv/gFPv30UwH5+/v7sbW1haOjI0xMTIiZCOWnfLDe\neustWCwWFItFVKtVPH36VFRfCoVCYpq3t7cRi8UAXCypOGpzEUAmRavVwtOnT4VveXx8LBnz1Ck3\nm03pSGijNjQ0BADScRFDJJ+XdCYWadKh+vv7YbVaxfaOyw6r1SoGMiym7Hi5DCHsQsoPvyfPFUd1\ndtHk5kajUfFwoDdpX18fbDYb0uk0gsGgMDd6e3uF51soFHB+fi4XHzvAvr4+OBwOkZXywqFWnY5W\njPPmRMANNzmfdrtdlm8ko3c7XhGv5SjPS545W5wGqE7j+E7fU7/fj1KphHK5LIvbK1euIJ/Py3vt\n8/lElDE5OSmvKy/ao6MjHB8fo9FoIBAIYGtrC3t7e7Jk3dvbw97envBluaSl+xmLIGl01WoVR0dH\nIgLgVMHnhJ3097mjGo1GMsB4WXaP8N3LqU6nI502s8d+0plNWq0W6+vriEQispXkCzk1NYWdnR3c\nuXMHv/3tbxEKhUQ5UqlUEAwG0dPTg2fPngkdKBqNIhgMIpvNinMRKTU05yB3kaPe3t6ecA57enqw\nvLyM27dvY2NjA0ajERqNBsvLywgGg8jlcoKxMq0yGo1KmFhvb69gr2azGUNDQ1hbW5NFCnmM3S5T\nDx48wMzMDHZ3d0Uqx67GarVKjnytVhNjaOrw5+fnYbfbYbVaUS6XMT8/L0qVdruNJ0+eCM9zc3MT\nBwcHYmpiMBgERL916xY0Gg1UKhVGR0fhcDjklj8/P8eTJ09Es93tAkSn9JmZGYRCIeh0Ouj1elgs\nFuFJrq2tiWKJBZOXDxU1VG5R/sgRndgaLz1OA9w08zUiH5PxJHQw6vb1ZBoAKXO1Wk0uj2w2Kw8W\n5cAcaakQ4ufl8/lL3S7J4kajESaTSSg/o6OjWF5exs9//nNsbW3JWM4teDd+rFQqpUMCIMbkvIzp\nr3l2dibLN5o97+/vy+vIbjQcDiORSMhordfr5b0hVn96egqTyXTJJYs4MW3vzs/PYbFYkEwmxXyZ\nuDg9ZakQM5vNgu+SRsROkljk+flFOq9GowFwQXeamJjA+++/D6fTKV4bwHddZLfnqUajgVKpRLlc\nlvgZYtZUmQHfjfNUgSmVSnF4I5e5uwPtXkB1+wdQ5PH/Yuys/v+hLv4/f6yvrws1hZvYkZER7Ozs\n4A9/+AP+/u//HhsbG3jvvfcQi8WwsrKCmZkZnJ2doVwuyxJmaGgICwsLmJqakiTPRCKBt956C598\n8okYUITDYcnPOT09RSQSgc1mQz6fx+zsLFZWVjA/P49EIgGbzSZLgBs3bmB7ext+vx/NZlPwGCpk\nHA6HjDh0lafzVKvVEkkqN7u8ELi57u3tFaoOrcs+/vhjjI2NwePxwOfz4erVq2g2m8hkMvD/RVtM\ns+o7d+6ItpqLORYEmqsYjUaEQiGRcCqVSolr3trakg6EJhDpdBoOhwM6nU4Wf8lkUm5z4rbHx8eI\nxWJiFUeuYzAYRCQSgdPplIUNoZVIJAKF4iKZgLhdN37F/8auJ5VKSTfJfzcfArPZLAu7jY0NWCwW\nnJ6eisKKJHcyP5jsSniCpHuaZHNjzUJB9gNVRHSJajQaGB4ehsfjwdLSEqampvD8+XOEw2Fsb2+j\nVCqJzJe6dn4Ot/VU87AzYwFlRAoznpLJ5CVlEFMTKIvV6/Uwm81ot9s4OTmR956mJNxqAxcFs1Qq\nwe/3Y3NzEz6fD51OB4eHhzg7O4Pb7Rbdei6Xg/8vijtOVcViEZOTk9ja2sLVq1cvLVy5+Ver1Xj5\n8iVCoRCcTqdMGjR7YRNDGOf58+dYWVmBTqfD1atXxWGKfFdmk3ER6Ha7odVqxa+A0A+AS4UQgCi+\nWFD5TLI4dztAkUva7TZGyOaHfvwoHeknn3wiig+FQgGXyyV8suvXryOfz2NxcVHswehsRIpGMpmE\nXq+XIhwKhYTrx1GOSxnGlHCsJR+PI6fBYJCHrlgswuVyCZ74+PFjgR+4PSTdhjpxqot8Ph+2trYE\nDuC2l4eckjp2YRqNBpubm3C5XNDr9ZJrz47QZrPh6dOnaLfb4vrk9XpxcHAgeNnm5ibm5ubw2Wef\nwWQywefz4YMPPsA//dM/yfijVqtlpOLDTZ4kb1yOYg6HA9euXcP09DQCgQAqlQpWV1cFFyPOyfx6\nrVYreJ3FYoHdbpdCy8tGr9ejWCyi1WqJxV+1WkWj0ZCIEZL7aTX48uVLVKtV+Hw+EScwCYGiCLIq\nrFarYIf00Gy1WsLsoPGLSqXC+vo6rl27Jko4RlW7XC55TRn5TQMQUo9GR0fx8OFD8X69d+8eZmZm\nBHqZnp5GqVTC7OwsEokErFarjN8MLyT+WCgUkM/nMTo6is3NTZhMJsTjcRlbqfhit84cMnJxaQt5\nfHwsiQTUyFMyyRgednKhUAjpdBq3b9/Gw4cPEQqFBJrq6emR96Jbd08RSLFYFEYGqWM07mYSBHDR\nTfp8PkkmoIsZn2MyLFZWVrC0tIRCoSAQFEUxLIgAZAlkMplwenoqOLNer0c+n5ctPjtQvgbdFyZH\n925tPYBLevzuCaFbKOFyuTAxMfGDatqPUki3trZweHgoaotyuSy3MAtbOBwW5Q5xHapJNjc3MTY2\nhi+//FLoT7Th02g0oiNfWVkBADF3rVarUtRarRa8Xq8Ucxo5Z7NZoaOYTCbZaLtcLqFB0dWHxard\nbguNCIA48xMYJ8bDbSgFBPPz81haWoLf70c8HhfZH6k6lEOSP/uf//mfuH37Ntxut5hxbGxsYGJi\nArlcDnq9HuPj4/j4448vkbMrlQrGxsYwPDwsUSI7OzsyztGdqV6vo1KpoNFoYHl5GYeHh/B6vRgf\nHwcAWfy0223hvtJf8+zsDFtbW+h0LoydlUol9vb2sL29LcU/m83KYpFdH2WFHMWJHzLcj1jo8PAw\nKpUKIpGISEO5heYmnosYjqjEwMxmszjrJ5NJkdEaDAYoFAqRD/McctylDr6/vx/T09PY3d3FzMwM\nstmsvHa0ZySUsrKyglAohO3t7UuZY4wEIT2LCQiVSkWivPn9yM0kd7O3txdjY2NC8qdLVrPZRC6X\nk66NZjQcZTudCxvHRCIhjcHNmzfx7NkzOBwOVCoVIe6T9XB4eIhms4lwOIxIJIKRkRHZWbDItVot\ngbHYyalUKqRSKemQgYvukFJOQhHJZBJK5UXSAr19+/v7L5mqkKFA2KVcLgOA0CW5FKNybWBgQHBk\n/uzsJlnkWShJCevmjHYb3QDfQQSM8fkhHz9KIV1dXcXXX38t9mBUJ5Eg7Xa78eTJE0xNTcmGlSMI\nqTzUspNiQwyUD3W9XhdTEh5M/19MPDgyARdLD45PXHwBwMjICO7duyf0Hp1OJ51GLpeD2+1GPB4X\nYjNHW51OJ1vkoaEhJJNJhMNhJJNJwRZJn9Lr9SJ7MxgMKBaL8Pl8UhAKhQLGx8dFdTQ2NoZMJoNy\nuQylUonBwUHcuXNHOI21Wk004K1WCxMTE9ja2kIgEBB6mcViwdnZGW7evAmj0YiPPvpIDEloEEEs\nmYmW+Xxe4Ah2WLVaTYj2NGvma1Eul2VbeuXKFZkCLBaLWO4R/2QnwY01FyyEROiWxUWW1+uV5Q7p\nLCSKswMcGBhApVIRJzCOt7xECClxlGbSAi+86elpyXjnBcgNO9VzpM+xCPF14wU+OjqK3d1dBINB\npNNpAMDS0hKuXLkiHSWXaGReZLNZUXJxacb/FovFxF+BO4Xj42MEAgGkUikpjLzwiUdWq1XB6Vlo\ni8UigsGgFGm73Y7V1VXY7XZ5HcnzdTgc0uUz5YCLMj43ZKv4/X5ks1mhjHUbkVBNdv36dXn/vu9K\nT24wNe9cgNJDVa2+SM0dGRkRRynioCyibFa6l05kb3TzX8l26JaQfr/4+v3+n7b70/2/RFgQ5N3b\n2xNfy8XFRQwMDMBqtcJgMMgGdGJiAul0WsZJGhysr6/D4XCIaw4XNKS38GbT6XTY2tqS8Y00FJKV\nz8/PZcQjX3FwcFCy57mU4UaV3DsSm3t7e6UjJWmbJtF9fX3I5/OXbMeMRqOoZbLZLCwWi+ShLy8v\nw+12i8cncS/Sh8i7A4BCoQAAorWemJiAVqtFNBoV/i2dc4aHh7G7u4uenh6JZaZVYKVSwcHBAcxm\ns3hUchPLAkeqi9vtRjgcFsURH2w6WvEya7fbSKfTYsrMrXilUpHXiF0At8TARSfAB54jGJUrfJgb\njYYUFqvVimg0ijt37og5TLfHK0nrvMgIDe3s7GB8fBw6nQ4vXrwQCIlYOi8nv9+P9fV1eDwepNNp\nqNVqSS/o7e2F1WqVYhQMBoUmtb+/L+NyN2WLtD9eUHyAGT1Dj04ahgcCAZyengKAYPiHh4dCtSKL\n5OjoSCYFl8slEEy9Xke5XMa7776Lvb091Ot1ccyieoiXFqcOvje89DKZjCyv6vW6NBj0KSANjRnz\n1WpVOn4uA8/OzhCNRkUyTLc10hJZcAkt8NL1+XziTkVzFvJeKSCgzBvApXGd54dLZRbSbsluNxWv\n2wTF4/HINPa/ffwohbTRaOCDDz7AwcEBWq2L/HQuDeiDOTg4iGfPnqHZbKJYLMLv9yOZTIreeGFh\nAUqlEm63W1p5l8uFWCwmKpl2uy2HjVv2vb09BAIBxGKxS5+7s7MjYDoNUagP1mq1gpOyQyCuykLL\n25RUIn4NqpDYFfCN9fv9WF1dlU6aD1S9Xpflz61btyTP6MaNG1hfXxeZJQnXxNu4sNje3haBATXq\n9XodL1++FFGAXq8XxgM37FqtFjdu3AAAuUxICHe73SLdo8sT6SgmkwlHR0eo1WqIxWLY2NgQwnir\n1ZJ4Zcr7eCGRa8iNNlVZJpMJq6urIpU8ODgQ+IV4MzmWhEnK5TICgQC+/vprvPrqqwJz1Gq1+0KC\nJgAAIABJREFUS6Yb3Lz39vbK8i6fzwOAKMjIZSSfk+7+5FTeu3cPdrtdLA4Jw4TDYSwtLcl7Yrfb\nUa1W4Xa7USqVUCwW4Xa7hQ9Jx3l2pfv7++IdSnI9L3pSqxwOh3R5lEXSU5Z8XOACW7RarXjx4gVc\nLpeQ8PP5vFhBMv47kUig0+mI5wMnRCqlIpHIJXtI+gwQmmAeFADs7u5K0WSy797enpwnLkRJgaL3\nQ/eCiM9cN4eYOLRer4der0cqlbrEFCAUQIiBZ4XLQhZVFlTCAN3y0W47Pf6Z3+/H2NjYD6ppP0oh\n5cPYaDQwOTmJUqkEk8mESCSCW7duod1uIxaLCemWWAbjlelcTfNikttJL/L5fKjX68jn8wiFQnJL\n8ibrdsU5OjpCMBiUgptIJERDzU6QfotcJHEEpFlEKpWSZdTIyIjgVnxziBXRa5UFihvPYDCIarUq\naqHT01P4fD48f/5c5Idmsxn5fB63b98Wk+KBgQHpehjJ0Gw2YbfbEYvFZPQuFot48803pdOuVCrY\n2dnB6uoqIpEIfv3rX+Ps7AwPHz4UNRRwMe7QkT6VSklkBR8InU4ntnE2mw12ux2jo6NCt+EBpV9m\npVJBKpUSOhgnEnY9TNgkbaxSqWBoaAhWq/US7kbYhmRuLmBYeGkQQ8oLN9Y2m00uoFQqJV+3UqnA\n6/Xik08+wd27d8WOMB6PQ6fT4YsvvsDc3BwSiQTGx8cxMzODQqEg+Fk6nZZLg9QgcjHpqpXJZDA4\nOAi3241oNCqptvQ22N/fl7PKnQALA88Pu8STkxNsbW1hbGxMBBz5fF6gsmQyKV6kTqcTL1++xJ07\nd4TuxfNP0xW/3y+4Pu0ruwuVRqPByMiI7BlY4Oi/GovF0N/fj5GRETlj5NSGw2HxvaAXKxdoPP+U\naBKbBiCvCRkLLO6E6UhV40c3N5Rda/eGnosmvqbAZTkpP/g1Sfv7SXekH3zwgWx5W60WHj16hMHB\nQUxOTiKfz4tbDDeu5IJ1q002NjagVCrFRMNsNgvpfWxsDE+fPsXs7CxOTk4QjUbFpZxmxAMDA3A4\nHKjX64L5TU5OolAoCIl4b28PZrNZkkA5TpLbRooTR2jg4g3lQwtAdMoWiwWRSASBQABHR0cS2Xt8\nfIx4PC6KLHJeFQqFHEa32y1O+nT8YQes0WjgcDjw4sUL8X1stVr4u7/7OwC4JB54+fIlbDYbbt++\njYODA4RCIYl+ZkRwIBCA0+mEzWZDOBwWyaper8fW1hYSiQRyuZwA9jQsqdVqkudEwQEPLk00SKon\nq6H7IJPiRUXJtWvXxJyC7j7EY202mxjRGI1GSRTl0or2iDSn4etit9tRr9dRKpUkXZabb61Wi2Qy\nKeq4yclJvHjxAmNjY8I5NZlMMBqNuH//Pnw+H3K5HF68eIG3335bJKX0HmARY4QNoRmOjjabDc+f\nP4fD4cDa2hqCwaCcdca5ABcPdC6XE2EAKUtUoq2trQnuzRGZMAvhg2azCZ/PJ45l09PTePnyJbxe\nr0Aua2trQnciX3VsbEzwX5VKJQ2C1+uV94yQA5eHxJRdLhc0Gg2KxSL29/fh8/lEBMN8KkJsnU5H\n1Eos6DSz7uvrg0ajke1/JpORyJTuC79728+v2W2dx/P6/T/vLrSEqIiXejyenzZG2t/fj08//RQA\nBJAnEZ95MxwBqGAgnuP1erG6uoqenh74/X60Wi0sLi4KjvXXf/3X+PLLL/H222/LoaWzNzFQytGo\ndiFGajKZRFfMwkgeHDEx+pnabDYhWLNTsFqtSCQSMsJyHItEIvD5fCgUCrJVJTWFLkQTExP48MMP\n8dZbb8nISLegJ0+eIBgMwuv1CkhOQxJK3UZHR3FycgK73Y7e3l58/PHH0vEFAgFEo1FxnWKoGzE4\nRjpwStjb20M2m0UsFhPHepPJJIsju90Oh8OBs7OLyGAS+NlhkJg/ODgoiwur1QoAl/TsBPXJ2yPt\nan9/HwsLC8IDJPZtt9vx+PFjgQ1ofnLt2jWYTCbhxZISxOhlatSJuYbDYaHncHIJh8Po7e1FOp3G\n5OQkPv30U7RaLfh8PhFi8BIlVYvGyMS+2Q1euXJFtPZc2FGGzLhndqhjY2PCXyTflMIEq9UqMBGF\nCORUp9NpiaOmcQ439c1mU7o3tVotnFvS3+iqNTIyglQqJc5YDocDBoMB5XJZxv3j42Nx3OLz+Omn\nn0Kr1cLhcMhl73K5sL+/L3AEHflJnqeKi5AEABGhcPQmNk/xArtO/h3KpHl+ukfybgoTuaG8yIHL\nHSvPHX/ln3//z7xe70+7kNJOjobEc3NzePDggcRXcOPn8Xjw2WefYWxsTDS7lOp5vV45FASdSTjv\ndDpYWVmByWTC5uamdERUxgwODor7D2WowMULx9GGVKFOpyPA+c7ODvr7L1I8aU5BnTVpNtQVc+FD\nc2kqm9LptCSg2u12HB4eykKKPo/kRB4eHuLGjRvo6+tDPB6X7pVAfCqVwunpqThjAUA0GpW8npOT\nE+F13rt3D2q1Gvv7+yJLDQaD0Gq1YjzN0ZBjDXCBD7fbbezu7qLRaIhRCLegR0dHKBaL4i/JDpKX\nRE9PDxwOh3irctrghp3jIwtAPp9HoVCQRd3BwQEmJydhNBpRKBTg8XjQbrfhcrlgMBiQTqfx4sUL\nWWoEAgG5KPk1uQQhZszuf3t7Gy6XSxy1bt68ifv37+Pw8BBvvfUWksmk8C+r1SpmZ2fx4sUL+Hw+\n5PN5pFIpzM3NSeGhhFSlUiGdTmN+fh6Li4tygTE1kwuSfD6PfD4v228uMYmDEk8mdMSOCYCMzZub\nmxKfEggERFo6ODgoOPfQ0JBc3FarFVtbWxgaGoLH48Hm5qZ4A5Blwq4UuNj689nS6/VoNBrweDwI\nBAJYWVmBwWDA2NiYTEROp1MUcDw/NL/mJUEpNJ9VymI1Go34LtDwnH6zVLFR8NDtNfp9H1J2nd1b\nehbX7k7/+11o999TKpXw+Xw/bYw0Go3i3//93/Gb3/xGxqZqtYpqtYrV1VXMz8+Ld+b777+PWq0m\nnVU8HodWq4XBYEC1WsXz58/x6quvIpvNil3b0dERrl27hkgkArPZLEoYOt6oVCrhu5EETHK9SqWS\nUZtdRqvVgtPpFL1zpVLB3NycWKBxSdC9lSdthNQtpfIiGTSZTGJkZAR7e3ui6FlfXxe1CotzoVDA\n2NgYPvzwQ5hMJoyMjCAUCsHj8SAej0shX1paglqtFsu+UCiEfD4vo9LR0ZHkSRFTZFH74osv0Gq1\n8NprryGRSODg4EAC7HK5nHQMhUJBJIvtdlveq+HhYZhMJpycnGBvb0+2+sRQOWYTZ6VzEHEvJnQ2\nGg0kEgm4XC6Bc+jWT8cluuCzU9/d3cXZ2ZmIGOi6XygUsLu7KymmnU5H/EOXlpaQy+VkgUP8i74H\ng4OD8vpRJEJPWVLUeIn19PRIAZyensbCwgL6+/sldZMyV/JnKR1lQNzU1JRQyGiUws0zWRkMmSO2\n7nQ64XQ6JeOMnghOpxPRaBR3794VD950Oi2x1tS9U4EGQMxhqJYiH5gpq7RWZFDjycmJsFPOz8/F\nyMRutyOZTIrhEDt9qoa+b2pCYxHivsTa2exwiVmpVEQCSsydCQEc0/k/FkQWR2Kj1N53j/H/t6LJ\nIsvXnuq6n7RpSaVSAQB8/fXXCIVCsqV3Op2CYzHDOpPJYGVlRfKlFxcX8d5772FlZQVms1kyeF68\neIF33nkHtVoN9XpdtnXcvlLmZ7FYpLOkRdv09DTMZjOi0agA6KSZ8AFjF9Pb24udnR1MT09Lljfp\nGgTCaZ3GhQ+VKnRoAiAGKDwUdH8qFotS0Il/ER44P78ww7VYLBgfH5fPI357enqKZDKJ69ev4/j4\nWGSaqVQKMzMzGB8fx8TEhOQm0cKNwWp016LpMBdtjJCgTRr9Pc/Pz8Wzkz8LDU64lR4cHBTMj1hW\nt0UeR7np6WmhN3GUPTo6ksWLz+eDwWDA9va2PGC8pPb29uB2u+HxeOTC4uVM1gAAaDQa2epTAaRU\nKvHnP/8Z4XBY2A+FQkGMVxYWFtDT04O7d+9iZ2dHfBpCoZAsOmkaQytE5nsxbqbZbMLlcqGvrw+F\nQkEmH51OJ5NMKpUS5zCOoxQDMOaFOWWkZp2dnQnmz8ucDAXi6XxN/X4/tra2oFarL0mGSeGjxycv\nufX1dVHwKZVK6HQ6TE5OyvTFwnl8fCzFulKpoFKpCEYLfJcRxVGcXgjdLvj8mXp7e+HxeER1ZzAY\nMDQ0hEqlIv+dijZ+fL+j/L78sxsDBfB/FE5SochLbrVaqNVqKJVKGBgYwOuvv/6DatqPUkjz+bxg\nXS9evBDuqMfjwfPnz+H1epFMJsUp5/3330ehUMD+/j5effVV/OlPf0IgEECr1UKr1UKhUMCVK1dk\ndJ2enkY8HhfJGnmMmUxGIhCuX78u4zcAIZXTgYeb71AohOXlZVHM0IWetzh5fFQakT/IzpH0GUpX\nWSSoWydbgJETpEIplUqMjIxgcXFRTDr40JJMrlAoEAwGRVdss9kQDAbx+9//XmgkfJB6e3vx5Zdf\n4qOPPhKnH3blCwsLaDabCAaDuH79Os7OziRKl5pw4mGkAgEQEjQf6u5Rnd6s3WTrbs9Ljqa5XA4m\nk0nGdBZWdj5+v19GTqYhBAIBOBwO2cqz6D948ADxeFy0/O12G/v7+8IWmJubw9LSkiyQtre3US6X\ncePGDcTjcXi9XjH2Xltbk6wvj8eDTCaDvb092dTTQCYQCAj/eW5uDr29vXj27Bnu3r2LZDKJer0u\nSyji66FQCIVCQbplACJH5cKIeVRU5fEyBgCfz4e1tTW89tprwss8PT3F6OiobNsPDg6kswQg8k6y\nVo6OjkQFlMlkRARBmp7T6YRGoxFDoFqthidPnohjFKG2g4MDMbeenp4WfJwetFwAsmjp9XqZOmhm\nnkqlxGA5k8mgVCohn8+j3W5LtDix7u7ukuN9twEJ8N3YTloUi2m3EQqxUhZnvhf1eh19fX0wGo0Y\nHh7+aRs7f/DBB+JWo1Kp8M4772BtbU0UEvwhIpEIbt++jQ8//BAej0duWd64xWJRFlMWiwWbm5vy\nUFN5QVkYde+MiGi320gmk7DZbBK/zBt5e3tbxm/SjqxWq7z45XIZV65cESxQqVQin88jEAhI1Ajx\nPUZB22w2iUuo1WpwuVw4OzsTL1Kqf7gMCwQCImd0Op2yLTeZTOIWBVwA9i9fvhQN997eHm7cuCHO\nO8fHx+ISFQgEcP36dZycnCCdTos14djYGPx+P54+fYpoNAqXyyV59wqFQqzFiGNxu8qD2V20Sa0h\njnV8fCw0IJPJBK1WK9r84+NjOBwOdDodxONxKBQKidmlzpoa64GBAQns4wRQrVYlWsPtdsPpdMLl\ncomXJQChSZFUfv36dSwtLQl9zOfziTyZIg+LxYKtrS1ZllEgMjAwIEkHNKeh14DVakUmk4HT6cTq\n6iomJyflHNGbldEx5MJqtVrxWzg/PxfLPF62pKKxUJIM32q1sL+/j4ODA9jtdhwcHMDn80GhuIiK\noX0dKXlc9sRiMYyMjGBzc1M29nSC6jaYBiCZUV6vVxZZ9C/gZUruqsPhwMuXL3Hv3j0pYDRE7+Z2\nEiIgn5N6eNL0qFSi9HZoaAinp6dyuZKR0j3GcznUjX8C3xVaFnB+cJFFDPf09BS1Wk2YAoS92FS9\n+uqrP6im/SiFdGFhAU6nE3/4wx9w9epVIceTB6lSqbCzs4PXX38djx49koPM25PAs0qlEiu8ra0t\n0SRvbm7C7/dLhIharUYmk8H4+DgqlYqoMXK5HCwWCwAInebs7EwgAACy1edmkyR/phaS9Et8keA9\nidkDAwM4ODgQdyKr1Srb8uHhYVgsFjlkPHTdFmB0lspkMlLgvvjiC7jdbkmufP3116HVauF0OmWD\ne/XqVVkc7e/vi1n02toarl+/Lj6UXCYsLy/j7t278Pl8qFQqqNfr2NnZwf7+vsgJDw8Psbm5KfJN\ndpdcprFD5EJQrVYLdYnc4Gq1ipGREZyfnyMWi4n8Va/XC7cUgBzmSqUiHdnR0ZFozinzvX37tqTG\nsmicnp7CbDYLGT0UCgmvd3t7G8FgEAcHB7hx4wa+/fZbGI1G3L59G2tra/jss89w9epVtFotJBIJ\nzM/Po1QqYWlpCaFQCOPj45JnRWGG1WoVFynS1Y6Pj+UC7e5KWZgsFoskg1KySnECxQTkuZKRMDs7\nK3LTQCCAg4MDGfspAMlkMuJSRW8BFphWq4UrV65IA8EYmHq9LiIE7gxYyGKxGHQ6naQ9KBQKwZZH\nR0eRy+Wka6cIhDxeYtzdLlPdyyQu1dgJ8vkjVk4DEhY9KuyA77bwwHdKJgCXiimfI3ajLKBqtVoY\nAlTNEf7hs8jl5WuvvfaDatqPpmx69OgRfvWrX+HZs2fC+6K3IqlNLIi80YgrsTDxRt3Y2IDX68Xg\n4KBI61KplFioseOrVCri7k4SP4sLI0YYmcFOLpfLIZPJwGq1Sj45TSoI0BOz6u/vF0XHwcEBdDqd\nxDlYrVbJnSE9KpfLQaFQSMYUzTCofnK73eKbSuzv4cOHmJ6eRl9fH168eCEyU7pjsatfWlqSmOR6\nvY7d3V28ePFC7N7oN8lOmw8AuzyTyQT/X+wDSdrW6/Xi1tPpdITmQkkhaWBcrp2cnEgstMlkwuzs\nrFxM9XpdpKDValXMmrmcUCqVMhbSa7RcLiOdTotHKQsHcUdOBmazWS5RQjbpdBrhcFh4wplMBrlc\nDjdu3EC1WsXS0hLOz8/xz//8z3jw4AEcDocsqKanp5HP5yVLLBgMIpVKifcBqXvcPu/v7ws3FYB0\noPl8HiqVChsbGxgZGQEA4WRqNBqsr6/Lv50MDZVKhcPDQ0xNTYnclhS0TCYjeOfp6amoo+hfSqpV\nq9WSy47MF16MXPbNzc2Jqu78/BxOpxP1el0YJlyIHR0dSQQ3t+/0/6XSjIs4mqCcnZ1JMWy32ygW\ni8hms9LRWq1W6cK1Wq38LNxxHBwcCDbbPaoDuPR7/n92oMSaebkD3zn4M82BGDA71e6v09PT89PG\nSBOJBDKZDFKplBQwAGJETLkdt5UqlUoA7ZGRETx//lziNbLZrCiBstksjo+PZVseDAaFr9fX14dK\npQKLxSIjcq1Ww+joqIxO3EDzkLATYkImM2so4YvH43A4HOKPSCchOhlxM1mr1RAIBMQXgEsSs9ks\nPD3iNHQIV6lUWFhYwOTkpGiQqRUPhUKoVCq4deuWZLN3Oh3pHmgHWC6XUSgUMDw8DLPZjOnpabTb\nF7n0Go0GExMTKBaLWFlZESyyXC6LJLRarcJms8FkMuFPf/qTjOQcr4eHhwXzohFENwZFaIDO6ru7\nu+LW1Gg0LlGhaKHHTr9cLiOTyQD4rrNgBw8AZrMZzWYT29vbcgENDw9jaGgIpVJJMFvCK6lUCltb\nW/D5fOjr6xM9/e7urlgI9vb2Ck8zl8tBpbrIu9rd3ZVR/erVqygWi0LLoVad8A+xcEJJjPKglJSj\nr9frlQt8bW0NXq8X9Xoddrtd7OWMRuMlqWu5XIbL5YJOp0OpVIJarRZGADs0LiIZ9Edq1/j4uOQk\n+Xw+PH78GG63Wy5EdmLkaJNNQligv79fLgJS9fhak3ddLBbRbDYxPj4uwXL8WkajUQo4ifjcB5TL\nZbl0z87OJNb7+PhY3J26cc7upVI3TspfKRIg5U2lUkmCLIBL7lDE77vlovyaGo0Gr7zyyg+qaT9K\nIf3d734ntyO3vuwurl27Jnpyi8Ui45JSqRTTV7q8UBVCVyE+sDqdDkajUQi5NBzmsoME/U6nI/Zn\n3aRpGlcwxMzr9UrH3N/fLymk3B53W3d1F0XScxKJhOjoaXhLbujo6KgsGBYWFkT2R5hDrVYjlUqh\nVqshHo/D7/fLGETC8+bmJvr6+vD666+LJd4nn3wisAf9Rp8/f46dnR2k02mUSiWsrq6iv78ff/M3\nfyMqIGbO80Fk1zk3NyfOQOR4UiXEg0rHHi6LFAoFCoWCUNWo6BoYGIDFYsHJyYlgkLxMialSsUXc\nktSbw8NDHB0dSXjf3Nwc5ubmxCCFpstKpRJLS0tQKpVIJpN4++234fF4BCrhdpqYtslkEnw6Fovh\nyZMnePPNN1GtVnF+fi5RKd1GwSwwBwcH8rNlMhm5nLlECYfDWF5exvz8vCTo1mo1kc5y9NXpdJcK\neCKRkN+fnV1EZLvdbty/f19C8iwWC548eQKn0ymCjGw2i6dPn4pRDU3TiVOfn18kxt64cQNfffUV\nrl27Ji5RN2/eFIwawCV/A3aZnKrW19cxNzeHbDaLVCoFl8uF+fl53L9/H41GA0NDQ8ImoTSYuHlv\n70VyKy8Wk8kk7/XAwABMJpNQ9lhAu3FPjt/d6iYAYlJEaIB5Vzxn/HrdLvz8UCqVMlVxi/+Txkgz\nmYxY1vX29qJarSKTycDj8QgZnZQfJlqSCP7nP/8Z77zzDiKRCICLLnZiYgLPnj2TA8Nxhg8Rwey1\ntTUYDAYhAWs0GuEmApANer1eF9A5kUiIvpzOP2azGY1GQ5Y+HB/5gHHBdXp6Km9ef38/YrEY3njj\nDcFR6VXJg+Xz+S6NIV6vF0dHR1Cr1ZicnJTo5r29PRSLRVG+qFQqSVddX19HKBTCb37zG0xNTWF+\nfl5YAxqNBl6vF3Nzc5icnITdbsfp6Sk+/vhjRKNRISFzWReNRsU7lZAHt7tc5nFBwhBDYlDc6Dud\nTrloGHNNtUq3pJMyRLrXs0vg36GHKXm29JJlR8OUgIGBAXz11Vfo6+vDyMgIrly5IjglJ6FgMCgP\n0s2bN/HixQtZDJFHGAqFoFAohL9Jn1QmnXJRwkwkACKjrNfrCIfDsNvtwmmlUQmtBpeWlvDGG2/g\niy++wOzsrHAvOVJyHB8cHMTi4qKotx4/fgyFQoFf/OIXuHfvHk5PT/Hmm2/is88+w61bt7CwsACd\nTichh7u7u8hms/B6vULpCYfDOD4+xhdffIF3330XT548ETf/TqeDpaUlgVN0Op1Q48jIIMNgZmYG\niUQCyWQSr7zyCk5OThCJRKDT6eDz+cQOsNuBS6lUCh5J4YhOpxPzZ1Kuujf03SM3F1Xdm3o2WnSB\nIvuA547ntlu9xHPc/X2Io7JA9/X1/bQL6b1791AsFsUu7t133xXqk8fjkRRPk8kkLzJw8YK+++67\nWFtbE09CguzsLpRKJa5cuYKvvvpK4iW8Xi92dnYkQwiAmBbv7u6KioJ8OurDWSSYJc78HpLuuWVn\nN0zPRVJayI+rVCrCbTSbzYIZETvlhnN/fx97e3uiaureXu/s7ODdd99FMpnE3bt3EQ6HUalUZMkD\nXIwib7/9Nl6+fIn79+9LAuv6+rrwIgldbG9vIx6PI5FI4Je//CWmpqaE9+hyuaBSqeD3++F0OhEI\nBMQ5nt4BBPHpnM/DyE6G2HGj0ZDxncmmfFi4hOJlRpkku2ricRzJ+HDQlpAUnrOzMzgcDukSGZHC\nsL5arYZqtYrBwUExrw4EAuh0Onj06BGmp6fx85//HBsbGyiVShgdHUUqlRJ4olQqSXdOdZLRaBQ7\nOwCYn59HPp/H3Nyc4MjJZFIiuIl/Eh8+OjrCzMwMtre35SJmxAbPXU9PDwwGg+wLjEYjTk5O4Pf7\nsbKygpGREVFMhcNhfPbZZ/D5fEJ5a7VaYqC+s7MjOGQsFhPGCTtMl8slaq0333xTsM5mswmbzSav\nYTc1aHl5Wbxsv/nmG8RiMVitViiVSsRiMWE1UJxAtRW/Br17uXzNZDIyrZH18X3JZzcGyiLIIsmz\n1Gg0pKh2q5y6Sfo8pzzHbIK6bfo6nQ7efvvtH1TTfpRC+uGHH0KhUODXv/41jo+PxTaNVAxu4wnQ\nN5tNuN1urK6uIplMCmGe+ULJZFL8J1999VVsbGxArVbL2E6ciUukoaEhVKtVeDwekZJyy0mn8maz\nKUWvUCjA7XaLLwCpR8PDw/Jv4DjaLUvsdDqS00Q5H0dzYrJ04t/d3UWn0xFVF2kgtDFzOp3Y2NjA\nlStXEI/H8eTJE1GdhEIh3Lt3D+FwGE+ePMHZ2Rnef/99GAwGLC0t4Z133hFeKClnGo0GwWAQ4XBY\nnOvT6bRsYSORiJDJyWigKozdCQ81+aPfVysR6+XrRQrV8PCwsCO43WUhZpon3wMavnQ6HaE98UHh\nREHslH83lUohnU6LymlsbEzMTXp6egRPz+Vy4hOwtrYm0wNJ8sz2YnHjFNKNtdFdy+12i+lMIpFA\nsViUs+jxeKBQKGQ5yS09nd4JR21sbGBsbEx4wQBEsswJivzqZrOJZrOJbDaLiYkJKQwMbiwWiyIr\nJbWIvreEvYLBIFZXV2XRFAwGhaXA4s5lKM9ZT0+PsBbcbrfkXoXDYbEs7O/vl2eHCbsMOGS3xzPS\nfVHqdDoMDw9LnWAn2r1950dPT49Q7bo9VLlL6JZ/do/vwHcRJgAuFWcmDlDR9u6778oy8H/7+FEK\nabFYRDQaxcLCAp4+fQq9Xo/j42NZRvAmevbsGV555RVp55kTo9frAUDAZrVajd3dXdy5c0fMddlp\ncoynOoMPPc0mNjY24PP5RBLGcXRvb09G127zDBbnnZ0dTE1NIZlMirKIDz9leOVyWezYur1QaXxL\n5yWLxSJu5M1mE/F4HDdu3JAMKkox0+m0cFW5fKEIYXh4GNlsFrVaDXfv3sXnn38OhUKBV155BV9+\n+SVmZ2exvb2NhYUF1Ot1aDQarKysiKM5NdbpdBpmsxlXr14VQ2yHwyGUEQAystEDklBGt7afMbhq\ntVpAf9LE2A0BEBcfOl7RLo0PgVarlQ08rRDZbVAv3tfXh8XFRXmP6aA1MzMDi8UijIWrV6/Ktpx5\nTzTVGB4exujoqITylctlTE5OirTV7/fj+PgYBwcHeO2117CzsyMqMXbqvb29Iu1dX183hRUeAAAg\nAElEQVQX+TCztjY2NjAzM4OlpSVcvXpVPHBJkNfr9VLkeMnQuKNQKKDZbOLOnTvY2dkRHf3MzAyi\n0Sh2dnbEhaparUr09PDwMP70pz9hcHBQuNHJZFK6N5vNhkajgVKphFqthpWVFYFZzs7OYDQaodVq\nYbPZEIlEJBeKzxB/fkbTTE1NYWRkRBaH7Dp5RnmhUDVIk3Ya8fC57l4e8awR0ySWyT0El2X8fHJh\nOb53q5j4wWmKakLSzaampmTpOjw8jOnp6R9U03608LtisYhwOIxQKCTyL25SGUvMiA6C/QqFAkaj\nUbAcjocqlUqwJxZStvgzMzNYW1uTrpQhd4ODg2ISQtI8YyMom+TWHoAsi0g3USqVsNlsMuIbDAZs\nbW2JKxK7MMaKkMbFm7PRaMDpdAp+xQwlei+q1Wrhq1L5RKdzmnMolUqJyaCax263449//CN+85vf\n4OjoCN98841wDklhstls4oJUq9UEAtFoNHjrrbeEV8plQLlcxtnZGQwGAzQaDSqVinRK/f39QrI+\nPz8XEQS9JFlgyfvl5cRi0e3kxO7WYrGI9R0nC3JNyX0lREDKj9/vRyaTEYf84+NjMQKnW1Wz2UQs\nFsPi4qLglC6XC2q1GpFIRPBNGnbzYa/X6zAajZJ4yYsoHo/DZDKhWq0iHo/j5s2b2Nvbg91uR7vd\nht1ux+bmphQsh8OBBw8ewG63IxgMolgsolQqIZvNShLu9vY2Jicnsbu7K0u6YrGIa9eu4dtvvxVc\nnhvw9fV1NJtNvPfee/jDH/4geU6tVgs2mw2Li4v4x3/8R5mcmHt27do1MQHpviQpNKFzWbPZlEx6\nTmOUMOv1elk2Uq69t7eHeDwuPGIAUlRJlaJXBr0f2BBxjAcuZy2R/8nf81x9H1fuLpbdI3v32E6q\nU7ValeX0+Pg43G63CFW65aqUpv9vHz9KISX+8ujRI0xOTmJjY0O8FdVqNe7cuYN6vY5IJCJKlImJ\nCYkWIfXi4OAAe3t78Pl8AC7UGNz20hGfJiHs/JgkClxsiHlz5/N5IcdzaUIuI5dBNAXmITGZTMIt\n5YNFWV+1WhWjlEKhIH+Xt3k2m0UgEJDgNToqZTIZ0fF7PB5YrVbhiHLM4mVgMplw69YtofowifTd\nd9/F/fv3hUpEb89IJILJyUksLS1JjviVK1dQq9VE1fLgwQM4nU4Eg0F4PB4xfSH9hW5CtKjLZrPC\ne6X7FlU6pH/19fXJ1EFLNB5sAJIHxKVcOp2WC0qlUmFlZUXoKzTWpkUd1TD7+/vQaDTweDzCInA4\nHMhmsxIqx47FYrFgZGQEc3NzYoc4MjKCdrstvrbLy8vy+h8fH6NarYo0lZADVWSRSARWqxUOhwPL\ny8tCpeLmt91ui96enqzpdFr+jLlj5FAeHBzAZrPJxexyufD8+XOhNc3Pz2NlZQVGoxEHBwd45513\nsLq6Cr1ej5GREcHEh4aGMDExgQcPHuBnP/sZFhcXhb+7tLSEeDwuJj9OpxNGo1ESIjh2M12V/gDs\nKAmJud1u+Hw+Weh6PB6ZYJj6QLNnQkUnJycoFovSVACQ9/H7lCZ2mnwN6eIGQBRrxEJJifqfqExc\nkmWzWfT19SEYDGJkZARKpVI6Un4tTloul+unXUgfP36Mf/u3f8Pf/u3f4uHDh7DZbNKt3bhxA7u7\nu+Jcw0iIWq2G9fV1vP/++1AqlVhYWECpVEIoFBKp3dzcHLa3t2UMnp2dRbPZRKFQQKvVku0jcTom\nL56fn4tLOjXU3D53vxHslsgXpccoC2mtVsPh4SFCoZC4EdGDsa+vT5gKpFX5/+KnylF0YGAAW1tb\nIh6gPJPFngXCbrfD7/djZ2fnUkdssVhgMpnw+9//Hu12W4LiHj9+LAT7zz77DB6PR8bSr7/+WnKw\nuEE1GAxQqVT48ssvRYxAyWWtVhONNBd0TILk2M4uk90oCyW36uxG+SCo1WqBUGjlx6JCUw1S08xm\ns2QBRaNR4b329fXBZrMJpYubdeKxZ2dnyGaz4tCey+VklKUPLgn0JpMJr732GlZWVuRnJNNgeHgY\nsVgMnU5HJLbffPMNQqEQdDqdXJx8KBnmyKgaMiB2d3cxPz8vTmN06yJWx4v76OhIvBvS6TQMBoMI\nS7hwJG+Y2ncuaIvFIiKRCKampvDf//3fcDqdGB8fl4XKxMSE+K3yvDNznl04iyIdpDihjIyM4L//\n+79RKBRwcnIiiaTkcpM2RePvTqdzyVOBnGjisCygVHh1y4zJN2bnyde223zk/za6057w6OgIXq8X\nwWBQFHflclmUTZyGuhdYP/k4ZvoYdtMbGo0GRkdHUSgUkEgkLhkubG1tYWRkRF5gug7xFs3n8zIm\nsP1nTLJKpUI2mxXZnlJ54ZOp1WpRrVYFn9va2pKCTeyEo5XT6ZRcJrrTc8nBB53Gv5SKEp8pFosy\npnIc49KFXEJGVHRr6anzJl2EHfbExASePHkiD/bQ0JAs4TweD549e4ZAIAC73Y5yuYzBwUFJyHz8\n+DFeeeUVUU/5fD7R/Gs0GpRKJRnVz87OEAwG4XA40Gq1hKZkt9uh0Wig1WpldONyhIcSgPy7+WDw\n7zJskN+D/2N3ys/hB1U6hBTIDex2vqezfqFQEGilv79fGBY8Mz09PUin01JoOGJS4ECootPp4Ouv\nv5buk14OjMRhZEa33eLMzAw2NzdltLdYLGLUTK4qfUF9Ph8ajYZkGfEsU/Ov1Wqxu7uLv/qrv5Jz\nYbFYoNPpsL29LVS2R48eCazFhRgjpSnTpdm02WzGzMwMlpeX0dfXB5fLBYfDIRREnvtmsykJBX6/\nH2tra+h0OmLac3p6CrfbLRAN8WoAchl1v+cGg0EMbOi2z+VfoVD4P4j2XCi1222cnp7K2SMcxHPE\nsf77eCpH+Xq9LpfT6OioxKfw3wDg0pnk5c4uuN1uw+fz/bSjRnK5HD7//HNoNBoZR0nVKJVKmJmZ\nwcnJCRqNBqLRKH75y1/i4cOHYmgSi8Vk02swGORG9P/FJZ/u3cyGb7fbQlmamJjA8vIyxsfHpbvq\n6enB8fExgsGgbO2ZgaRWq0W5NDQ0JG8c+YMq1UX2E3Hbs7OzSzhnOp3G2NiYjMBGoxG1Wk24iSRQ\ns/Dw11QqBYPBIEYnc3NzWFlZER21QqHArVu3cHBwgHA4LB0xC3s4HMbnn38urlTJZFLUYU6nE51O\nB4uLi7JAIwZJbJQFn+GDHLHIOOAh5/vAkat71GIR4u95+NmBUi3GB4WdAS/Znp4eiWwhB5JcxqOj\nI1mEkHvKzbrBYABwsezb2NiQzr7dbovjOdkYpGD5fD4kk0lxZ+KIbzQasb6+Lk5VJycnAh+4XC58\n++23mJmZEfOLarWK8fFxDAwM4I9//CNu376N1dVVzMzMSFc6ODiIQqEgvGe1Wo3R0VGBuLhwDQQC\n2Nrakp8nHo/j2rVrKBaLmJqaQiaTQX9/vyR6Uvb81ltviaEJU11LpRI2NjaERUE/3EqlgmQyiUAg\nAJfLBZPJhFwuh3v37mFhYQFarVbC6rRaLSKRCKrVqrhujYyMCA5tMpnE62Bvb0+WRM1mU87UxsYG\nHjx4IKM9l64AJCuNeU5kdHQXy+4FJwsnbR6ZpHF0dCQQw/HxsdQBFmt+0NrvfzI+USqV8P/U45iX\nl5exuroqHpCMNjabzUKsZrSI0+mUUWpkZER4d7SNK5fLsiBgB0ZKEc2CgYtxrRv/4IKDnEgWAd6k\nxOy6ndwZNkeiNIPzotGoLI4AXNpAHx4eIhAIXFoKxWIx+P1+cT4PhUJYW1vD2NiYbGQHBwdlfKFm\nWavVIhAIIJ/PiyXbysqKGGcQ92y323j27BmCwaAwCYxGI5xOJ1QqFZ4+fYparSaj2uDgIJLJJGKx\nmMQ5m81moSIx2oEdK9kCarUaxWIRKpVKRjU+ON3GJiRGA5CHgwW2+2ATP8tkMjg4OJD3Ix6PC4OA\nURbszs7OzsQEmu8nAFEp0UaRefaHh4fI5XIAAJfLJZh495aZ0tKrV68Kr5jYukqlQiwWk4nCYDBI\nprzZbJYzRtcm5kJRGVWr1bC2tgaPxyM+sLlcDmNjYxJTTJ/OtbU16YDj8Th+9atf4f79+3C73Xj2\n7Blu3boFr9eLjY0NVKtV1Go1zMzMYGtrC5lMBn19fUIdM5vN8Pv9kvzKC5zLvI2NDSk65XIZer0e\nPp8P09PTItckbYuLo2q1KhxQxkPv7OwIF5lQiUJx4UPa09ODQCCAyclJgRncbjeOjo4kl43PWvcy\nksslnh8WRC44qc3v6+tDOByGwWAQI5RuBkQ3BNBNw+ruhPn1O50ObDbbTxsjjUQiKBQKMkY1Gg0E\ng0EpFsSkWq2WKJyodjEYDMjlcjKq7+/vS7gbR3e/3y96bZvNhmazKXnutE+r1+vyewLqHBn1ej3i\n8bgYqFAuyQJLqzNyRxuNhmCnJHtT1sj46K2tLTEIISeQeTzxePySYqRYLArGyJ8rFotJp2I0GgWL\nU6vVuHv3LorFIsrlMu7evSverJlMBgqFAru7u9IxUBqbz+fF9YgxxVqtFn/+85+hUqmwu7uLpaWl\nS+T5sbExtFotxONxwX/JLQW+i9Cl6w87U5LLKRs9ODiQDqXZbEoHQtqU2WwWZVmj0ZCpgNQqZh+R\nR0oCeE9PD05PTwWP5XtEHT4LNc8YAIFiKKygzya798XFRbz66qsS7aLT6SSWmPHIfX19+PLLLzE6\nOort7W2BqGhoTbaBz+dDIpHA7OysmHFQw282m/HixQvcvn1bXhvyl/v7++FyuZBIJLC1tYVXX31V\nkks5mlutVnFBUygU+NnPfoZvv/0W9/8S1Dc8PIwnT57I8i8Wi8FkMokRicFgEM5kOp3GxMQEhoeH\nUSgUxJaQkch0pWq1Wtjd3ZUteKfTEaI98UnCEH6/XyArheLCWYmMhW7+KNk4VEJ1d6Pd9CgKNxQK\nBaxWq8i4S6XSJZl298f/1I1+f0HFqbLT6cDr9f60C+k333wjJsFra2uyrOCiZ3NzE8FgEMlkEn19\nfUKV2tzcxPT0NBYXFxEOh1Eul8VmjCYYxBtJcO/t7RWqU6PREL4mpaTE3LhVpzKJyw5uMMll5MjJ\nzqfdvshkTyQSEhzGjHkC490x0vyaDE6j64zD4UAmk4FWqxXckuOKzWbD0NAQxsfHpQtot9uYmZmB\nSqXCs2fPMDQ0hFAoJLEp3GyTLF0ul3H//n34/X5MTk7ixo0bOD8/x8LCgnz/SqUCo9EocsyBgQGJ\nly6VSuLQRMOX4+PjS76SLJSdTkfMY7pdeuTQ/cWEhhZr7CwI73SbnxCaoL5foVBILAvZBN32aCza\nZGawW+b5YDd1eHgoFosALrlZ0WBGq9ViZmYG6+vrEj+yubkp/p+5XA6dTkeC7jiC07uBnOFIJIJM\nJoPh4WHRoFOlxdG225yE+Up2u11CGkmAVygUSCaTEjLIUZZ84ps3b6LVaiEajWJiYkLOrdlsxq1b\nt2SZSUN0pVKJa9euAQC2t7dxcHAAl8uFnZ0dPH/+HPV6XZZSQ0NDiEajkiJ7cnICn88Hi8UijQQV\nZ/Q+SKfT4u9AvisvcavVKg749XpdxAPEzykZ7qbJ0c9Vo9HIkpF6+u5APO4XePbYiXZ3pYQPvl9g\nKSoZGRn5aY/2Dx48kPHn+PgY7733Hp4+fYrDw0PMz8/LSMTscY6P09PTiEQi4iTDF4NOPPl8Hteu\nXUM0GoVOp4PZbJb4V71eL/gnC5vb7UalUrm0Sea28vz8HKurq7h+/fqlbCZipTRjYFQs6VCEFeii\nT94j5XGHh4fixUjuaq1WQzAYxObmpqRtkirFDguAjOlcjJhMJmxvbwtpeGhoCIlEQjT4FosFZrMZ\nV65cgdFohMfjQTQaxRdffIEnT55gdHQUb775JlQqFRYXFzE9PY1QKAS1Wo29vT3BtOgH29PTA7vd\nLvQzgv88kN2jercmmsRtxk5wbKf5CsMCqXNvNBriIK9WX7i988E9OjqSwkp6Ealb3AAD38lzGVlC\nVVGz2ZQYFJPJJBcWvTkZnWyz2dDT0yM0s9PTU2F1WK1W1Ot1kV9y7LRYLIKd8xLI5/N4++23xfjb\n6XQil8uh2WzC7/djcXEROp1OYBh6JXQvG3lhlctlmM1moaWtra1hYmJCFjg2mw0rKytIJBK4ceMG\n+vv7Re4aj8flnOVyOdy5cweNRgNbW1viQEYxCCejq1evStT3ycmJmI8PDAxAr9dDr9fL5fT1119L\npInf74fZbJbEhpGREXG6DwQCktHFrpZLKcb5kNtNFgSfNUIUfD739/fl/etWMnV3ot8n9lNDz3PD\nRIzujpR/RoL+D/n4UQrpixcvcHh4iCdPnuCtt97Chx9+iMnJSQwNDUlkA3N0WFDsdjt2dnZQqVQk\n9thgMMio7/F4xDh2YWFBNpLs/mgwwQJLbmcqlRL8tNlsolwuC7ZD93MukLLZrGxVmfhYKpUE/zk8\nPBRKFaWu/LukMOl0OqRSKXGGBy62hi6XS7oWdrnkbvr9fvT09CCXy0lKY7FYFGnfN998I8XA7Xbj\nX//1XxEIBCSXKJvNYn9/HysrK+h0Ovj1r38Nv9+Pjz/+GA6HA1999RXef/99bGxsoFAo4KOPPkIo\nFEIoFILX6xUfUfIW2UFwsdRNqOeBZyfBzpzu+MCFBV5/f7+o1OgIxOUdzTK4fKCvKy9BlUp1yeOT\n7uY0Re7v7xd+IiEApqF2Oh1xQmfky+HhoYT50W2Men6/349EIiFRNZOTk+jv75dFFMfAer0u+G2r\n1YLRaIRSqZRsJNLfyE2mty4vI/o4UGQwMTGBhYUF2O12DA0NScIqm4PFxUVRq73++ut48uSJjOtj\nY2N4/PixWBdS4ceu3+VyIRaLYWZmBjabDZVKBaurq7KHmJubw/n5OZLJJA4PD4Wn3W0XySlAqbyI\n67Db7TAajahWq0ilUsJUqFarePnyJf4/6t7suc37OgN+AHDfQGJfSYIgwE3USu225S2xHSfTpNOZ\ndtpedJreddrpTf+I3vWqF22n06QXaTNtknacOHHkSI5sa6VIigu4gNiJfSUJkNi/C/o5eqlmprr4\nvpE/zngkayPw4n3P75znPMvh4SEymYxkPHFBSb4tte0q1Um4IRVl1OtrtVpxzGfHy+LJJSYP7he7\nTCVcwMBLflbKJRQnQLVaDZvNBq1Wi7m5uZeqaa/Mj5QPL9v47e1tTE1NoVqtQqvVigRzY2MDc3Nz\n2NjYgE6ng9frlRAvbta5jTSbzYIbKpc6jP4gjsMlBo1k+cUxyul0YmdnB9PT0zg8PBRzEj5gAIR+\nxC5kYGBA+HwA5AYjGE+Fk8PhQCKRgEp1EhDGf7uj4ySegZ0SzTBYlAgpkBxOjLVSqeDWrVuSdaPT\n6fD+++/j3r172NzcFL7nw4cP4fV68dprr2F5eRm1Wg3nz5/Hv/3bv+HChQvY2tpCu93G7u4uvvvd\n76JYLMJisSCTyWBtbQ3Hx8fCcmi327Db7ZLdxAUeN/vckgPP6Uyko1AtRC5uKpUS/K3dPok0ppEv\n/12aj5C2RfqK0kmIskbGSiv9JrnEqNVqEjPD18sCzlygvb09mRwMBgMKhQK0Wi3Gv3J/J294cnJS\nYrprtRqGh4dPMRi42KJaj5joxsaGfO48QImlU3O+t7cn3gB0B+OCkZLLmzdvSk69z+cTNgMD9m7e\nvCmmKvQMJdWO+fN+v18STefn53HhwgV0dXXh3r17YgFYq9XEgISGKF1dXfD7/aKGI/eVyxtSq7jp\nd7vdGB0dFYWZzWaD1WoFALFFBHDKZo8R1lxgvggV8YsFkJjoi3Qo/siOFMCppTL/PrFRQg6PHj2C\nzWYT2OP/+nolhfSHP/whxsfHkUgkRD/O9tpisWB5eRlqtRoOh0NOfBY2eoUqzWhjsRimpqZkFDMY\nDFKceJOzq+AHpFarxZmIpxixWm7oDw4OZGHDwtXX14fj42PYbDZJ29zd3YXL5UI8HpfugXJWLhIA\nyGnL5VYmkxEOHyki7MIINVC7393dLX6bHo8HGo0GkUgEoa9y7ufn5zE8PIzbt29jaWkJ3/rWt+S0\nZ1YQrfGYbVQqlXDmzBloNBrJaDKZTKdoYlyCbWxsyCKJBh0ApGCyyPGGZfGnP+nIyAi0Wq0cNFSo\n0RGeoz2XE8olFjFXkv2VSywqbXp7e2XJQMd2jtjKnClq6XkPsMMiu4Ba9+7ublnkKDOSmJ55584d\nzM3NoVQqwWw2Y2dnRzpydpa8DizyzLwql8vyGkkDcrlccl+l02nxe/B4PAiHwyL93NvbQy6Xg9/v\nh0qlgsfjEYXZzMwMxsfHsbm5iZWVFaRSKXi9XrHpq1QqiMfjcDgckorq9XpRKBQQiUTwk5/8BLFY\nTIzQ7XY7rl27Jl4UQ0NDKJVK2NzcFPcshkFSlGIwGCTZlTh0OByG3+9HPp+XRiCRSAj+TWNw3kf0\naeABqOx+gedLoxdxdyUOynGff05J/GdhBZ4ftMTs2ZTNzs4iEongnXfeeama9koKKQnlpB5R/8sx\nmeOewWAQXTxVTw8ePMCZM2ewtLSEd955B0+ePIFOp8PMzAw2NzcxOTkpBadUKmFkZEQoDiaTCel0\nWsjE3CpyAcBxTmmgQKxPq9WiXC4LGN7d3S2RGkdHR9BqtadUNqVSCTqdDuvr6zLK9vb2IpVKoV6v\no7+/H/F4XJQjnZ2dMJlMWF1dhcfjEVJ5oVCQWAhulg8PD7GxsYG3334bY2Nj4tTErkWlUuE3v/kN\ndDodxsbGYLVaxQpPp9OJ85DBYMDQ0BAikQh2dnaQyWSgVqslspoGJl1dXZiZmRHDD/IlKRft6+uT\n66Tk9RE7Jj0lEAgIDELcjH+P3SeLHA8WYqtqtVpoWEqGBon5Lxr3AhDmANVBypA+ym15UPMzIN5J\ng2EKBrRaLQCIc1itVhOuMt3w2e2xOKtUKqEz8TXRVIU5SBQM0CqRzv/83rFYDBMTE9Ik0OSDaq/1\n9XU0Gg3cunUL9+7dg9/vx1tvvSUd9Pb2NpLJJEqlEoxGI2w2mxTZubk5rKysoFgsYnp6GgsLC9Bo\nNJibm8Po6KgozXiwPHnyBB0dHbBYLGINqeR90jC8Xq9Lh8p8JqvVKhaWSpUTF4vElnloAs9dn4Dn\nRiTKYqj8Unaj/DPKRSc7T372vEeJ82YyGYx/lfMWDoflWXvzzTdfqqa9kkI6PDyMBw8eSPzH6uoq\nvvWtbyEcDssINzQ0JIufhw8f4o/+6I/wX//1X0JV4Y2upJtwJMhkMoI1kqje3d0tJOu5uTlEo1HR\nQbOTYvQBvSeZcrm1tQWLxQIA2N/fP9UJ2Ww28SKlcW8ymZTcmsPDQzidTqHubG1twel0iuckCfbE\ne30+H+x2u4TP2Ww29PX1wel0olKpYGxsTEa+jY0N7Ozs4OLFi1JsyuUy3njjDczPzwvXMhKJIBgM\nolQqIZlMotFoYHR0FOFwGIlEAmNjY/B6vZIL9Nlnn+HDDz9EV1eX+GAy9ZP0JXaQSlNmOgYp0yjZ\nDZINQA4q7RH599kxUKNNjJnYr5K/St9XPjR0XqIclQ8LCygxUnYt/PzIAmCxp6cCHzoetOQq9vf3\nI5FISBLt7u6uLPAqlYpIPOv1+iljFi7QLBaLxAxT3MHX0tPTI4mne3t7OHv2rEha8/m8dNoURNDm\nbnh4GEajEZ9++inm5uYwPz+P//zP/5TueWFhAYFAAAsLC7Lo4zKx0Wjg/PnzcLvdgg9qtVoEAgEx\nGu/q6hIeNzFoMmF2d3flM9ZoNLIEZkGkT4Nym06ohxaQPNS5CCKMw/+Um3Vl8XyxSPLnxE1ZNAGc\n+jfYrXKRBQAulwvlchlra2tCseRkeOvWrZeqaa+kkP72t79FPp8X6ztiEhMTE9DpdHj27Bneeust\nLC0tQaVSYWZmBoFAAKOjozJ6Xrp0SahP7XZb4pinp6clO6azsxP9/f3o6upCLpeD1WoVbTpNEPr7\n+wFAqDDslIPBoCSXUvbXarWEg0iSOXXF9BclWZxRKTS/5chHFyWalZC0PzIyIkWNJg3T09OSH0Uy\nNx+m7e1t6HQ6TE5OIpFIwOPxiInEvXv3UK/XsbKyguPjYxnHrVYrZmdnRQOtUqlgMBjwi1/8Ah0d\nHXjw4AGmp6eh0+kQCoVQKBQwPz8v0dAsciSmswjx9SqBfxZTpmkyFYFcTm5YGXjHf4/XmLQmdifE\nHolfZjIZ6SKpjuJhyA63u7tbnKA4JvLP8aHkA8ltLpkk/DkXW5Q98mD84osvJJV2YWFBctlZwIkX\nV6tVmXosFgs6Ozvlc+QilO7wLCTsaMlaoRiChZ++t0ohBD0PWIQLhQLm5uawtrYGi8WCWCyG3d1d\nTE1NYXh4WDr4WCyGQqGAtbU1aRIACMGfXOJYLIaFhQXk83kJ2OMCkg0QrzXVaWwW+vv7xRpR2WHS\nfJpUPXag5P3yvld+VkpWBn/kEvHFkZ4LtheLMBuY/v5+RCIRCVRkAeV0pNFo8NZbb71UTXslhXRx\ncRGFQgEWiwWffvopRkdHhfAMPDdeJdXEZrPh7t27sNlsWFpaws2bN7G5uYm+vj5ks1lkMhm4XC4U\ni0UxH2k2m6ccfyKRCDwejwS98UZgkmg6nYbZbBYYgJZ7HM8Y+sYPLJFIwGQySQdWrVZP5Til02mY\nTCZ5wBhgR5I1vSJJ6OZJTP9Eg8Eghtck4W9tbQlQf+7cOfT09CCTyUg21E9/+lOhPPX29uLixYuY\nnJyUcDEl55FRu7FYDH/wB3+A0dFREQ6kUinMzs6iVqvhk08+werqqihkuMnl0kbpB8liRLoKfQw6\nOzvFV1RZlIgZcmQneZ1jl9Kgl85B+/v7aLfb0pG1220xAuEyiwkF3NSysyQcwweFBR2A/EjnL3Jb\n6e3J99nT0yNm0eFwWGSejA1m50XWAvA8RfTw8FDoe8TmOA1xwqHhOLtgLpDopHG1yrkAACAASURB\nVMVpi5HHLBBPnz4ViKDdbsPr9eL27dtiYu1wOBCPx7GysgKbzYbj42PJUTo6OoLX65VunEKHbDYr\nHhdms1nkmiTvU3jhdDqF/aBWq4UPfnh4iFgshlgsJmwPflbE1gEILBaNRpFKpQBAIJbfRWVSFlEl\npMQv5Ziv7GapGKtUKgiHw3Jo8/Pmco20M6fTiStXrrxUTXslhTQajeLOnTvyAZ05cwa//OUv5QSb\nmprC4eEhPB4P7t+/L1iGVqvF5OSkgO80GtFoNEIujkajQqJlFDO7gPHxcXFaAk4KNgnglL5FIhHo\ndDoxBKESiFQi4oLMKg8EAtJNEtNlGunAwICE3FksFqEtkZDNzS1pTjyNaSDSaDQEl8zlcpIYWqvV\ncPfuXaHPDA0NCYbI0TMUCqFUKmFvb08MKaanpzEwMIAzZ86gu7tbIIx4PI5oNIpcLofz58/D6/Ui\nEomgVCrh+vXrmJ2dxdDQkGzrGUWiXBAQ0KdrFYsVl1IA5EFjgeCNy+LTarUkSI4dASWy3A5zZCbp\nOpFICP7MaBpKWzkxqFSqUyYWpD1xFFcuKTQajRToVqt1yiGfRP/h4WFsbW3BbrdjaWkJnZ2d4mzP\ncVUZf6EsrOPj46d4r+zCmF9EBkMul5Nob75XRuBwS81CQAs+Lgy3trYAQPxDNRoNwuGwhCPSLtDr\n9cLr9cJgMMiEwMNwbGwMU1NTYuxDz9ZWqyXk+d3dXayurkpnqdFoRMxCZRohHaPRKAqr7u5uKWAU\ntvT19cFkMomXKuERfm/lwuhFruiLo7yycyXvm/UgGo3Ke+TnrtFoxNybr49y4UuXLr1UTXslhfQn\nP/kJCoUCbt68KdtgYkksMhqNBhsbG5ifnxcu4d2v0hPv37+P+fl5HB0dIRaL4ezZs1Cr1cjlcoKv\nEofjeN9ut2V8Z0Qrx/hGoyEkbNrGUT3BwsouiJ6eh4eHMBgMCIVCsNvtKJfL4nfKjoGLKXZlVD2R\n9O1wOGR5Mjw8LBgVOz0WKnJlc7kc1OoTQ2niXIx/CAaD0Gq18Pl8cDgckqbJMberqwtPnz5FNBrF\n7u4ulpaWYLFYYDKZJPKaUSuPHj1CvV7HlStXJGeIBYGdlDJbSGk9xpuQ4z8xTboftdttgVYajYYo\npMgR5efD7wc837rydXDMp+SXB2OpVDq5qb8aeXO5nDx8FBCQM6xWq6Vo09SYDz9HZXZV5DOyC4/H\n46LTZ2R1b2+vHAzc9BNe4oNNSSw9IYirk9PKkTibzQrtiTADiwWXUMSpuejhofPgwQNZuDK4kBLT\nXC4ncdbMn+J2nHp5ANjd3YXZbBanqGAwKJaVrVZL3qvdbofD4ZCY6Xq9DqfTCa1WK3JmwmrEdqvV\n6qmRnd4H/Ix4ENEXgteM94ESD6UxEH/Oa6ScPtLptFj9cQJiJ00JOAswlW2k3KnVarz++usvVdNe\nSSFdW1vD9evXcefOHcFIyOmbmpqSpEeajpRKJYRCIbz33nvY2tqSMK4zZ85ga2tLOjJG/9LOjUqY\nyclJtNtthEIhOBwOscHb398XSgfdj4ATFxqe5IxPJs+TOvBEIiHMAJL0uWEm9kWch5vh4+NjuFwu\nlEolgTZ8Pp9QYnhj0KmIDvmMMSFQT2oNZaXRaFS65qmpKZTLZdy7dw+Hh4cwm83Q6XQYHR0VPwFu\naBcXF6Wj8Xg8cmMZjUa5gZ89eyZUMMooSWkiW4EPNtkOZESwiCkXSbwOpFIZDAbxUYjH4zL6ceRn\nZpQS82Q8CR8iFgMqpDi6UdvNCYNLQI6urVYLg4OD8r34PnK5nDxIOp1ODsJisYjh4WEMDAwITYj0\nMhYIYuf8LNl5WywWsbMDIJ+zMjeeHSE7VTI3iNvyYI7FYhj/SqShVAPVajW43W5Z2A4PD2NoaEg6\nPIPBcMq/gP9epVJBJpORRaTdbpfPT61W48yZM3A6nQgEAiiXy5iYmBDWCQ1hiGnTt9ZsNsu94nQ6\n5Z5i0WLB1Gq14qNLGhKhM75OduEvKujI/QQgard2uy1kfhqKE+9mIjGNWfL5PPL5vMB57J4dDocI\nUZxO50vVtFdSSNvtNv75n/9ZcDmetJ2dndLxsVO9du0afvWrX8Hr9criYnR0VBRE8XgcBoMBBoMB\nu7u7sFqtMo4MDg4iGo3CarWKsw4pF1TR9PX1YW9vT1IUCfgPDg4Kd5FqG2KlXCaQTK9SqcQVnwob\njiYE79nRUrlCB3e+Bo46DBMbHx8X6AOAvB+OqwT1aSJBMndvb6+kXh4dHSEcDksMcW9vL9xuN3p6\nevDw4UN5PTQFqdVqGBgYEEx2cHBQDFL42hj5Qo9JRp+Q/8nXr3TVYhHlF7tVdqX1el0isOm7qcQz\nuVB50RyFsAC/vzIAjaYqPp9PqDrE7OjeRbs+ZfFTq9XCFaUpDg8O+jE4HA7BwmmETNUbJwB2iaTC\n0aM0HA7Le9nf38e7776Lx48fY2BgQIoDmQIc+UmtymQysFqtGBwcFItALrQcDodcbx7iLDTUo2ez\nWfHjpHcuDxRGoLtcLhQKBeTzecF88/k8UqmUSE79fr94BrMp4RRCPi/5rvV6HaVSCYlEQmAVJSzE\naJpkMimBhKlUSgoht/vs6nkocxLieyTGmslkTh26ZDtotVoxdvZ6vXC73bJLICTFaOloNCq2l1ev\nXn2pmtbxf/+R//e/6MFIonkgEJCt+tTUFFQqFUKhEJxOJ9bW1jAzMwOr1YpAICBLolqthpWVFRiN\nRilyPJFIjWKULB/2jo4OkWlWKhUMDQ2JykhJt6AklKOn1+uVJQ3duvng8qEBTqhR419ZlZHSksvl\npJt1OBzieE/XcLVajVAoJB6q1NEzU4avqdVqIRgMymhms9mQyWQwNjYGt9sNh8OBra0tNJtNLC4u\n4vd+7/dw48YNKbqPHj3C2tqamI5Uq1XMzs5KkkCr1cLOzo5gSHa7HY8fPxaJXDgcFhluNpuV68mH\nnosQLpFIx2IXSq4nu3YlOV5JleF/XDawoyO/VMkc4Pc5PDyUDpDJBxrNSRLt7//+72N5eRmHh4e4\ndOkSAoGAdIOkU9G/QBlgaLfbZQnCw6vdbkvCKekxT548wbvvvitR3pQh8rU3Gg2BTOjPSnvGZrMp\nibdU2PH7KfFBTgQ08GHOFw2vG42GXHviyLXaSYY8ry9xSRrFcBxmF0jMlX4S4+PjgoNyI28ymYQ6\nR3UUO1c2OVxKud1uYWiQN93R0YFAICDdP+9puqoZjUaZjOjwT/tCLux4/ZS6+s7Ozv/FXabYhoo8\navb53nmtGKY4MDAAg8EAtVotEI7y8P+/vl5JIeUm/qOPPsL777+PDz74AM+ePUN/fz92dnYwOjqK\nDz74APl8XmIW7t69C7fbDZPJhEAgAAAYHR0VF6lYLCZjEz0Z7Xa7UHnOnj0rDzRx0Xq9DrvdLkB/\nMBjE7Ows1tbW4HK50NnZKa1/s9mUDpgejsDJiKYkjbfbbZHm0ayDXTIfDhZHdhtms1nMqRkFS/UT\ni0w4HIbBYBCVFuklv/rVr+RhoA78r//6r7GxsYG/+7u/E0cdrVaL8+fP48yZM1hfX5d4XtLIqDBj\nl/rgwQPMzs7i6dOn8Hq9uHr1KqLRqDgfHRwcCPWIOCOnC/5ITJO4IpcLhHEoviBliOYx7DSYOsCl\nGCESFnTSn0hnofOVx+OBSqXC8vKydOLpdBpGo1G8D1QqFba3t0WZQ8bA5OSkyDXJK6ThicViETNn\nKqCYRaX0GVCSvpU4Hg8FpciD748JsxR+sFBwBM5ms5ibm8Pi4iLsdru4O1GUwK200hSZ2LtG8zw7\nnhAED3kyJlh4KVPO5XLiGkXGCd33OQ1yr8HulxxYcr0psKCFYa1WE3N2flaERvhed3Z2ZPpSqVSw\nWq2IxWLy7BJvZ7fM6w5AFmF8DnmwMQLbaDTKwcTJkdxiQlnHx8fIZrNQq9UvrbMHXlEhrdVqGBkZ\nwXvvvQe/349f/OIX+OY3vymFpFAoSCyA1+vF48ePJVwLeH5qA5ALVSgUYLfbUalUsLe3J2MQ+aJ8\nGInf8YNTbohZuIh5MQqZnpXKmFvqqdk9kB9KugoAUVaxm2EuOl3PKWfNZrNSMLn4KRaLGBsbkw+V\n4wrHWGUyZTabFUIxH4yRkRG43W4Z7QYGBrC+vo7FxUX8xV/8BSKRCI6Pj7GysoLh4WHEYjH4/X7c\nuHEDhUIBo6Oj6OzslNjgjY0NzM7OYnR0FIVCQbAppRkECyU7VCXhnGRz4qMMz+MoC0DGTDrxk+tH\nihApNqQ3EZOl4QW3zaFQCOl0+lT3NTIygmAwKL6X7FiJ23HLn8vlhBdJc2sazDx8+BBWqxUWiwXt\ndlukrewKWcDYzRDzPDw8FMcv6v3ZSeVyOQAnDBKyO9hV9/f3i3+A2+3G3bt3ceHCBayvr4thTalU\nwtDQkEQIMymARYUEfDIb+PwRkuLWmocYJwMWs2azCZPJJGIP5quR8sfoaqr3VKoTDwW6do2PjwM4\nKXLMdIrFYtDpdLI0ValUgvPzuWMN2N3dlW3/ysqKqPF4aPHfJgRA7JewF6WlSjVTtXoSG86FpvLA\nJ67Naetlv15JIaUjETEXr9eLUCgEg8GAyclJ2UCTCP7OO+/A7/djcHAQfr9ftOPEYxqNhjjj0yWK\n7uAcj6ksYhHlFpULh1Qqhd3dXfHVZA7U5OQkAoEALBYLjo+PT2GkBwcHAuwTK2LXSSkn1VK0x6Mj\njsfjEToUl0AMzOPYrNVqEQqFBK8qFotiI8ZETYL/DocDwElxIZWJ7uZKM+ybN2/iX//1X0WSykKj\n1+sFf4vH4/D5fHjrrbfQ1dWFq1evylKNruOUyyoVPHTmobGFcpPPQsPDkNJXdkHMjeKITIckUoW4\nbKME9uDgQAqq2WzG7u4uKpWKyB2J6XIJwodmcHBQOsVWqyXmGpubm/9LzUQlD4srPxuOiRqN5hTm\nqLy/iAESW/X7/Xj//fexuLgoxYv3TiQSwQcffICnT5/KkpPLUh6KTHBldA0nHEqgq9XqKUk1APEk\nIGOFhYfXki5MvD4M3YvFYoKX22w2STzt7e1FKBQSHmw2m5XXtrOzIxiry+WS61QoFERW6nK55O9x\nEUVJKalPhM2IkWcyGXnv3/ve98TohpOI0iGKIZAqlQrxeBypVEruIaV5OJeEbMa4gOTBAZzg+Hym\nXubrlYXf8QRiN0Gckwuea9euIRAICHbHbHZuOOmotLe3J1nzHBN42gAnlBZKPdnOKzXzAwMDgrky\nP5ybYC46iDnxpuM4QCoKN6NHR0fQ6XSnzFCIn3IzT85qs9mE0WjEzs4OpqamEIlEMDo6img0KkoY\nHhLUu6dSKcFu+RAQYigUCjhz5gxCoZAUYUbtEivmoXDlyhXcvHlTXjtTHQuFAnZ3d6HVanH58mWs\nra2J/C+RSGB9fR0ajQYOhwMOh0OKAcc2mk/wkFKG2xG75nhpMBiku1apVOLU3tFxElVtNpthMBjk\nc+Qyjvp7drS0Z2N3Ti4wbQhJneHUUC6XpYDt7e3BYrHAYDAgGAyKBygVTQCkM+Z740HB+OZyuSyR\nysQLCTPwc+Hf6+zsFHYD7wPlvc/uTEnp4Z/l535wcIC9vT2cP39enhXep5SpKuEjQiRc2JHxwIOP\nDBFijwBgtVoxNjYmVCx2cg6HQ6YEPkO1Wg0zMzNCV+J7Ji+6p6dHHKgymQwKhYIwZoi9Eo/e29sT\nxsXa2ppAC5OTkzg4OMDS0pLQ2MgPVk6Ax8fHSCQSopXX6/WYmJiQ9Ace1Oyc+Yw1m03Z9BODX19f\nx+bmJj788MOXqmmvpCMdHByUm4UbOODEp7JUKsFqtSKVSkn2e2dnJ54+fQqLxYIzZ87g3r17cDqd\ncrMQuCehmRhNrVYTL9AvvvgCY2Nj0sWSzMxirlKpYDabsbe3JyF0AGRcoCaYNz87EnZnLL6VSgW1\nWu3Ujc/ICW7DWVCOj4+FC0gKBovoyMiI6PsZ6ctF1NHRETKZjHhs0rlepVJhbm4OmUwGoVBIXH/c\nbjcGBgbw6aefQqPR4LPPPpNTm5SemZkZeDwevPHGG2JKzdiT5eVlfPOb38SlS5eQTqexsbEhDyhH\nPeJSrVZLYBReVz6gHAc5ujKjHoAoh6rVqjghcbvd0XFimk3ckpaGZrMZ586dk4yiQCAAq9UqBYs6\nfX7eTOpUdqkDAwP4p3/6J1y7dg21Wg1zc3N48OAB+vr6xIGKeUU8EFqtE69OFhLev8BzVQ1Hd95v\nRqMRhULh1EKN5PXe3l5kMhmMjo4KlkkYh1DA3t6eFAO3243d3V20WicBeXt7ewKtsOtSSjFp3Nxs\nNk9FwCiLbaPRONWksOvn+6arGZkZ9H0tl8uyPKbhObXsHR0n4XrEkckoYEMyMjIi348S6kAggP7+\nfly5cgXtdhtLS0tyeNMZq6+vD2azWZgSwHMjGrIuSMgPhULyvkZGRsTPlx0xl1j9/f0IhUKIRCIw\nGo1wu92SePAyX6+kkJIjx59zi0kqS6VSwfb2tmwgDw8PYbVaoVarcf/+fXzjG99AtVrFkydPZITj\niLO1tYX3338fyWRSNqu0rONprQTB+cEyBplxD3wQQ6EQvF6vnF7K10QTYG53aUCrHCMASHokbfc2\nNjZw6dIl8Z3kjcqu9+joCCaTCfF4XGJO9vf3EYvF0NXVJT6sBwcHMg4xGuTLL7+EXq/H9evXkc1m\nxWf0xz/+MWw2GwAInHH16lXo9Xr09PRgfX0dn376Kc6ePYu1tTWo1Wp8+9vfRjKZRF9fHz7++GPx\nEzh79qxspEkZUy5UuHwD8DtJ2IlEAt3d3eIcxddE13smGnCkVKvVopgqFot45513MDs7C7/fD5/P\nh0qlgvPnzyOTyQDAqSXY/v6+KMjy+Tza7bYocehEf/HiRXnol5eX4XQ6odfrsbe3h2g0KgsxHnKE\nLgwGA/x+vxQmpXUfF2B0AaNUUUm9Y7dPDJ2ULqUfAAnwxEwbjQaWlpZgNBrRbDYFcuA1ZqHnfc6D\nnsWdblg0V1EunqhxJ5uESyayVRgwR48KHrhTU1NotVoCZfEeZgEl0Z9LHxpc0xWM3/Pw8BATExNQ\nqVTirXvz5k2Jd6FqDYAoCCkDJ1TDAsrPgAY3/LVUKoVarSbP2vhXjk/Mi+NzFY/HxefhZb5eyWhP\n0Jmkbp4IHMH7+/tFLUJVAk9bk8mEn//855icnIRarcbq6iquX7+OpaUlTExMIJPJoNlswmKxCC7k\n8/kwOjqKSqWCvr4+AZu5jKD7z8jICB4+fIi5uTm5IVmMSbQneV/JKSUdg9nyDPTijdtoNISqQ/WW\nRqNBPB6XWGjiYd3d3eK8T7Ce5hXsFMjtJBmeogZuTJPJJD799FO4XC44HA7odDp8+OGH+Pa3vw2b\nzSZuVGazGVqtFo8fP0ZnZyeuXbuG4+NjXLlyBU6nE48fP0Y2m8X4V8Fl5OH5fD7pJok78nSnxh6A\njKXKMZLY7PDwsBw0AOShotHy7u4uBgcHZWt74cIFeL1evPnmm3jy5AlWVlawsbEhxXdqagp7e3tS\nrBiAR3UMcWeSzElQj8fjYhxCAQB9DOr1OtxuN1QqlXh3EvJh4aSpNwsXOyNijMViEU6nU7ouQget\nVkvgqL6+PvHx5JYeeN5l7e7uykLp+PgYly9fxvLystgi5nI5YZ/wnmPHTYyaPF8lMZ10sWazKe5Y\nhGKoPScbhXllLMjkSjM2JfRVgCPpaOR56vV6mM1mYT/k83mZZKhYNBqNspg9PDwUw/CdnR2Uy2Xx\nAeC1ISzCQs5Dil9KHu/Q0JAo5pjPRsZHd/dJAN+zZ88EDhofHxeIaH5+HjMzMy9V016ZaQnHLXo5\n5vN5dHZ2CnWIpz75dbQ4Iw2CGUTEOpPJpGy5bTabFDW/3y/xwqRNGI1GiXYgz5Gdhk6nO5Xrrlx0\ncMNKXuHg4KA8pIQYRkZGsL+/L10lN5r889ls9hTnkM443DByS88FDh3CuWzKZrMC2vPGIs5Iz0yr\n1Yqenh6JFtHpdFhcXMTHH38MlUolW99YLAafzwer1SpdRzablcPNaDQKD5fXZ319HZ2dnRj/yuOA\nRiStVktwS2Ux4BZb2WUR22PxPTg4kAOGDyvTMwuFAs6dO4ef/vSn2NzcxNOnT6XgGwwGGQ8ZqEYq\nDLsc4q98eABIQeXDzddKrPCLL75AqVTC+vq6sCk41vOz4Y/8HrR9BCDMiWKxKB0nvzcfenJHuR0m\nHY8FnIWA/FnaEWazWWxvb4udHelIkUgEDocDJpMJpVJJNPVKxY/SHJvXm58Xi65yMcdDiXJp/h0A\nclAMDw+LITfvoaGhIXg8HuTzeTQaJyF7rVYLFotFolOCwSBqtRqKxSL29vakKSB7YGhoCFNTU6jX\n65JUykOQSzNOs2x6KDPl80oTGLKBOPFSKcUmSqvVyhi/s7ODJ0+eiPPZ1zr87l/+5V/Ej5Q8N45N\n5XIZU1NTSCaTskXltnRra0u0893d3fjiiy9gt9vRbDbx+eefY25uTsYbcvuoWBoZGcHy8jLcbrfk\neXd3dyOZTAqdJZFInOKgsngSS2u1WoIbNRoNUTORGkU568jICGKxmOQwabVaKcrd3SdO4uvr6zhz\n5gwikYjw/Wj4y5uDBYgLE+KpZrMZPp9P7Ne0Wi0ajYZozTs6OkSVND09jadPn6K3txeTk5MYGRmR\nwDSG+5VKJaytrSEcDsNms8HhcMDn8yGbzeLBgweigtnf38eFCxcAnLgNmUwmLC4uwmKxyOjMDp4L\nKI72HFNJM6KSh9tSOuxzcZfNZmGxWNDb24tnz57hG9/4BgBIzhYTKAOBgCwLlZ0hixeXgCwWPMDI\nleREwA6KIzsPayXfkPguCx0ZGIwdYTFSKpKGhoZkSUgmgM1mQzgcliBBqtJ4ndiJ0kIv9FX8NVNe\neeiSgkWe8N7eHjY2NsRGkukQiUQClUoFNptNeKG0rePrUqvV0jVTEksWAjv7SqWCUCgkUBv5oIRP\nSL5vNBqIx+Pio8ok00QiIYXf6XRicHBQDrFEIiE8zu7ubiQSCYl14S6Dnx+vI18/l008lNnZUxRD\nXrMSLlFSv9hlA5CJkLDBa6+99lI17ZUU0qWlJdmuM86BbkStVgtLS0sYHR2V3+PpSIMEnU6HbDYr\n8cYA8Oabb2J3d1eoMzR/rtfrYkbCjsnpdArdisojYqyHh4dif0e3IkbNEscrFotCn+DmlzcjsVdu\n21nEWZC5NSXJe3BwUOSGg4ODACDwAWk4PIk5rlosFrFGY+dD2pZSk8xRm7w44KQQ/fu//ztGR0dx\n6dIlrK2toVqtwu12S+H65JNPsLCwAL1ejw8++ADT09MYGhrC2NgYNjc3MTAwgNnZ2VNZO81mU9yG\nlAR3YmY8jCiZzOVyiEQigoeSPsSiTd/Ljo4OYRCYzWYMDg4Ks4BqlHQ6fUp1xu6T4YfEbnltuECk\nQXY2mxWqFt8PO2mOsMrFDK/pwcGBpIKSJUDII5VKyXKTBHZCHTRvYeQGJzNCAn19ffL3VldX8frr\nrwt5nvxJ5cHArpKsFXaJNGWmNHp3dxfBYBDBYBA+nw+5XE4CF6kIUhp4EGMl5k1ozWg0Ip/Pi+SU\nm3z+fRZDmsDw2nF5xqVuKBQSjwRq3PlMs6MmtYkGO4RyeFgqFVa8zwnjEC9VTnjK/wee2ydyUuCU\nwanhjTfeeKma9koK6aNHj8QP8fXXX8ft27fFLKG/v1+6DtIjeGpUq1VxDA+FQtDr9ZiamoJarZa/\n53Q6JXTMYDDA5/NJd5FIJEQfz41sb28vIpEILly4AL/fDwAC3LO4pVIpoQnRo7RQKMhCiAbN3M7S\ntJmEa/7+wMAAstms0J8o33M4HHIqHh4eShfEh4XmKCy07LZ5kxJDjsViIpllHIbJZEKtVhOX9KdP\nn8JsNmNkZASrq6vQaDSC9ZKzyXGG/pmff/65yFHZZbfbJwmebrcbWq0W2WxWxiiTySQLHeC5a0+p\nVBI60cjICBwOh5i9pNNpHBwcSM67yWSCx+OB0WhEuVyWz73dbuPq1au4d++e4LzDw8PY3t6WqYaM\nDHbGdEAi/EEskH4KRqNRRl7ivlzy8HNhwWfnotGcxCNfvXpVsFkuUcm+ICZus9nkQKHghA5HBwcH\nIrkEIGNys9lEJBLB2NiYLGcIMylJ/8oxl7Qn4DmkQliLh2tfXx9mZ2cxNjYGk8kk5uWkdVERxWvA\nKYqFSMlJZcdLD4KjoyOBzAYHB2EymdDR0SEHDfFKNkg2mw06nQ4AkM/nEY1Gsb29LXJpupflcjkk\nEgnkcjlhu/DgIz1RWQD5xWtD8Q0/SyU8oCye/DtsOrq6ur7ehXRlZQX37t3Dn//5n2NpaQk6nQ5a\nrRbLy8tyY7NDjMfjwnVTEo3Z7q+trSEajeLx48cYGhpCOp0WI5ONjQ1MTk5K4Fq73Rawm+MTuYBW\nq1VGW44eiURCxmmKAMhh5JavXj8JTOMNRLmlVqtFT08PtFotNjc3YbVaRcZHp5lSqSTAPw1W9Hq9\nPOh8MKrVqpzyLKbU75PqxYRHLr20Wq3ESTebTTidTvh8Ppw7dw4mkwmfffYZ3n33XQnuo7epz+eT\na5DNZqULu379Or788kvBy+jCdXh4KCmY1FcTi1balBFPJeZL8L9YLKJer8NmswneSZyMCpxKpSIL\nykwmg3Q6jT/90z9FMBhEOp2GRqORbplLDB5CjDlhJ8ctMe8H2uABEJ05AFHC8HVMTk7i+PhYDmEe\ndLlcTn5PSRPq7++XBNfV1VWoVCr53mq1Gru7u2J+woUPKToPHjyQIk4TbLJAeL9wOUvMkocpAKFj\nsaiwWCgdzuj3wPuMHSi15lxc8X7loUSvBp1OJ3sHJf2KsFImk8H29jb29/cFTkin04hEIujp6YHN\nZhOzHJVKBafTiWvXrsHj8SCTyWBraws7Ozvi0MZp5sVx/MUu8sXNPX/kjD10KgAAIABJREFUQfDi\nUkpZfPlZ88/19vZ+vUf7f/zHf8Qf//Ef486dO4JpAYDFYkG1WpXO0Wg0yo3HUYqAMqlHlFxeuXIF\nn3zyCcbGxjD+VWa72+3GwcEB1tfXBfehHp/jAOMVGFXi8XiQTCbFvq5Wq2F0dFSUG9vb27BarUin\n0zI+ccOp0+lQLBZht9sRi8VgsVhQKBSE80hncD4IBwcHcLlcCAaDGB8fR7lcRk9PD4aHhxGPx+Vk\nJ9GfqptwOCwYGcPrOBbr9XqBANRqtWTzWCwWwQuZXMnDQ6vVYnFxEWazGXNzc1hdXcXk5CRarRYu\nXLggjj/sWpgvRfy6q6tLCNrk9h0dHcnCp9lsivaa3q7sFOnbSioUGQgczTk1sGCQC/iDH/wAb7/9\nNprNJpaWlmC32zE2Nobd3V2MjIxI8SFux86KZjb80mq1CAaDcLvdIrMkpY783FbrJNiN/E4eDvv7\n+3C73VKQWfjYNZL25nK5sL6+junpaaEe6XQ6bG5uYmJiQlRxxLoJVSgPe36+Go0G09PT6OzsRCwW\nk06UuG+1WsXY2JgoepTMCN7v8XgckUhEYCYuAKvVqvBT2WwoTVgYI03FEpVllMqSVcJxnVxRvmeN\nRoOpqSnJSKI6kcyA7e1tLC0tie0gTcR5KCo7RxZJfvE68f3wi5258u+yO+eikAWY71Oppvtad6Qm\nkwk//OEPZUGglNRxWdFqtbC5uSkb02KxiHQ6LdpejhaHh4eYn58XH83t7W0kEgncvHkT/f39MBgM\nMJvNorff29uD2+0WbEhpXFwqlTA2NoZ4PC6dEfmQlOwRNuBmkCMWOaI0N8lkMtDpdAKAU7rG8Y86\nbz4QdOZRaoA5Lu7t7YkEtre3F/l8Xg4JdkAczznGUoOt1Wpx8eJFJJNJ3L59G6+99pqY/tKjlF32\n3bt3Mf6V6082m0Uul8Pa2ho2Nzdx9uxZ4dw9efJE8r4Z+bu+vg6n0wmTySTdNj+fzs5O6d4JIRB7\nGx8fFxpRvV6XkXZ/f18WfuVyGfv7+8JKiMViOHfuHG7fvo0bN25IrAajqjc2NsSlidgfaUfE17gV\nB04mHMI6FotFKFEajUZ8NZWmwFRzkXHh8/lkIQrglNCgr68PPp8PTqcTFosF9XodmUxGDjqLxXKK\n00zqDj00WcwIExSLRRSLRZw9exYdHR0wmUxiq8exnIIQ8p5ZDNlhGgwGMe6hgASAYMos6Owy6/W6\nwBFks/BwI6+6VjvJ0xoZGZHGZ2RkRAQHlLqWy2XhclICSphPKVAgREPlI68Fi6JS+aUsiuxUX1wq\nsb7w93gPKIUJymVWu33i3fC1Dr/7+7//e+FskWROwDoYDGJ+fl4exOPjY+j1eng8Hgn44mhIPLBS\nqQh1xOVyiTEtT86DgwOREgIQChLHmmg0Ko7eNptNxn2z2SymJiygHO96e3sRjUYF4wMg29y1tTWc\nPXtWvEfpgaqUiLK7UOKiPT09ogxROswrDW8ByENCw5RHjx5henoawMmSwOFwiHmL2WzGo0ePZJO5\nsLCAZ8+e4fXXX0dnZyc++ugjnDt3Dvfu3cP3vvc9rKyswOVyiRyvp6cH3/jGN3D//n2srq4KTYXd\nms/nQ39/P2w2G7LZrIx5yiUQH0wAp2SK5Fmy00kmkzCZTOLadXBwgK2tLRk16XPK+JWJiQn85je/\nwdDQEN544w386Ec/woULF2CxWPD06VPYbDaUy2Xk83mhD7Eb5xaaByFjqnO5HHp7eyW6mLxXpbkz\nuzwWEOqylcozdq3spDs6OhCJRIShMDk5iY2NjVPiDo1GI1AFOys+6JQjU1xA6lo0GpXphayS8fFx\nMQ7hRMAJht0naVdUofX29mJmZkaeo6GhIVgsFomsVtKgOGKzA6YPQyqVQigUkgmEktx0Oi3bfWrj\nqUiiGbfZbMbo6KjYLbKhUhZHXosXu1Kl4oyFlvguaWXKZaFyQ0/VIl2sePCSnnbjxo2XqmmvpJCG\nw2HBL+PxuGCMer1eNOkcgb/5zW/iZz/7mfghJpNJObEKhYLw246Pj6VoFotFZDIZoT/09vZCq9Vi\nbm5OLMjoDkMT5bm5OTgcDsEdt7e3MTMzA5/PJ7Z23KRHIhGhLtntduk4OVJ3dXWJ0xOz63O5HGw2\nmzyIvKGJ1zFTivBFT0+PyAPpttPV1YWVlRXMzs4KBQg40YObzWbRoRNjpFOT1WpFq9WC0+kUP0un\n04mtrS289tprePToEc6dO4d6vY5wOIy+vj7Mzc3hwoULwgWkYUhvby/m5ubQaDTEEi2VSsFut8Pn\n82F4eFiWKJRnVioVCWsLBoOibOLBWC6XBY8mAb1SqaBcLqOjowM2m02cgshS4NhssVhkHPyzP/sz\n/MM//AOmpqZw6dIlbG1tCVWOCh+lE5JerxcskrAHADng6FVAWh4jaIgXsstVppSS9cGMKIvFgtXV\nVXg8HoEAOjo6sL6+jrm5uVMHC6EkmpzTF7PdbosLGfE7Mk2MRuOpe6RSqcDtdgt0xaLP5oMdGicn\nLl3ZnXLSoxsY4aL+/n7Y7XaBqqgWJHODxXZmZgb7+/sYHh6WCdJoNIrWf2xsTKYobvaZq+b3+5HN\nZqWJYBFkkWRnquTy8tDh89HV1SWQG3+k/R6ZG8rulP9RosxOFTgp8tevX3+pmvZKCunm5qYom+r1\nuuS/8zRotVrIZDK4evUqvvzyS9y6dQvBYBBHR0dicNBoNKSLUS4PeFpSMcKsGJVKhUAggGfPnmF8\nfBz9/f0STVIqldBsNrGxsYHHjx/DarUCgCw5WOA2Nzfl4aVXJU1KeNpzPOUIyA+RElXiQoeHhwBO\niiCxSm76Ozs7ZTTnxpNSUTrWACfYlN/vx9jY2ClDDW4d7927J3p7bj7PnTsHv98PlUolKqVqtSrC\nhvfffx+rq6u4ffs2jo6OMD4+js3NTbhcLnz++eeSKMC8e3IJ/X4/rl27hmr1JADO7/fLooGQyMDA\nALxeL5xOJ7q6uvDs2TOUSiXpTtmZGY1GuFyuU+oTGtqwM+rs7EQoFMLAwADm5uYQj8exsbGBv/mb\nv8EPfvADaLVaDA8PY2NjQwyJeX8Bz4MPyYDo7OyU90PeJGEApb8Cu1kuBPmQU8LM5SMdiiiR1Ol0\nCAQCknY7MTEhEAT9SKlhJ3GcHFyOruzqWRB5z/HXDg4OhJpUKpWkO2bBoUsUCzFxanJeuWzSaE4s\nJbkgJcuEkBoPxnb7xBuWsEd/fz+2t7dhMpmE703hAP1FU6kUstksUqkU6vU6YrEY1tfXxfCcy1S+\nRj4/7BwBnOosufRjIeQ1UxqyKPmt5JeyXhBKUTqC8XrqdDpcvnz5pWraKymkHDtDoZAYGVCORlCf\nm+D19XUZWYxGIxKJhGCPjAQBILxM8hd5UXi60RSBqibikf39/Ugmk2g2m/B4PNJ1dXd3i1JESbdw\nOBzCVW00GtDr9TLGUMaXTqcFzzs4OJAwPG71yUBgl9BoNOByuWSsZBdH6gvHTxZO4ofKrlzpisQb\nja5EkUgEFy9eRDabRaVSwcLCAgKBgFw7t9uNaDSKjz/+GG63G4ODg7DZbGJbePnyZfz4xz/Gd77z\nHblhx8fH0W6feHTOz88jHA7Ljd7be5K0yW0t1VUsDuzwuNVnwSFTI5VKiV0i868qlYo4NQEnYx1N\nbng91Go1fv3rX+Mv//Iv8R//8R+YmJjAxMQEAoEAhoaG5B7jw8cAP0qECQXxYOQYSc9SJfbGB667\nuxujo6MSNczv12g0MDU1JXCA2WyWzp1JB3SUYhOh3DxT1QVAlorEC9lsAM8384SXKNIg95jbao68\nZHbQ64Lfj01Ib2+vsFM4EQWDQVQqFUmTrdVqSKfTcv/Rfo8HBuGCfD4vLk+0nAQgkILdbofT6YTD\n4YBer5fOmu+PRVCJZ/Kz52FGCIUcUnby7ERZiIlJcwFH2hTNaQYHB2VS4b+t0+lkF/B/fb2SQnr/\n/n3EYjFRtQwPD8NsNsNoNMLr9cJqtQoVxm63i/IIAH77299K3AixMxqU0EmGWl/eNKROkNLBPB46\n1/f29iKZTMqHz40su0S6Den1ekSjUenecrkc3G63OPMoMUy9Xo/19XXBxAicd3d3IxwOS0okkz/J\nCGDcNMeyVqsl3Mp4PA6v14toNAqbzSbLK4oZ+FBxiUWlDGEELgsI8Nvtdnz00UcYGRnBlStXZFPM\nE/7Bgwd488038fHHH+N73/ueUKIoQgAgm3jyYskyCAQCiMfj2Nvbk5ubnSkxY5vNJkRushrK5TJ6\ne3sxNjYGlUolsddWqxVra2sIBoPyULFr57inVqsxNjaGH/3oR/jbv/1beW9UqNF1DDgpIDSp4HjK\nTpBS5UajIaoh0tBohsIxmrJGFjlKRe12OxKJBAKBAEZHR0/JG/n/dHg6OjqSBSELALtdHmoq1fMU\nUo77wAkmrjQfIeOApH4+A8qDgAIFJcOAHTbhKU525LsSOiNMYjQaceXKFaGOkWi/v7+PQCCAarUK\ns9kMt9stkA35woR1CoUCHj16hEgkIs1IoVCQDpLLQCV7gb8GPO8olZ0lBRc8LHl9WJDZmfKwIYRE\nVRf/PJfTX+uO1O/3IxKJyIeqVqtRLBal7edSgdQXLmk6Ojrw1ltvCc2I0jRiiuxGWXAY0UEAnBvB\nxcVFcfdRqVS4fv067HY7rFarhJmRgkPLN/oBECeioXIwGBQZKgFrGitzjKMaiuRjqroIcqfTaYyP\nj8sNTfK4Xq8XeSNPVwL2jG3mQ0XzabIF+OvsyqmBZlc7NTUlN7rf70cul5MMI7Vajb29PXz729/G\nnTt38O6772JlZUW6ILfbLVtir9cLn88Hg8EAi8WCUCgkFJnXXnsNfX19cDgcMp5RccawMsIW5PAR\nU2OBKRQKSKfT2N3dxfT0tPAnlQmtvH+sVisSiQQ8Hg/+53/+B++++y7W1tZkgUjFFQsYH04uTehf\nygmJr5lwBe9JtVotHgP0JRgaGpJ4GGUhZewvI2uIXfIaAyf6bi4IiY2zm+zo6BAnfB4WVHWxQJIj\nSsiIxZHKQWX3qaT6sOMmHKVkOXCKY0FXdpPVahWrq6viGcprF4/HkcvlxMS5WCwKF5SLvNHRUYyP\njwurwWKxYHx8XEyV2U3yOrNwKlVKyoWR8kvJB2Vd4f3MH5V8Uh5myt9TsmX0ev1L59qr2r/rFf1/\n/PXRRx/h888/l9GWlB3SJGjyS9K3ciwhGK4k6Wo0GgSDQYmocLlc2NjYkG6ERg5UkRBAJ263uLiI\n4eFh2UaPjIwI6M9xh61+6Ct/Q9J8lpeXcfnyZWxvb+Pw8BDT09PSzSg3mwAEB+ru7kYqlRIcl9tt\nFr6hoSGJoqZjVTqdlrGQ8bfsbMlp5SFC53uqaGjV19fXdypttL+/H3fv3sX3v/99ZLNZDA4O4pNP\nPoFarcb8/LxIKZPJJGZmZiQemsVtdXUVf/Inf4JPPvlEgtj4nvV6Pfb398WDkxHW3d3dwsNV+m5y\nsTI2NoZGo4Hd3V0cHh7CaDTCYDCgUqng4OAA09PTGBwcxNramhQ24oCJRAJGo1EOLRa/g4MDeL1e\nrKysYHx8HIeHh0KgV6vVMJlMUlQpceWIy86MeCMLDhczc3Nzck23trYwOzuLYDAoKioe7mr1iRWg\nzWbDxsYGJiYmBD9ls6DkfJKqxEUWiyrHUD70JNVTaMKlWbvdxsWLF2EymRCJRFAsFsXOjl98puhz\nQAyxVjuJ5KEJMgUhDKQbHR2VRSdTO+lgdXx8jEAggEKhAK1WC6fTiXa7LVznZrOJaDQqnf/g4KAU\nLz7LL3I/lVxzHnwvfinpUEoeqVKx9OLXiyonJde02WzC5XLhr/7qr16qpr2SQvrLX/4Sd+/eFVkl\naRo0n+jq6pJxnScLN6QAThVV4LldG/PRCRwXCgXpYHjisPtjKiOxMtJPOjo6kM1mYTQa5UEbHBzE\ngwcP8MYbb2Bra0vMdMfHx/H48WPMzs7KKanc+nu9XlE89fT0IJPJwGQyycZ9YGAA8Xhc5LHBYBAW\ni0UOBOqtBwYGkE6nMTc3h4cPH+LcuXOS9kmdOgAhdXMMJGF+dXVV6FHkaXZ3d2NhYQH5fF5SXF9/\n/XX88pe/xOzsrFBAaOzbbDbx05/+FO+99x4KhQLcbjfm5uZw584dKVqMo2DRYJfB0Xl4eBiNRkPc\nqjiqRaNRtFotTE1NiZUeu1aS61lY6FX7xhtvQK/X486dO7BaraJ6q1ar4ngUCASg1+tl1BsfH8ev\nfvUrTE1NCf6nVp/4YrLzZywx8clSqSTTDgBJu2XxJ0RFapBGo5H30NPTIzQwKrSmp6dFnMCuj/cy\n1UZKyzje73wOyCRQQhTDw8OYmprC7u6uCA8ikYiohmw2G3p6eiS9kyoqupjx9SiXtWRIcAphMaMK\nb3h4GNlsVgofF7NsOoiT8oAkT5qfIacJPmN8L5yyOKEoN+nKUV/ZsSrxU36xKCqVTvx15Y8A5M8o\nCykATE5O4vvf//5L1bRXtrUnDhgKhSQKgBxKv98vHwbfMClDwHNSLccSFrFsNov9/X3ZanKxQaJw\noVAQYjjxRxZS2tQNDg5KCB03m8wUp6JnZ2cHbrcbsVhMNPBc9pjNZuTzeUxOTiIajQoFibgXidfk\nGNLcmTZ7dL4HIEWH2KbyYY/H45iYmBCuHvXiTPgk9sixnw9wqVTCpUuXkM/nxdzj8ePHeOedd9Dd\n3Q2n04mhoSE4nU7UajX4fD6BWAg1sMshP5fAPalB7DZIcD46OkIikcDs7CxGRkZw+/ZteL1ePHz4\nEAAwNzcnBi9cqlgsFszMzAgUoAyPO3PmDLq7u3H//n188MEHUKtPfGnJSazVasJmWF9fl034wcEB\nLl26hAcPHsDlcklh4AHAtMtoNAoAsm0OBAJiHUi8N5fLSSw0u32O0YRWqDKj2Uez2ZT7MZVKwel0\nCv2PY7TSRo9LFyWxnIsSdv28T3Z3d7G/vy+OVdwFkHEA4FRRZBPDz0x5v/B5o7tSR0eHxJcbDAYk\nEgkcHR0JpQ04Sb0YGhqSSZGMFh6ANKpJJpNCH6MEudE4iYzZ398XvHJ/f1+6fkIOPLyUmUuEMZQC\nhhfhAP7InQEPE6WngJJ3SixVr9djYWHhpWraKymkyWQSq6urkhlfLpdlFMjlcrh+/TpCoZCMwgBO\nuSAp8RLlooFYBzsansKtVkvUQ/wz7HIZ+kbsip0veaDcRNIQJBqNwuPxCO56/vx5pFIpyZknzsNF\nCYnqrdaJK33oq6TIzs5OpFIpMZ2lxwC7Z3YlymRN/jo16wCksLbbbaTTaXFHYnfPxZlyaxmNRrGx\nsYGZmRno9Xp5rXRVMplM+Pjjj9FoNAS7JV3ozJkz4qhVLBbFOJo4YT6fFy9YFnjgJCL78ePHqFar\neO+997C0tITz58+L4UU6nRYvVH7mq6ur4g0QDAaRzWYxOjqKTCYDv98Pq9WKjY0NHBwc4MMPP0Qg\nEEA4HBYCfSaTwa1bt7CxsSG6e9KclpeXRbU0PDyMvr4+5HI5oTIBJwWHn+nExASSyaSIOnp6eiQa\nnPLWo6MjGAwG7OzsoNFoyOKJxZZ57SaTCdFoVDKEaDBOahJHa97jxFTVarUstXi4As+NNvh9yKGm\n/l6pMef3IT2Iv8YOmX/++PgY+XxeDFnIja7X6zJN8VnjvdhqtaS4ajQnOV/KBZvL5RIRBv1klaoz\nZZFkgi93FRzdj4+PZUHE4ku3sHK5jFKpJDQ1JRUKgMAj/I9Fl905l288RLq6ur7ePNLt7W0Eg0HY\nbDZp/+12O/L5PPR6vdy4oVBIljL8sIDTo47y/9mpKgF1yu1IQaE5Lm8cUqBUKhUikYjgi729vfJg\nU/pHF6ZsNgun0ynGseR2skNhp2mxWBCLxVCtVgXvZEFjdEKz2ZRRnsFttHZj96yksDidTqyvr8uG\nlF083b+VPFpej3K5LPprih5sNhtisRgAiGsW/24mkzkV0ub3+2E2m2EymbCzsyMYJLtZxoJEo1Hh\n1fKUZ/Q0F4n0eVQqlbjJPXv2rDx4jBFmbDSXKeyepqen4XA4ZIL4/PPP4XK5MDs7i+XlZQAQfqbV\nahWpLXE7eg4QwiGkND09LZrxVquFZDIpuDqx0na7LeYrjK5mYapUKnA4HKdGX3JYie9xsuBXoVCQ\nA5HLNuKcHN2VmC67KC6luPSirZyykyQn9sVFirKQsMAQI6bJutvtlqmMkxEbEMIDNC4hdtzd3S2O\nUt3d3RgfHxfbR3rb9vf3C57LLpGvh9eI04eSoaB87Zx6lMokCgyUfqpcXtFmklirshPlPuFFbFat\nVuP1119/qZr2Sgrp8vIyIpGILAr6+voQj8dx/vx5BAIBuRlotRYOh09xx5QXAHiOkbKAcgnBk1yj\n0Qjlhs7sFosFyWQS4+PjyOVyMgLV63VYLBa5URhJQS4cO7F2+8SQgZt4nmyHh4dwOBxYXV0VqaNG\noxFebE9PjwRsUcXEG4ALA3YeFBTo9XoEAgE5eJQ56ZlMBhaLRezJWJx5TXQ6nSyI2I0fHx9jfn4e\ner0euVwOu7u7ACByynQ6jc3NTbz11ltIp9O4ePGiGPNev34dVqtVxiDmHhWLRdhsNrkuFAAsLCyI\nWffi4iJmZ2dRKpXgdDoFagkGg7hw4QKePXsmiynSaVKplHggdHR0oFQqYW9vD+12G8lkEsFgEPl8\nXiCNaDSK69evo1gsygPOOOxarYatrS3UajXcunULPp9PMEVSvvL5PFwuF1QqFba3t2E0GuUhrVar\n8sCzQ1QaVBMnJj7Ig5XJChyRufG3Wq2SScViTUYH0xcoQCDkQdoO7QDL5TLm5+dht9sFD30x3I7v\nDXi+rCHVi4Vjf38frVYLbrcb09PTKJVKAjNRtjs6OioMGVLZaH1I4n1nZye2t7exsrIiWG4oFBLz\nH14vpQiAYzY/L0J1yqUS3wsbJd5/3LoTZ1bWBdYAFkalhwXrBvC861f+OfLGv9amJRsbG2J0rFar\nZRvO2IFmsynczEajIWNzuVyWLd/vwkGUWzieXjz56UDTbJ7EL3R3d8tCJpVKSQTC6uqqjNu5XE7M\nGOLxuNieXbp0CTs7Ozg4OBD8FDjBlchLZaxIpVIRgxJGxJIzyA+PnQMlpyyuhUIBBoNBVFCMZeHN\nRPI+CwzJ+CQ/0/+UNya9WC0WC372s59JDs/Zs2dPpTNqNBpYLBZ4vV7Y7XZEo1EYjUY0GidO/j6f\nT6zfkskk2u22wALsjK9du4auri7o9XopVvPz85J3Re23zWZDKpUS/i69LumR6Xa70dnZKWodjol+\nv1+EAS6XS/68Xq8XhkNXVxeKxaJkM5FpwYL7ne98BysrK//LFWxjYwO1Wg0Gg0FwU3ZHjOfg/cbY\nYY64NBDp6uqC1WqVzCt6cJZKJUnDpJiCBzBjpev1urAauLWnoYnVasXU1BSy2azIgVOpFJLJpDQK\nxH3ZlRGPZ9fF18/Ug+HhYYyPj+P4+BjBYFAOXeLexWIRsVgMGxsbp7BMJu7SWYw0Nrr4Dw0NCZ2R\n16+vr0/eC4Df2SHziwWPv877WAl18P/5npTQ3e9aQLFovtiQ8XvxdfHfevPNN1+qpr2SQlosFrG9\nvQ0A8Hq9+MUvfgGPxyMqIsax3r17F2fPnkWlUoHT6ZQPhcYlyhNFyS3jz5VSPt747a+UKjQ1mZiY\nQCqVQqPREDkjxwAmNWazWXg8HrFC++yzz/D2228jkUggn89jenoa4XBYsplMJpOYoHAcJEUkFArB\n6XTK5tJsNiOTyUiRZ2GmRyoXOtSvKzX8dKqhEfbY2JhIE9mxcuNMyg4J8dVqFZcvXxaJIOlWn3/+\nOXp6ejA7O4v//u//FqNdlUolXQEfWJ/Ph4WFBTx8+BAejwf9/f2IRCI4d+6cRD2zqCWTSSQSCTx6\n9AgABHphYN/FixcFn+3r60MsFkM6nT41jVCxZrfb4fF4xKNha2sL6XQaMzMzouNOpVJoNptYWFhA\nOBwWbiKTFdrtNra3t/Hmm2/i888/F+PmdDqNs2fPIhaLCctASe5mx0I1FEdnYs90MMrn8zJy22w2\nrK2tiQSSjkpKdRzd5NPpNCYnJ/Hll18KnkoXM61Wi+PjYzx79kyMR7hpJ4WJhzALDxcrh4eH0lTQ\nB+HcuXNyTxIWIr5P3FKJI9KIGziBTSYnJ8WTlvcbOdMulwsGgwFTU1OYnp6G2Ww+lamlvJ/4zCqf\nXSXn9UUVF+8HQnok7yvHcsJayq5UWYD5Z1lcX1xks2P/Wrs/hcNh0a0HAgHJyCGJ2Ol0IhwOw+Fw\nYHNzU0YnPgCU2P0uYq6yI1XqZoHnGl0+VI1GA8ViUTbwLxYddk68uQqFAoxGIzKZjKSXHhwcoFar\niacl/STZ2dGsmUWP+eYsTvF4HHq9XqR9hUIBXq8XT58+leRTk8kkoYA0XeaNQ7wpFouJAoUbc46g\nhUIB9XpdpIhU6qyuruLMmTNYW1vD7OwstFotHA6H4MOUyCaTSczPz59yhIrFYtDpdKIS44M3NTWF\nw8ND3L9/H/Pz83j69KnER9frdVy8eBGdnZ2S1Eg5ZDgcRrValThplerEC4Dpofv7+wiFQigUCqhU\nKkgmk+I6VK/XxWU+GAyiXq/D6/Wi2Wzi8ePHGBwcxNzcHJaWluB2u7G+vi48zidPnuC73/0ulpeX\nxdiFGCmhHeLYPBTZzdEukd0buyGaxihJ+YzHoecpi2hnZ6cQ2emI1Gw2hQaXz+dFE8+CTiaJErOk\nwooj84uNRblcRrVahcvlEknw+vo6AIjCi0srvg9uxuv1unT3mUxGrkmtVhOGA+9Jwl7Pnj1DpVJB\nqVTC7u6uSG/ZYVPeScYHDyxCF8oFGA8MZYFUjvEsqnwPyt9X+gfw2gI4VUCVY70STvjaF9JcLge/\n3y+UmmbzxPSiVCphenpato7ACfcwmUzKJpjqm0AgAJ1OJ3xEZdtLsuKIAAAgAElEQVTOE+VF6ghP\nQQBCRKaPJk9srVaLTCYj20sAoky5ceMGVCoVKpUK7HY7AoGAdMrT09Pw+XzQ6/VCxCZGGY1Gxbav\nr68PW1tbwlCgozvpFslkUopVR8dJ1jqD8ZrNpsQyA4DD4ZBNfDKZFHyN3Fl2t3TKHxwcRD6fl0UJ\noyB4UGQyGVHb0FR7bW0Nc3NzKBQK4vxDM+mFhQU8efIERqNRCo3f7xcyN3BCbeJ4zKUfIYFf//rX\nuHr1quRmKYPZ2u2T9M5PPvkE29vbWF5exq1bt3Dz5k14PB5UKhWEw2HE43HByzo6OuB0OjE7O4tQ\nKIRwOIzZ2VlMTk7C5/NhbGxMXLhoBj05OYlHjx7h0qVLIr+kGEMpreS/z4VMd3f3KTUR4QvSidj5\nHB4eolgsinMTDXr40PN7saCYzWasrKyINwHjiZXFmvcXiwI/P+WugPc/bfk++OADqFQnCQilUkmS\nA1g86vU69vf3pZPms0L2ARVNIyMjGBgYELYB/SW4Y2BxY5d9fHwsz6yyieEmnvJN/j2andAEhV4c\npIQpD4gXR3g+9/y5splS/hq/lH9Pycvlv9Hd3f31xkjD4TCePn2K1dVVPHjwAAMDA3jttdfQ09OD\nfD4vpz1PJIbP7e3tSfHR6/UIh8PC2VOSaZVkW+UIwA+PJ3hHRwccDgdSqZRQUkjvUXohkpbx85//\nXB5WsggymQwmJyeFasFRfW9vT3iRN27cEKf+4eFhXLlyBX6/Hy6XC36/Hx0dHaKsGhkZkYTJcrks\nDw0FAyyoWq0WyWQSR0dHErFCaEGv16NYLKKvrw+FQgFqtVr8Ksk/pJFyPp8XjFjJFT06OsKjR48w\nMTEBv98vwYQ0DlGpTkxDeMCp1WoEAgGMjY1JCmuj0UAwGBRcjBZphUIBfX19uH79Ovb392V0ZXe6\nsrKCWq2GnZ0dGAwGeDweXL58Gfv7+1hZWcGvf/1rqFQqmM1mfPe738XFixdxfHyM5eVlPHv2DIlE\nAgMDA3A4HCiXy1hbWxO/A6fTKY5azWZTCuvBwcEptgPHYt4n7B7J9+Xvs1CQ2kT6Fg2TDQaD0MR6\ne3uRSCRgs9mE7sdJhN1fPB7H9PQ0EokEqtWqXCelmor3L8UOfPhZFGu1GlKpFFwuFy5evIhoNIon\nT55Ao9GI4fXx8bHENnNJ5fV6YTKZoNFoRNKqhMOowNLpdLIwymaz0hgUi0XUajUpsMRMlUVf2eTw\n9bKp4fTHJTRjVfh7/f39GBoaQnf3Sfw5qU4stMRZ2dEq2Qovmp4oXwPrhRJGIDPja11I9/f3sbi4\niGvXrmFhYQFdXV24e/eubKBpwJFKpcReTK/X47333pNRMhQKwWg0IhAICFdReRopMRFeSP4eTx9q\nqEk47+npEY38/fv3xdGcvD5itTs7O8LRnJ2dxcHBgWwvQ19Zu01PT8PlcuH4+Bhra2tQq9W4fPky\notGoUGTIHqAZBBdVZrMZm5ub0p2FQiGBHSYmJmSxk06nheg9PDwsCiYu0IxGI5LJpID/pP+wEEej\nUdy4cQNffvklLl26JGmalUoFV69exc2bN1EoFHD+/HlsbW0JRktZrcVigVqtFo09nfE7OzsxPz+P\nO3fuSApBKpXC9PQ0otEoCoUCpqam8Nlnn4n5yf7+Pra2tjA2NoZoNIqpqSnh+PLBICezt7cXHo8H\nGo0Gi4uL+Oijj7C7u4urV6/iD//wDzE+Pg6fz4fNzU0EAgFMTU0JpYwmIrz+SmyRW3Dydklr4/jM\nokezbU4s7faJVJMHAQChQ41/5ZLFpSW7PHZxjDY5OjoSCabD4YDRaIROp8OzZ8/kNbGj4raa5iIA\nhPeZSqVw5coVuN1uPHnyBPF4XMyBGJ/S0dEBj8cj7mDZbBbJZBLhcFi6bZqnAJDixmaBtDsyAbxe\nr+DQNOmhtFmJZ/L5Uy6MlMWaHFclJKekb3HpdnR0JDsHq9Uqrm21Wk0OB14zdvJ8Hfx6EQpQdqr/\nv+lIQ6EQ7t27JyTanp4enD17FkajEcvLy0gmkxgeHsbbb7+NGzduoFqtYmdnB0+fPhVSNC3KbDab\nZJu/eOIo8RLlQkopfyNWw84uEAjI0ocPMO22nE4nvF6vmGl0dnbi/v37wq28cOECRkdHpcjxQyfx\nmgVxf38fqVTqFKmeHNre3l7s7u5iZmZGOsX9/X309fXJ+9RoNBJPQfUMsVcA4uHJJQFhBW5jaa7x\n29/+VgqvSqUS+7/l5WU0m008ffoU5XJZWAxWqxWpVAoXL17E+vq6yDeJJVerVfw/zJ3Zb6Npdt4f\nLhK1kKJEUaL2rSTVvnf1Mj3d7vR4EtgDXziwMVls3wRBbnJhwPCVE+Q6f4EB29mQBcggsB1kgFkw\nmLZnprunp6qra1OVttIuLhJFbdQukbng/I4O2W1MBQhQJlCojSK/73vf9yzPec5z2tvbdfnyZd2/\nf1/JZFJDQ0Oam5vT9evXdXR0pMnJSX3zm9/U8fGxurq6rEsLkWcUpjAox8fHNkaEQXFDv2wSwMFd\nu3ZN7777rra3t/XZZ5/Z+//gD/5Ab731lv7yL/9SU1NTikajeu+997S8vKyFhQXTf/ValBRqSBu9\nEQiHw0a+Bwf1Q+KIqKRz6g26oGQIrBdGgokGDMZDIOfhw4d2jclkUt3d3cYi4FqJoJeXl3VycqJ/\n8S/+hbq6uvSLX/zCIBsEdlKplK5fv24C5AjrQH7v6elRe3u7FcgYL40ADcUtpBfp6ecc9fX12fx6\n7pWuQ4918vqqtNxHhx7jlKrrGx7HPT4+tsGIFO6GhoZMdapYLJrzBuvmxWfXQgAY3P8XQ/paeu3/\n+3//70qn07bI+Xze9D+JOH/0ox/p+PjYVIqkyo2TFpJuYVjm5+etI8bjKLUGlQ3IAfJCvWA7jx49\n0pUrV0zIFpEIWuPi8bhpKqKqhF7qxsaGtXMCD1As6OvrM0zXF54ikYjRnMAhj46O1NfXZ/JidN6E\nw2GNjIzo448/Vnt7u3p7ey0Vp5OF6Km+vl6ZTEYjIyNaXFzU5cuXNT8/r5aWFrW1tRmzIBKJaGZm\nRs3Nzerr69PW1pbRUnZ3d41NEYlElMlklEql9OjRI73zzjva3t5WPB638dTPnj3TtWvXFAqF9P3v\nf1+/8zu/o2fPntmMpd/8zd/U//gf/0PFYlG/+7u/q6dPn2p7e1vDw8N2uHZ2dkzmcG1tzYSnaf+F\nbrS6umopfLlctvWncMmgt2KxqG9+85va29vTwsKC+vr6rNhDdw/0HJyn52ASrfhokPcS7YAr4pzZ\nn3BBiWB9/7nvHYcDDA8aih6V7kKhoPX1deVyOZVKJcXjcVPg/73f+z1973vf08TEhIaHh61AdevW\nLfX29mpmZsY6+9DEpagDbMbs+nK5rKampqp+eJwJZwU1Ms4akSLUJ55nrXGsLex8VcDjYTnpvA/e\n/9mvx1dFlKh3ged3dHRYp9/q6qrBFkB24LueMcDP/pt/829eyaa9FkP6s5/9TB9//LGloqOjo/rs\ns88MX6I9rKmpST/72c9ULBY1MDBg3QwYJ7yen/kOtURSFV9M+rJR5UBSjQXfOTs7M2X8dDptUANY\nZLlcVkdHh0UPfkFp8wsEAtbmub6+rt/4jd/QX//1X5sAcSAQMMWfs7MzKyhQBKBt1le8JZkuwMDA\ngB49emRRYS6XUzweV1dXl1ZXV9XR0WF97vQ5f+1rX7O58jgEPyNqZWVFbW1t6u7u1qeffmriw/Pz\n83rrrbf013/91/rGN75h3TzT09PGMnj8+LHeffddpdNpzc3N6cMPP9STJ080Njamzz77zDrGLl++\nrO9+97v6x//4H+vly5eKRCL6+OOPdePGDdvU9fX1GhoaMlEQjCftfqTXPHc4lf7A0TUTDldm7xBV\nSdVjijF63qixjwKBgO0333EDRc5HqxwjH0Hx87yXtJ49CqxAloRhJmqCE5rL5YxixfpAyJ+entZ3\nv/tda0Lo7u42nvPjx4/V2Nio3t5eS5HBLVOplGKxmBYXF63ijjIZnFRYABjU2vZqz4YBDoE1wP/V\nVsJ5+Wfq2QW1xpX38h2+pdQXA32NxHNFgVVOTk6M69vd3a3u7m7t7e1pZWVF2WxWwWDQBhjiSFtb\nW/Unf/Inr2TTXosh/c53vmOTOh8/fqy5uTmNjIyY2tHZ2ZkVPhj9MDk5aZGLF2Y9OjoyTc2joyMb\nYOXBbO/VpPOFBwuiYs+hQcy5WCwaVxEptHK5bG2h0E+k843hsbFCoaBAIKB8Pq8PPvhA3//+99XX\n12dgOofV40mSTOCXbifUoRoaGmwSKiNKSAkx2LQ8kvoDK3z66aemKcDIi56eHj158kTJZNI6ZJhr\nTxEDIeq7d+9qZWVFxWLRCkmrq6uqr69XX1+flpaWjEsYDAaNOcBc8pOTE2UyGV2+fNmeGy2ZuVxO\nExMTevnypXWQoeDENEp6z4nOoZ35XnJ/OIkk6+rqLDoC4mDLe36i/1kMcW33nOcgMlcJAY6DgwPL\nTiKRymgZRqMgFM0+RFbRN5cwO4mOIZ59PB63/YyCFIaYNtHu7m51dnaqWCzq5z//uZLJpK5du2Zp\n78rKigKBgDllJs6yflTJ6VHv6OgwUj/f5aNJX3/AoPJ3/6ol0fP6qsiztljszVJtuu/xTf8ebzxr\nv8djtcfHxzaCqLW11dhAmUxGy8vL1sba39//9zsi/bM/+zP9/Oc/VyAQMPHUQqGgv/3bv7URr1Qt\n0RQdHR1VNBrVzMyMSqWSFVBIm5kHj/f2wD4piY8cOSRsAg4Y1d22tjbNzs7a3HFoQ+CrfiOTBpOW\nMd43n8/bzzQ3N2vol/J9wBF0FsGB9PqUaGiCWTH5lJG53d3dmpmZsVSetB+9SiIrtE6ZuFooFDQx\nMaHx8XGl02krakxNTen69evK5/Pq7Oy0kcQ7Ozu6deuW/uqv/krf/va3tb+/r+9973v69V//dRUK\nBT19+lS/+Zu/qXQ6rXQ6bUWma9euGR7c19enkZERbW1t6eHDh3rx4oU6OjoUCoX0/Plz3b17V++/\n/76WlpYsE5mamlIwGNTQ0JAmJiZMGKaxsVGTk5P6jd/4DZVKlXnz+/v71oVzfHxs+LZUwTUzmYzR\nqzDy8GqlcyPpsxciSY+jeUe3sbFhkxgikYiuXr0qqSLSnEqlDKohGvaYIRxg1q2trc1gCjKjcrls\nlWsYLBREuQZYJxSMmpqaTOuWCLO9vV2hUMggEgRyKH5FIhETVyGDwSBGo1FzBjgR6RyvREGtluPp\njaQ3jl9lbD0+WRv4YDh95M/7an95o817vwqD9Y0GrCnTLurr69XV1aW+vj6juf3hH/7hK9m012JI\n/+t//a/64osvrOWT+Uu/9Vu/Za2OUmVm+tbWlkKhkCYnJxUOh3X58mW1tLRoenpak5OTtvDw7hh0\nBv5HZZMFxjP5ij4PlbSECAFKDMPMwB0pShQKBZMVA3+iA6VcLlskgHI7hxJ4oLu7W3NzcxblkAKS\nxjMehKo3WpuBQMAI3LFYTG1tbbpw4YJhr9BGoMlsbW0pHA5rfX1dFy5cMNyOQtHGxoa2t7fV2dmp\niYkJffDBBwY1NDQ02Jjsjo4OdXV1aWJiQr29vYpEInr+/LneeOMNEw8eGRnR6empBgcH9ejRI52e\nnurhw4dqamrS4OCgPvzwQ62srGhjY0OTk5MaGRnR+Pi4mpqatLy8bCyHX/u1X1OxWNTU1JTGxsY0\nPz9vYz8oUGazWcXjcdXV1Rl2i1GlwwlVrbGxMWWzWU1MTOjZs2d688031d/fb3iwP4QUSHCaPFci\nMDDyQOB8tLGn+KDQ5LUTMNTwe1H1osBE5ErLZlNTk3XcpVIpNTY2amFhQfl8Xm1tbbp+/bokWRZE\nsSUSiVjkCZQB9o+jxkjz88g1egMGpZCfryW0e4NHWu87CHlx5vzn+Z/1HHBeGFSMnnSeRXqmhP88\nf53IZPrrYY29M/DXBwyDytnOzo7eeecd/ct/+S9fyaa9FkP6v/7X/9Jnn31mHofUi5QZfhyztpmT\ns7KyYikxYzPw1ozNBQjHu0NpYcGICogofUURw8MDp8MH3iQCE5Ks+6W1tdWKPKSvhUJBzc3NGhwc\nVEdHhwYHB3VycqInT55obm7OlK5QpDo7O9Pa2po6OjqUSqWMMI0qfCwW0+DgoN0r0QXjJwKBgIrF\noilGUVBg1g9CKzid1tZWGy3y+PFjjY6Oan19XcPDwzo5OdGzZ8+MgsNkgZGREWUyGcViMc3PzxvJ\nv6GhQV1dXYbnBYOV7jTuhTRqc3NTmUxGo6OjNvLj5OTEinR1dXU2fubDDz/U4uKiRW6kueBdMzMz\nun79ug1KhLwNBECXDOl2uVzWixcvtLe3pzt37ujixYva3NzU8vKyzdryCkbAAT4KQ8EJAWc/v2h5\neVn19fU2Z6pYLCoSidjawYsOBAIGdcA/zWQy6uzsrKpwc7Ax5FCNRkZG1NDQoImJCcumcPTNzc1G\nYAcHr6urs/HlYIDlctnUuQgoGPECDkoTB8ZVqjY88D65Xs4Qz8/Dav5na1Nu9q43vrXmqLaSjxGu\nNeT+c2qDJP9Z/nr8y18P0faVK1f0T//pP30lm/ZaDOl/+k//SdPT04ZLnp1V5iFBKyFCQ9iDTgoq\nq4Tx3puBH0Lz4Wf94UBFHe6a7+rhwPHvvngAbuRZA7lcTsViUbdu3bLoR5J1o7DA6XRaS0tLSiQS\nGh4e1o0bN+welpeXbUwIBQ/GqASDQaXTaXV3dyubzapUKtk0U+6f7iNSaIRgIJKnUimT83v06JFu\n3bplz216elrJZNLELMbGxrS2tqZAIKCVlRWNj4/rpz/9qS5fvqwf/ehH+uCDD5TNZnXx4kWjXaXT\naRvt3N/fr+npaVOPX1lZ0dWrV/W///f/1htvvKFwOKwf//jH+mf/7J9pfX1dz5490507d7S5uam3\n3npLx8fH2tjYsAIaBxI1ruXlZQWDQV24cMEmwRJ5MrqCabD0wMdiMeVyOQ39ksuJQtT09LRyuZxh\n8DgEjClRTS13k2IEEUsgELCZTIyVhjSPstP29rakypyuTCZjk1I5zCjGExWS1uMQjo+PTYyGcSFH\nR0dKJBJW3CkWi/Y95XLZWm75DMbGIJrT0tJiOgIEEcACh4eHamho0NlZRfR6Y2PDZmThoFHp9wEK\n+g0+svQYtDdwnG+Pt/oCk69p+JTeQy2hUMgq85LM6WA4a9N6fv8qI4rB9c6iVCrp2rVr+oM/+INX\nsmmvLbX//PPPq0DowcFBizY3Nja0ubmp3t5eSRWRBSKBWo+DEGyxWDTJNTYiqufxeNyU0/P5vBGx\nfcGJ+TFgRYFAoEoj8uDgQL29vZauj4+Pa39/3+bC9/f3V6U4GAIiC0lVQ8COjo5048YNA/jpwY5E\nIqZUhJHPZDI2RgWD2t7eboa/oaFBuVzO+HX09oPRIgS9vr5ugtJNTU0aGhqyawW73djY0P7+vtra\n2pTP5zU6OmoC2fl8Xj/84Q914cIF61a6deuWPvvsMytyxWIx7e3taWBgQJOTkzo5OTFZNlgBKOAz\nanl+fl4zMzO6e/eu4d5+NDMiux999JHeeecdm5EEHkrXC+kqUR+tsNDLZmZmrP23paVFly9f1ubm\nptbX1009yK+hh4Tgse7s7Nj1xeNxHRwcaHBwUJ9//rk9e5z/zMyMaZVinPk8BhKCZ0Nha2pqskIZ\nBt7rctIBdnJyYlxQusNSqZQuX76snp4eKz5ms1mTa+TZcn7QZKVCL8kcMe3XFKcQYnn58qUVaZiZ\nxtBA4CAMFwHJV6X73pD+XS//s/7PnM36+no1NjYaZY3P8n/3FX8PAUjVYke10XIgEND169f1e7/3\ne69k016LIf2Lv/gLKybQHkfF3HMF/YOm4kr6iAE5ODhQLpdTNBrVwMCAzRhisqFUEc6Ff9fe3m4L\nDI7ow3nvPTHyGI1yuaK1GQwGjfvqUz+pejiXr/RKMj4kohSnp6eanZ01paGOjg5LiyDnSzIKENqL\n5XLZqsAtLS2qq6szFSUwL8aZNDQ0mCIRve7xeFyJREKTk5NG56GHmpERdXV1KhaLVqnHeBwcHOjm\nzZumGjU9Pa27d+8a17G9vV3z8/P68MMP9Z3vfEcffvihVldXFQ5XRi7Pz89bAS6Tyeitt97S3t6e\npqam9OMf/1j/+l//ayt0hUIhbW5u6saNGzZ6GYgCsZZ8Pm+RFdElVDBwTrpd6IG/ffu2enp69OLF\nCz19+lQdHR1mdGsZHhQuGRMciUQsxWcdPB45MjKiaDSqn/zkJ3r//fe1vLysK1euWKfaxsaGGTQa\nQeAxMj0WQwGuCvVpf39fS0tLKpcrY0QYVY4hfvz4sT755BNFo1GNj4+rvb3dzlihUNDBwYG6urqM\npwztT6pEj9wDTQWexkTqH41G1d/fr8PDQ01OTqpUKqm1tVUNDQ1qaWmxGVBwZYkSfaXdV9h9hOjT\nc5/O+0jSGz8yTs4Y7yFj49+84fTfxX0DS/DiO27cuKF//s//+SvZtNdiSP/0T/9US0tLVomEMgSV\nBY/CpUUikSr5LUlKJBKmF4qhgy/mux/gHCJfRvTBPHTSYMBmFhy1Jr6P6IeUx4Pg9C5znT795ncK\nWXV1dVpYWDDlm/b2dr3zzjt68uSJdTDBPwWHhZpCGk9xS5Kp7YBzohBVKlVa6GZnZ63w0dnZqXg8\nroWFBQWDFVHizs5O4xju7e1pbm7OMOlkMmnG7OrVqxZx5vN5STL+Kh1NxWJR2WxWvb29VkBBexWi\nP/KEaHEuLy/b7KL3339fjx49smJaT0+PHj9+rJGREYvqOjs7bXImUE6pVLJuqNHRUYMvtre3DQ+l\nCwqMl0LRjRs37PnwQngEDirKUyMjIwYBBQIBg0XACyORiFX04SNTzLpy5YokGQ5Pd5PHKWFgYFBI\n8w8PD+1a4vG4VlZWlMvldHh4aKwL3jM/P6/h4WH19vZaZLq4uKjp6WmdnZ3ZBFqyOIylL7qCGWOE\nCBhwGhgxeMvr6+uan5/X2dmZzTVrbm42xokXHPHG0kv2SaoqSNVinx7r9C9vJ2qNrY9mSf1rf47z\n7g0x/3/z5s2/34b0P/7H/6jJyUlLo8EviQo4COA3vhe6XC4rkUiY0C8bnoo3+NPp6altVg8JYLgL\nhULVDCeMMIUNFpjup9HRUVNml1SF1WJA6cX2FUc2A33io6Oj1sO/v79vuCCc0J2dHVNYR4kHtoDn\n16LcjxFnEuf777+v2dlZSbII2wsjU9ghvUWSDocz9MsmBDpCEAOhaJVIJPTs2TO98cYbmpqa0ujo\nqO7fv6/+/n4NDw9bVMMsJqglo6Oj+tnPfqZ3333XlJnee+89gxEg5f/iF7+wtBziOYYV/JOOq/r6\nevX29lrzwtjYmObm5rSysmJ6sY8fPzYq1tHRkT2HS5cuaX5+XvPz8zo4ONB7771nBgVnTBS4s7Nj\n1XPEQiguEnXRuomaPfuavbu6umrNCzhUX6Rhn8CThVPKGBzfjEDH0/7+vjFAEomE+vr6TOiF7G16\nelp1dXUaHx/X+Pi4cbJnZ2eNhQG2TKYAz5UIGTgJxwjDhc6tcrmsVCplgx0ZDCjJOgDRioCSCDxB\n4Yu9TbBQWygC2uBZeTyT32uLV7VFLG9YsRE+SiUz4DNu3bqlb3/7269k016LIf13/+7fKRKJ2KRH\n0kupWtiVRfTUBeYmoQ7u29Wkc3k8DCT4pheZCAaDpp60t7dn+pe+ugiYfXR0pKGhIStuSLKeXQ4C\nmwOZMyqj3AMGubm5WXNzcxYRJ5NJDQ8P26GjwQBP3tbWZiONKYTgNObm5jQ3N6c333xT8XjcWAsI\nnxD5QpEiCuns7FSpVJmltLu7q3v37tmmgqAdj8c1NTVlFflQKKR0Om08XVpG6fChUv/1r39dP/rR\njywa+vTTT3Xz5k2r1iPecunSJa2trVmkUl9fb1NAr127ZpE/7bYculAoZHQnsORAIGBFEqJ5eL/L\ny8t69913rToPbnjv3j1ruUU6b3l5uWpkMd1Vf/VXf6Vvfetbevr0qRl1jgwaoNDVyGp8BAbuT1Gq\nUCiYHizMAuAejCcFH7+veA9qR2D7p6en2tnZMayzrq6uKkBg/xEhEkDcuXNH5XJFN7RUKhms5Jks\nRGnwT6ESUvAi0IlEItZIQ2EXCiCty7SQgmvSPu070oBKgHWIhHFWGD2aOXA4fKckY2p4/YRa48p3\nk0n4IArs9fT0VHfu3Pn7XbX/9//+31cNv6Ma7Q2mx0fxRH6sa19fn2kbUin1i0+VE1V16XzuCw8S\nYvzc3Jx1eJAGUO2NRCJaWFiwVM1fW6lUMsMZDAZtJIVU0fP0KWIgEKgi5+/v7+vx48daXFw0JR56\n+9HzJAqhmss9UBVuamrSX/7lX+rSpUt2SHEcY2Nj6u7u1sLCgnUf5XI5zc7Oqre314owdDDR0w2/\n0TMqqA739vZqd3fXPDdFrd3dXTNAT5480aVLlzQ4OKg///M/17e//W2rcq+trenChQumWvXd735X\n9+7dU1dXl82wYg4QG5yIBnhkcnJSd+7cMQYFEI2fYd/U1GSyiBw2CjvT09O2Fvl8Xm+++aa1Sh4c\nHBhrhKaKtrY29ff3a3l52QplpKJE+xSDgsGgQTCsFbOciBBxaJ5dIMmMCiR5nH99fb2NBPFRsVQp\n0NK+zHjjxcVFm4mF4EwsFjODV19fr729PS0vLyubzaqlpUXvvPOOTk5ONDExYYU1b0TBb8vlsumq\nkkEeHx9/STErEAhYpNnU1GRZnnTOguFn/LRQXwPhudLN1dDQUIUhE+nznIHivBYCur68gKoIWIAD\nySa9qEq5XNa1a9f0+7//+69k016L+tOPf/xjq1p6UQQezFdxxaBkMF8eL8WDJ2rBaPr0zNMifMsb\n4gZgSbRborFZX1+vtbU164QBXsCAAjvgnX0HCx03nuy/tRj2G7MAACAASURBVLVl4hMMWfv6179u\n0noo5XsO5MDAgNbW1qzwQFqCstStW7f0ve99T3t7e+rv79fFixc1Pj5uKdfg4KA2Nzc1MTGheDxu\nxhWnRNEhnU4rFAppeHhYsVhMiURCW1tb5rmZ2w52F4vFNDU1Za2J0Il2d3ctcsFohEIVuTuYD4eH\nhxoZGdGVK1dMunB9fV2bm5vGSGhtbVUqldLU1JSlYK2trcZgePnypZLJpObm5hQKhRSLxbS9va3W\n1lbF43F9/vnnGh0dtcj85OTE0lKaQBobG/Xo0SO1tLRYizJrxXfD1AASAkIiapFkTr5UKtl8eAp3\nXDvto6S8FC0lmdPHCLGP9/f3JcnaGBk78ujRI73xxhva39/X/fv3FQxWJCeh5iUSCQsCMH6np6cm\n84hK2MjIiIZ+qc716aefKplM6vbt2zo7O1M6nbYMkDNJrzpGEcX7aDSqtrY2EzspFosmQM2eJTLl\nDMIBL5fLRt3DFsC5xcCB7QNlUPRjPYEGI5GI6a1CKeT5lkolG8iIcAli6j09PRaxE32z327fvv1K\nNu21RKT/+T//Z6sY24UEzvl6nhOGp29ubtbU1JT6+vrMOIK5ELJ73NKnAQD4nisoqarzATIzM4dO\nT09tTLBPQSkowDRYWlrS7du3tbS0ZBEF0SMp7MzMjKXJOABGOTMfiUFiVE/j8biNg2bGE5uWtBEh\naCQEj46OND8/r6GhIbW3t2t6elqffvqpCR97ncm9vT0lk0nFYrEqWEGSVldXjYDOLB/aRtva2gwD\nXFpa0sjIiFV0g8GgGR0+586dO4pGo7a+hULBogAitVgspr6+PjN6cB65L0ZuDA8PW3sq00QvXLhg\nYjbHx8eam5vT0NCQdnZ2bPAdaTzvg1pGd5of9obm5oULF/SDH/xAo6OjVe2mRGihUEi7u7uKRqO2\nF3zDhsfmmpqaND09rTfffFNPnjwxrQL2NtVwMEPYGUi/ocS/tbWlubk5jY+Pq7GxUc+ePdM3v/lN\nra2t2dhvHFc8Hpckg0H893kcEKyzpaXFhKeLxaJGRkbU1tZmo0S8CIk/d6FQyGhsiD9Tk2A8NZE3\nYizANRTbfKCEwS0Wi9a1R0aBwyJzzOVyRumLx+N2jbV8Ua7T/xuBCVkYAQXF15OTE/X09Ohf/at/\n9Uo27bUY0v/23/6bHj58aBiFp5sQSXpjWF9fb/qfPBQ2BRgJKRd0EQxrbQ88xH8WknSAvmIMFd/H\nw/acuGAwaGlloVBQX1+fRR7b29v62te+pl/84he2edHiZGIlM+FZ8OXlZfX19VmEDkkb3YGVlRV9\n8MEHev78uQ4PD00SDPzLb8ZEIqGPPvrIMFjPU6RzBfwVgVwMCWkilJzd3V0lk0kdHx/bQUZIJRgM\namRkRNPT08YWaG1t1d27d607K5/Pm1M5OTkxw1lfX69UKqVUKqWjoyMtLS1pcXHRVK0ymYy6urps\nxHM2m9Xg4KDy+bxJAw4PD2tpaUmnp6caGhoy3QL655k0SrTie6uZxwVuWS5XpBLBykgjF34p0o0z\nrYWOJFU5fPBiHBKYaV1dnR48eKDf//3f1w9/+EMrpNHzTtZVKBTU3d1tDjUcDlsUBi85lUrpwoUL\nWlhYMA7u9va2/sk/+Sd6+PChaTqAdfpBgKS5BCEeogKLhK9NVxQMkGw2q/7+fvtM36yAMZJk9EOy\nO3r9Majg6jwrzh8FPOlcBrFUKllX3NlZRYwc8SAwV8Rtdnd3lU6nLStkzcngfHYrVRP2/blGEjAU\nCmlgYEB//Md//Eo27bUY0v/5P/+nPv/88/OL+ArOGGk0i03a4lNrolceAA+utspPROqjS6lanYaK\nNv3neCVwQg4h39vZ2amHDx/q9u3b1plCRHB6WhmxwWHJ5XIaHx/X0NCQcrmcdYWQorS0tJiuJxEy\nKUYsFtPc3Jy2trb0zjvvVG1a6Txt8eLUyWRSDx8+NP1TKumeEYHzoBCytrZmWPP4+Lg9PyKjZDKp\n58+fK5/PW7EjkUjo5s2bamho0O7urra2tuzA8H2kWai0g4N9/PHHun37tj799FPrfGptbbXWUMZa\n8PuLFy/0/vvvG3Y5MjKiqakpDQ0NKRAIKJvNKhaLGZVlYWFBb775ptGavI4t79nb27OOJKLJs7Mz\njY6OmgMjVec5+33X2tpqzBOwN59ZsZahUEiZTMakBTc2NjQyMmJGhaISTo4z0dTUpIODA125ckWP\nHj2yqC6fz2tzc1NtbW26efOmYrGY/sN/+A9677331NbWZhQ/sFSctqcBcb0eRvNBjc/4SK+Xlpa0\nu7trc8Z4H/vKMxAkGY0OJgtFT7QgCHbIFHz7NvRAH7li5KDWocbv8XTgAiYOB4NBK75hY6Qvd1v5\nqj7PIBqN6t/+23/7SjbttWCkMzMzhsFgBLkBjBuLX19fr1wuZ22D3qOwAWtpUhg9qfowU6jyHNJy\nuTImgqF1LBIpZblcNqyTirAki17a2tqsYknkRoofi8XU2dmpvr4+SyGZqxSJRGySJgUfBFsA9yny\ndHV1WapEM0Bzc7PdH4aRgtJPf/pTffvb31Y2m9Xk5KSxEgKBgPV4070D5YqZUM3NzWYU5+fnNTk5\nabheLBbTnTt3ND4+bkpKuVxOuVzOOqJCoZAGBwd17do1E3SZnZ3V1taW7t+/b1NiHz58qLfeesvg\nkatXr2p+ft5YGDs7OzaxFW1VJBXpc2em1cTEhK5fv26qVkw1DQQC+uKLL2yevR9uh7Mkwm5vb9fg\n4KAGBgYUDFZ0FhhaiGPz9Bj2GFg02REGiD2KEQauoZhGVxtyde3t7dZkwN4lg6JttrOzU1NTU6qv\nrzfjsLGxoWfPnunWrVu6ceOGfvCDH5gDB8f3xkKqTn09xQhDQiZI8BEMBrW0tKSmpiZdvHjRzhH7\nhiIqhptzLckoYjjtra0tK/wxVQCKIc8OqAT1q1rIjkiXbIoxLxhLRNUTiYRSqZSJGFEAI9P0gZt/\ncVbq6+v/fk8RffnypRYXF6vSA1+8IY1h8fFaYJu1xhKPR7TKA/KbqFSqSO8NDAxYn3xzc7OKxaJS\nqZRND8Vj+98TiYTpXxLRLC8va3x83EjNpHbgj0xdRJOTgk4gUOlLJrKEhMxwOowpJHJPY2Fwmocy\nwNOkiujz4OCgotGo/s//+T/q6OgwAWXGdJD2YHx7enpM4R5RZriKly5d0qVLl6zXG9w4k8loc3PT\nqtzj4+Pq7++3kcPf//739fTpU2tNjEaj6unpMd6nNzCxWMyw1i+++ELDw8Nqbm62CFNS1UQE5PQY\nX4JaEsWHTCZjDhcqVygU0sLCgs31IS2UKpVcNGcnJyeVyWT07Nkzvf3227p//76lpp6DiIMtFAoq\nl8umA1FrUH0hlbbLw8NDcxIceAwtbbTwb5kUcO3aNcViMWNcDAwMmNg5Unk7Ozv69NNPNTw8bKyF\njY0NMzD+vHhj6VN8zlatQaWIFgwGtbGxYal/a2urAoHK9FkaAsA6MdpkF2DKaM2ynwgKMLRAaODu\nzOjieWAIPWTX0dFhrbPpdNrUznyDA8VLAoVMJmNtwES8nmIF5/zv9cwmOJBcOFEVnUhgUfSfE7X6\nVEQ6H2THw/IdTaQlHibY29tTsVi0g8ewrmg0qmw2axVzqqdsrq2tLY2NjRn+RvrPKBCugcof1KLN\nzU0TiKUXOp1OWzSJNyTNYnytdI41+fY6Wu9IX6DTeLxua2tLo6OjVql98OCBmpubdfPmTaPzzM7O\nam5uzsRdMHTj4+MaGRmxQsX29rYKhYKNrqCIcenSJV27dk11dXVaW1vTj3/8Y4tsGxsb1d/fr/7+\nfkUiEVPHAn/t6OjQixcvrAhEFR44IB6Pm/hJKBQy3iTFBFJ0ih04hHw+b6rnGFL2QC6X05UrV8zp\nRaNRtba2VjnBxsZGdXR0WHGjp6fHuLM4x9r0k0PohY+h6BCVUaRkfzOkjtHbUIzofAMfx1B1dnZq\nd3dXy8vLSiQS1obZ2dmp+fl5HR0dKZvNGqMC5ge6qPTww7P0BlOSBS2SqvYRQUytQYWahQMAkwQC\nYTotFCkf7GBUCVJIxzmb7FkcJ3u7WCxa0Q5DTfEVx0WHYjQateaA7e1t5XI5Gy3CmkQiEavWIzOZ\ny+WqbAiG9L333nslm/baxjEvLCxYeC2dCxz4FKS5uVlPnjyp4stROCH9B7ti0TFMaImCO7KoflQF\nKvLQi3zRiwMKKI6aEvqh4HFgQ/v7+9bKyUFubm5WOp22DiUWZ3Fx0aZ/gsuxidmMSK0BKXDIKGZ4\nkQmMPlSQQqGgGzdu6P79+wqHw1pbW9Pi4qLRaC5duqSbN29qZGREzc3N1hm0sbFhXNRyuayenh6N\njY3p5s2bxiH9+OOP9Td/8zc2Mrmrq0s9PT2KRCJV93B2dqZ8Pm/PPxQKaWdnx9pJvdiF5yiOjIxo\n4ZcTSRFOYWAbUR3tq5FIRGtra6b3yjq1trZausd89b/927/V0C+FtXnGfkKB5ydi2Cjq7O/va3x8\nXPPz88Yl9QItPhsC9/OYKpkUnUBEcrBFWltb1dPTY8LV0NSI2mg04DvIBrq6ulQoFCwoIMrd3NxU\nIpGwCbK01frsj2vyBRipOi3nGmvvBafBteHUgbTa2tp0cnJie8lTpvhOgh9oZUAnwB+oWTHqmhf7\ngEwAEXRacdEO2N3dValUUmdnp7q7u9Xc3GwwFCwCbAb0N4YvLi8vm5DQP/gH/+CVbFr4V7/l//8L\n41G7gBRf8N6bm5saGhoy/iiV6ba2Np2enmpmZsamKzLbGsyFqi+ctu3tbcNw6usr42JbW1u1ublp\nlX7fDOALUcFg0Mj9zc3N2tra0o0bN2xS5+7urhk+P54BDA4CPoIh3d3d2tjYUEdHh/b29ixFZ7Mi\n8OspNWweDAfEb4bOUdGmMr+wsKBvfetbxmrY2NjQxsaGlpeXDYagwAHRe3Bw0KrXExMT+uijj7S9\nva1EIqH+/n41NTXpzp07hnvxHInyYBGAM3d2diqbzWpoaKhqzPXQ0JDRWySZwDeRMPJ3HEjaSLPZ\nrBoaGuzekbKDttTa2mp4G80WcHzffffdKuMKzcoXERF3GRgYMKN5elqRz0NBnaiMFNH3p2PoyCIg\nv7PnGhoatLy8bJNM4ZkyefP4+NgaMWiBBTuUZPUAMqatrS319vZqbW3NJPI8pYriJvBHqVQyTFf6\ncpHX/92/B2zYF2I8fYouJK4xn89bRglfnKIemhcYT5wY0AHFNgpJ6O4i6u3bsGnmKZUq4j00rlCM\nRcEK2b9oNGrjv/f29kzIiJ8j42LYJvvxVV6vJSJdWloyMQ27EBedEkHC16STh0NLGjQ2NqajoyNN\nTEzYyGAWmIddKpUsOqWQQwoQDodthEdt1Q5P7A/I6empEdUxnLTHsfCM3yXtZLJoJBIx0vfh4aHW\n19etY6f2e9A0RTADuogXl+DAkFrVFglIu5icyWFE/GJwcFBXrlyxVPEnP/mJPvroIz19+tT0Pfv7\n+9XX12d6sHAo+Q4Pn3BASclwONFoVKFQyBSYMpmM3n33XX3xxRe6evWqDVqLRCKmCCZVdDrBQzHU\nFJ5oo6QbDcgDTI02TLDIiYkJ9fT0mPMCoiFSunTpkmUUOPPe3l5NTk7qwoULWlpaMvwb7NMzOQgM\nyuWyUZpwnLFYzAqMHGbGBKNzsLq6qqGhIatkg2mC8WGsfbbG36enp22KqteGCAaDptvA/8HqgBfr\no+ha3NTjvZw39p7fA0SpPhvEkeCsSenJ2NLptEqlknU0UfDyhhraodeW3dzcNNiDNlOeAwYTgwgv\nd3t7W9vb27YnMdZkFJ2dnbbuTGnlft544w0NDw+/kk17LYZ0ZWVF09PTVgiiAs8LD5XP543cu7m5\naanA9va2tTfGYjETFNnf369KmSn2wD3zuFpXV5devnxpBRg2YW2bGJuX6AIRCbAvT6/i2kgvpHOh\nZw62JNNIXVpa0vDwsBmhUqlkuBFYriR7TmxQIi4kB0OhkPL5vGGnbHivQwBdhRngDx48MH3OUqky\nl/zChQvq6uqy8dMcDB+p+y4v0liPZ1F04fmlUikt/HI+O4YhGo1qbm5OPT091lnGfSSTSTU2NiqZ\nTGp+ft46oShqhMNh41l6NXvwS4RYGJ1COypRLYctHA4b4+LJkycKhULGV6SjJpVKGQTAXsRAYEDZ\nrz6aC4fD6unpMS1SIufl5WXdvn3bxG/Ozs6UTCbV29urbDarQCBgnWE4J7IU70DD4bBxoXt6erS3\nt2f3CPzjO+rAbckgPEWLe/CYKH/3xWCPO/t79waYZ+Gvlc/0ymytra3mTMAv6WbygYx0LrwDNEYm\ndHp6aul8Q0NDlUCPFwUHKiFzhDNdy1whSEqlUmZb6uvrX7mz6bUY0uXlZU1NTUk6H13AQwbD8T2w\ntH9h7HgI9KLv7u7q1q1bSiaTevTokTY2NrSysqKBgQFLCehjPzg4MHV30mg2bzKZtHSdjYdn5KBQ\nVAJQJ4Lk76Q6bFIKJh5rBa8iosVzA02APbHp2ayQqtG0BM9rbW21IgWpOtDJycmJiS4j8nvlyhV1\ndnaqvb3dGhX4fF6+kOM5kUj7YURpQ/ScQ6JUNjMFQC90MTw8bH3U6XTahEfq6uqMXM9acbg8HscB\nQkRlY2PDonZwN9YJPC2Xy1kHTygUMh1YKvccOEjsa2trCoUqbbP19fU2YJD19c/KF5igLW1ubtrh\n39ra0r1791QoFLSzs1OltEQhpampyeaV8QzAjkulkglJ4+yLxaI9UzjMHsPkWmqhAU/O5z58yl7L\nKfWpv6/q8z0+E/SQXa1xZj9yDtCd8Fmaj1Q94wYHxdmEyiZVOqX29vbMQHr2Dg6JPQzj4PDw0LIC\nbEQgELD++2AwqLfffluDg4OvZNNea0TqU3vv2ZiVhHdFLBaDSp85fLCtrS29ePFC8/PzunnzpuFR\nRFRsNhYpGAwaRUk6pzoAA6C0Q/scG9K3mnJA4YDyPfDuiADBlzgwbEA6Nebm5jQ2NmZTIYPBoPHs\nNjc3TVIPDIqiDTOTKJxwL2w4X7xDiSoajer27duamJiwyrE3lH7j+zSNaITrowiH0eZw8PM4jdoC\nniQbHT01NaVEIlH1eVBjEKne3NzUzs6ORZKpVEq5XK4Ko+QeGE+9urpq2PT29rZisZg2NjYMPgC7\nLhQKNq6jpaVFk5OT1ipIVNzb26vOzk49e/ZMzc3NGhkZseYAKsxggaT9nguJ84rH47py5YrhsqiW\nkdWEw2HDW9mP0IFYt7OzMyvWeUyW8+KfIz3xPtNjfVlH6Er8u2fC+EzRvzBc7A/2MX/3UIcPADgf\n7E3u0Z8FSSY+jngNgQ77yb+gN+GYOe9bW1tWT4nH41ao8nxZFKfYE56PShNMXV2dLl++bFM6ftXr\ntRSbPAZZS3KGfEsBgvejeH54eGgPCG5nKpVSX1+f6Xu2t7ers7NT29vbVk2Epzk2NmbtqbX9wwcH\nB1Zo8JELfeGkID4V92kmPE/vmSGpI21HVEVrIJEBqSlRHdG47+6iFxnNADYHSkZUbf2m5n0UtB48\neKArV64oFArp5z//udrb240nimH+KpqZd0i8B2Pro1IOutfbpIhCpnF2dqb+/n5zhugctLW1KZlM\nmho+0UpjY6PS6bSNdHn+/LmuXr2qtbU1u3YOREtLi6WzGJbOzk7TNSDS7e3t1erqqt0XozNwTPX1\n9VpcXLT1ODmpjPY4PT3Vhx9+aKn14eGhXr58aek6tJ+WlhZ1dnZqfHxchUJBi4uLX9rj8Edx/GQA\nRG4YkkAgYMU88FfP1ID6A67K3mIfSOeUJgwga0FQ4M+mj0R5eZaMD3o8C4D7ks6j31oM1l+HL6L6\nz+DceTwTFanaCJc9StZIG+npaUWkpVgsWnrvYSnP9EGEh+fJOBkKha/yem2GlEOIB+Xhku6wUOBZ\neG+wyvX1dfNgRI5EUPl83mgNbAwKRA8ePKjceDhctVEoIqDQg2akN0oYZFJvAHyiMDY7jgGDc3x8\nrHg8bobdt9U1Nzfrk08+0b1794zLVldXZ3hsoVAwigfNAczH4fuAOTDobE7uk+cYiUQMG25tbbXR\nyNPT0xoZGfnSGvmUzR9qj8PyXowpGxB8WqocwqWlJTvsUoUITxSRSCS0vLxsTgysEDUp6ZzpwUQA\nRqhAveKeORiInrBPQqGKuEYmk7FCVnNzs8nTJRIJO7ToLXR0dJjDxlg1NDSYqIsk2wtvv/22PQPI\n40dHR/r8888tPfTPi6oz0Sn36PFB9omPptAB8J1A1A/YWwxj9OR4X2zks/kZ9jLf5w1ubRrv8VF/\nlrl2T4Fj7f054/V3ZSyeA+6vx0fWdOH5jJHPAh4CvqCmwSC/QCCgRCKhWCymw8NDc2TUTwgUYAi8\n6uu1GFLpy1VfnwozLoNoDs8NpgiuCJmZlNPTmyBL450A5BG2lc6xHy9Q7FNaXnhCuKhEr8i2lcsV\nKTCqs2C+bApIzD61wjOHw2GjwiAlBk+0ublZq6urisfjhgtSFcaAooHa1NSk9fV1JZNJ27jcC5ub\nNkUoZrOzszbqBNwOHh9cSTrNfBbBy9OHiK5TqZSR2D0TIRwOW+smxaDNzU3Nz89rfX1dly5d0sOH\nD9Xd3W2OB5L5ycmJiYvAvkilUiqVKp1Rq6urhntJskYJMLC2tjajwLE/4COnUimLUpk5zzUyLrm5\nublKsJkoVZJhscViUbOzs0omk1Vz6gcHB03+j3vyrcj19fXmjIkoa4s5Pg0m0qLbh/ZhovJgMGiG\nFWEdKuboHPBZZINoJ/gIlhfr7THT2kyFf8NY11IH+Xl+hpeHCLwR5rvI5Dh/BAuIPyObh6HFGBKN\nc118J1kOo92pv9CswH7n57/KAfxdr9dmSKXzKEM6X5y6ujqtr6+rp6fHPCrpI/2yEJQxnJ4+BIZK\npNHS0mI97jw86TyFgVPpQWnI7r5iyrX5TZRKpbS7u6u2tjaLlDj4pCZAEeCUfpMQPY2MjOjFixdK\npVKG79Ah0t7ebs7CR/K0OXpMkxnqzE/CyGHMgsGgcfKy2ayGh4dtvv3x8bGmpqbMiHvYRZI5F6qv\nPj316R5ODWoSkAZGg3vm/wYGBvT8+XOtrKwYPaytrU3b29tqbGzU2tqacUwLhYKRtmkFpRLb29tr\nhRS4wb69F9wyHo+b46QYBmaG8j+GdHd3V319fdYgQdFSqkR0iHDgIJBQxLDGYjGl02kdHx+bmAxd\nUrRJHh0d6eTkxPQ5UXtqbGysctwYA7ITKvC+Y4i1ODw8VF9fn+mOFgoFc8gEBN5wsq9ozpCqDZ/f\nZ5xbDKe/Pm9Ua6NZPtMXrPzn+zPh389acBbo18fAUnADM4X25CEFnz1hFwhUwuGw1Vw8RYpM+FVf\nrzUixQNzIIvFYlU0eHR0pKamJs3NzSkWi6mnp0dtbW0mIUZo39HRYfzBdDqtWCymkZERq7QyA2hh\nYcEmILIZ9vf3q6q1pAQ++iLN8AaJYhT0FjAz74VJR5qamrS6umpjPvwiY9hfvHihK1euWPrBhiBS\nJaIIBAJG8cFY4FC4vkKhUNU6SoUbj41+5OTkpH1nNBrVxYsXtb+/r83NTfX09NiYE6qlHJ66ujor\nnnEf9LDzHT568MITVKvBIZuamnT9+nW1tLRofn5emUxGZ2dnWl1d1cDAgBHvaV6QZFEoOOvIyIgd\nrnK5bBgrWQjsAopSjCvB4fb19Smfzxv5H65tS0uLDbKjuAQlbWdnx7A9DisHDxaEJEvDQ6GQNjY2\nND8/r66uLiWTSROyBrvDGXd1dRmTg/5ynhucaLQ/cWpE45FIZfS0V5ZiFlJdXZ2R03kmwWDQqEc+\nrSc9/rsiSe7P72WcvHf4wAq1hpX9QHDh+9xrsdmGhgabBwUntKWlxTizZH08Y8SE4K0ShZMleNGS\nbDarg4MD65RjnDtKUq/6em0YKSnu4uKiCoWCrl+/bm2btA4GAgGLRpheubGxYfqD7e3thpVxyGOx\nmPr7+xUIBMwoIT3W3d1dVaGmnRADUCqVbNNL54A57/cFFBYeRXwPZPvWT/AbcF+/2XyEirYpKRvc\nSNJ2SYbFegzJU3HAXIvFolE4uE8OyfHxsXK5nEZHR1UsFjU/P6/x8XFlMhlLyS9duqQnT56oXC6r\nr6/PoibWzbMXyChIFTnc0G6IdDhMVPvR7MRYsLmTyaTa2tqqcEAix46ODntuDQ2V6aTFYlG3b9/W\n7Oysurq6LFXDqAUCAeVyOfX29mphYUHt7e3Wukj0m81mrbWWgh3wDfcBPQnOoSS7ByJKHDEOEsdB\nlhKPx9Xb22vCxeVyWQMDAzo4OFChULCiU7lcNmgC+UG6gDAa7AtgMU97Ql0MsjvcWN81BIZ9cnKi\nzc1Ng4n6+vokyeh3GGgPE2FUgah804B/+cDCR5n+s3yUWhvx8n5Sd7IaWDdg1l1dXUZZIwuRKpxp\ngrFEIqGTkxMT0pHOJwPzPOCnwy3N5XKvbNNeC/1pdXVVL168MFB3bGzMOlUKhYLRGaBpwJGDAoSS\nEbSTSCRifELwUyKi4+NjdXZ2WoGF6AkDU+ulwOBIr/DOpPmkt9K5YcPo+VSJTX16emrTHX1Xice+\ngsHKWIOZmRlduHDBiPu1dCT/Z8j/LS0tdogwrKFQyASnOVSSrEJOz/fFixf19OlTE2Why+joqDLw\n7/T01FTxMWDAJ16Ni0IUBluS4cT8DBg0xsZXiuHxEkk/ffpUw8PDNreejQ/WzN9xKm1tbSZA4knn\nUiU6LBaLVRSqs7MztbS02LXxPopl4JRSJZXGOBLN0rHEz2xtbZmw9cHBgRkXnCsYMywCYJijoyPl\ncjkzssxjAl8nUmR8B4wEX5TiOWI46drC+JAWE30GAgHbv5FIxOTsqJZDNZyZmVE4HK4SB/dFXV/A\nIjAg6gM792k6FXkPUXksmN99yu8Ncy1eyXcdHx/bQwiIGAAAIABJREFUZNi2tjYTaAfHptq/t7dn\nHXI4e6h7CKCUy2WL3sPhsM0ee5XXa03tSQ+5KTC+jo4OSbLUvFagAy3Mo6MjLS8vm/Yn0SweuFwu\nq7W11XrhJZnxBkbgWjBw6HWCkfjoUDrfNPDdfPTjvTXvIb31nth7Ye6rXC6bIcGgsyFJyTjg0Hs8\n7sV3Y8xJ/2E5EHEQYcBxvHfvnhYWFvTgwQPdvXtXi4uLam5utp7+cDisiYkJXb161YwjEakvKmAk\nSO0PDg4sWveFCD/9wA9Gg48ZCoXU29tr4sRDQ0OGGxORgUMC42C8yQyINg8PD5VOpw1SwfjD96XL\nCtUq8F0O/ObmpsrlspLJpGlZMjAO2hqKRCiVYbT4HjB9/g3KEQc3Fovp4OBAW1tbmpmZUU9Pj2G1\nsAVYT54baTkOAaMGE4H2ZWhDfm96rJrWTyhbwWDQMj1EeV6+fGn7KJlMqru72yhCnpWBoePZ+cyr\nNtI8PT390pn5qmKWL35hmP3/c56ZKwXEwbnmOXFugb04z8PDwzo5OdHa2pokmSPJ5XKqr683xsir\nvIK/+i3//18YEagKGADU0DmQ0nlo742UJFsstDX9NEIOOukn+CSbB8J/Q0ODpThemIG0kmiUg0ma\n6dsIeY/0ZTEWomxGmPiqPffG76VSpd0P6T3eR9Tk8SQI9xcuXLCIk+fEPSD8gaGS9CV8yAPsQ0ND\nmpiYsPHYqPc0NzfrH/2jf6SFhQV7pn5Te/wLKINr9BAH1wxNiWcPjYuOnVAoZGLXaMQWCgUNDg7a\nFAEMB2tGDzn4Jhg4kAIOhMo+a3pycmJkfQ4ylDWUjBjrAlwBJa2hoUEzMzPa2dnR7u6uHcarV68q\nEokom82aMhOpuiSTbuT6j4+PrYgyODioUqmkZ8+eaWVlRVKFgdDR0WFZFvAMsEGpVLIOMfbo1taW\n7VEMLFAA68SZAVdGRISCGc+os7NTY2Nj6uzsNDGb+/fvK5fLKZFIqLe314ww+9RDT/wunRtNzrwk\ngx581uWLT9gLn+p7Rg1n0tsWvotrwXgfHR2ps7NTyWRS8XhcL168sLE2FHVxWqlUynjsr/J6Lal9\nJpPR5OSk8ejYVESGPuXy1WMOL+o36XRaly9fVqlUslTNP1iMBtEnhoOOInrwOdRgda2trRZ5BAIB\nw868WAXXtbe3Z4UhjAzXsb+/r46ODjtQtdw6PDFel8mc4+PjprqP8WFj1RKrvYPhM33VkaIEBsTj\nU1T/k8mkdnd3lUgkNDs7q4sXL1qKCF7U09Ojly9fWqQiVXMBPc5Fqo86DxGST9dqK7usDY6BAhg8\nS/BCiiVI6fnxyNwfxQLwsNPTU5sjBbQBnYomCVJkeKS+6UKqpMHpdFrDw8MKBAI288kLS5+cnFj0\nfOXKFXV0dGhzc1Nra2uGZ25vbyudThuOyj376AsDd3JyosXFRduXZ2eVufZAC4wigUrlDRfPlO/p\n7e01fq0/a0BWZEAUcLq7u02QnAgSnJi9vL6+bmOsm5qa1NXVZZkPDA7fUIKT5Xeeucez2Rv+777g\n5Qtb7D9e/s/sA5xgXV2dZbx0ryGwjtOrq6uIRCOg88477xhm/Ktery0ilVT1YPHinZ2dJvaKZ2Rj\nkOaCAcbjcZuBtLKyot3dXW1vb1e1lNJOifHiF+M3PEeU6AFvDdbCIZBki4IhIlXmcz34DsEfbilp\nlE9jeOHFIc7zHi9cwbPzlVAiD59mQ4GhOs1ICH/QEHo4OTmpmhPU09Ojp0+fKpVKGV8VJ/T2228r\nm81W8SmJ0GvTO9aOIXusN4bXXz+OlINwdnZmIyJ4dqTi/DuRlGck4JQ9awKo5ODgwCCWUKgiUOIr\nxnt7eyZMUiwWbUAhn1ssFnXjxg1L95uamtTe3q729nabtuopOUwbCAaDunnzphKJhHK5nDKZjDo6\nOpRKpWy8SFNTk+GQ6CZIMo3RUCik9fV1SVIqldLo6KhKpUo75NHRkbW60r0GK6JcrjA0bt26pePj\nYy0uLlqaznp7Z0x2EolEtLq6au8BokKntaWlxYRHGMV8dnamp0+f6osvvjDpRQRAPFPFp/oYcPY/\n38c+8XvKR6VkDuxnAhz2TiAQMHqdJIvMYWY0NjZqY2NDa2trJl4DFapQKFgw4XVQf9XrtUSk6XRa\nExMTVZQiRk4EAgFLIzY2NgyLIrWFJ8qIECJDLxKMkaLKCujPQQuFQlUUEL9IHMT6+nojPvuCjqcA\nIbThlcB91HVycqJkMqnp6WmT8PNG0UejRAi+SuzHiVD59bxWSPhUMr1xxtjDZAgGz+eSA3HwXM/O\nKnJ/y8vLNgtndnZW4+PjxlVsamrS1taWLl68qJmZmaoI+6vwLuAOjLzvEvGOhJSfyOX4+NhGEkPv\nIssIBCrEee8YMeZEpRQSgQo4+OwNWj/j8bhFohgcusd8Kys9/11dXXr+/LmJYjQ0NGhxcdG4okT1\nkgxHLBaLhlGzF+7du1elMLS6umqGBjyzoaFB2WzWjDzizBg7z33F6DQ0NJiA8fb2tjVGHBwcaHZ2\nVsViUUNDQzYhAQI7Dpgs0DcHEMHxjBCQ5vuhIbFuiK4QFPG9yWTSmDTs6dpo0tcL/Hn0MJLfP94w\ne2ybTJZINJlMGgQnyRwONRn2Jefu5KQi4D4xMaFLly59qePv73q9ttT+8ePHlqLDz1tdXTUFpo6O\nDlPAwXg0NTVZ101ra6s9FCJDPs8PeIO8DG6K4W1ra9PKyooJQpCSYhxbW1u1srKiUKgiUEwl3bcj\nSucLz4GWZBXOSKQyamN5edn4h7VpiTc+4XBY9fX1ZsSoNLLYvk1OkjmPCxcuaG9v70vAPQYNXVA2\nvDfeFDP29/fV09OjyclJ9fX1qbGxUS9fvtTQ0JAVJcLhyrC1y5cvG+vC41VgZEQHUnW6hVHFOPri\nAdeKUYPug+guFXueP89Ckg3Z6+rqqsKxfbTK9VPkQtSDFPPs7KwKKsBxMyYlEKiMeu7t7VUul7P0\nGIOMYSuVSlpaWtLZ2VmVchVRcD6f19LSkmZmZoy+Q+RLbzh6sbQxoh4mySJ0X6yUZGIdpVLJBvgx\nkJCxLpwrxmy0tbVZwRe8lcYD5A0PDw/V2dlp3V2sEZALUxVYn3Q6rXQ6bZ18DQ2VqaFTU1PKZrNq\nampSX1+fqVxRFPYG3UNFngnzVRV+/wy8bgDsAATPCTbYZ7ALfIZBbebw8FC9vb1KJpO6dOnSK9m0\n18Yj9fQQbtAT4dfW1jQ0NGQphm9d3NnZsZ5zohRSP1LxYLAybROxEl5nZ2fGD4SWAwYpybAxIgHw\nKw6wVF0Ao5BD9IMYys7OjmmNkvIRjZLO+k2AAeLZ4DwQMCEi8FE3OOjU1JSJLvjKLh6aSQC0P/qK\nqi8AcfhJUxk5fe/ePRPlaGxsVCaT0Te+8Q39/Oc/N8MkqarV1htpno+XC6yvrzcckJ/F6MA9hVdM\nxOuVjXZ3dzU0NGS0tqamJq2srFhrMYaPeVDwa7nnTCZjau0YdD80rVyu0J36+/s1Oztrgsx0C1FE\nhLC/s7NjOrMYopaWFh0fH9vEXGhaIyMjhqGT9YyNjSkQCGhqasrGvlB1p/vG94QT0fJsOjo6TLSa\n7yMiRZpQkp48eWLRL/cKPQgjArYYCFTGXFN4BdaCux0IBGwuVCAQUFdXl958880qdgUZ59HRkTY2\nNnR4WBnFTYsnzBCcJQEH8FEts8ZHoh4qoC5A1so1MfGB51cLqyFHub6+buwfolmvK/yrXq8lIt3Y\n2NDPfvazKuB/a2vLooDGxkbbYB6znJ+fV11dnfr7+6sMkQfq2WwoBjEugIgVI8Pmr60ieq8onY/B\n8BGnJIMHajua2KSbm5vq6OiwjhgvAOI3QG2hCO/MdWH48e7MevdEeIojbBQ+j8/hUL98+VKDg4MW\nPXEfUsVIFYtF9ff36+nTp1Yprqurswh5a2vLNlgmk9GVK1c0OTlpmBTXU0vx4plDkYKiBueSwoSP\nBn3UHwwGzfiiFyDJOIB1dXVm5MLhsHK5nDo6Okz0mMKL7wIj8oWhQdvm0dGR2tralMlkLN0Hg/SN\nDZ7LC8wRClWEUVZWVhSLxfTFF1+oubnZ2g6hLNGEEI1G1dvbq4ODA7148cKExsGzKURhjDBmnhuK\n49nb21M2m7WInCaKg4MDdXd3K5vN2qQDuKO1wj0ev4TWB8WMKM5nhxQrcdjb29taW1tToVDQ+vq6\nyuWyDftDGjKVSqmpqUlDQ0MmONPe3q7R0VGdnZ0pm82axB+QEBKDbW1tisfjph/gC7vYA+iK8Xi8\nahIpET37kb1JpooCGZzm+vp6DQ0N/f1O7VEcApdAnIMZK76Ci4jFo0ePdP36daPEeBoEhsq3SobD\nYZvXRJTLwwI3pDLvq7MsDsWuYDBo1CX61yVZlOBbN6XzdGN3d1epVMrSGQ6f59Z5o8rPShXsc3Fx\nUYODg9YBgyGGvkVqAg3MV+P5LG+IpIqTWVtbq6J68NlE01IlumEEC85ne3tbFy5csCFzAPNvvPGG\nisWiFhcX7XlQROI6gFO4Zq6V6JXn39nZaTACBre2uIYh89qvHGgKa2NjY9rd3VWhULDvam5ursJX\nMUK7u7tVRG3GYMNVls6NLlFPNBrV7u6utXlSqSa1pGf9+vXrVvyEGw1dqqWlRdvb23r+/Lm2t7c1\nMDCgvr4+KxRyz+xn1gGVMa9WVCpVTybwRHSyPPB1jzl6nNJnKL4oCMcUaMRDWryPiBZoCm4n1DMy\nK6kS9e/v75tTCAYrnFT2FU6Hxo1QKGSFuEwmo7W1NW1ubmp9fV1bW1va3t62QKahocEi85OTE5tk\nCxPBBzD84n7ZJ0Sz6+vrevPNN9Xf3/9KNu21pPakpHQWsRExLmzW+vp6ra+va3x8vEqhnM4aohaP\nNUqyntlEIqFoNGoG1bdw+pSB6yiVSl/CUyHv0zHFd7CBPN+VzyOFZCSsVy4CG2Tj1qb4LCgC09wP\n6leMfGZTBwKBqjlR/vDjfcvlskWbExMTVfPV4e5S1CMdRlUKPDmdTmtyclLj4+NaWFgwQzc1NaVw\nOKyxsTEj8iNmjDPk/nkRcfrUzeO7RJdsdN9HjqhzPp+3PvpoNKrZ2VldvnxZo6Ojmp2dlSQrApZK\nJeNZ+udFkYquOfBEL7Kcz+fV1dWlqakpDQwMGEYYj8dtGF9dXZ3a29u1srJiht5L9iHbR0smKf/+\n/r4SiYQGBwe1t7enlZUVi8jp7iOyAo5CrAZICYOH4STSxOnzfqiGHpf2RpV9yVngXJCi1+L5ZBSS\nbASyp7xRzCRtZyCdN8zYAvYp2hK+fuCbWYiC/RkGL+d8ZzIZqxdMTU2ZEU8kEmpvb7froWXWy3R6\nRwRe/qqv12JIMQR4Uul8plCtx5ycnDSBkp6eHsMsMWA8cE+lamxs1MrKitrb27W/v1+FOXIQ+Dvp\nMukU14SMmo98fbWQDe+NLtCE73OnkuthiNpN7KNhPgtFKbRG6SpJp9NGofFVfow2BtFfL9EsjQG/\n+MUv9LWvfU0zMzOSZLJuRBNbW1tKJpOamJjQvXv3dHJyooGBAb148ULLy8u6cOGCXr58aVVk2A8I\naty6dUvhcFgPHjzQN77xDf30pz9VuXxOOcNhSeedMOBv4H5eOpC0GsYG1XUMHv32dXV1evDggbq7\nu62izzMmMuOZERGzHxgxA2XGF7Oi0aguXbpkUwzYTxzQtbU1mw3GfbDPwVpHRkZs7cEOBwcHrde9\nUCgolUqZYT46Op9XD3+TtUJQZX9/X0tLS9rd3VVvb6+am5ttVDNFSu5Tkj1bTy/i7xhfaIM8B/4f\nY+dxStLrs7MzbWxsGKTgud9EtRhQ2qQJiliDk5MT65dnHxJBYnSBurgu7IYX6GENYbuw/uFwWKur\nq8bzhVrW3t5eNQEXB+9bq1/l9VoMqe+GIZ2ii4DN19nZqYmJCb377rva3Ny0yiipOSRz0hEAbrBL\nMMbT04oWKeksnhb8xHfIEM0hiIGxxNP6DUUU4L00hpT0BB5jLd1HUpWz8EUWHEN7e7vW19eVSCR0\nfHxsaQ3jOXwk7oVuOXA+0qU6XC5XZtXn83nlcjnTySSiQmkoGAyqp6dHx8fHevz4sW7duqXDw0Pd\nvn1bDx480PHxsXp6epTL5Sz9ppW3paVFS0tLOj091eDgoPL5vPb29vRbv/Vb+slPfmLRMOkbhgkc\nWKoYse3tbSsu8e9kLQcHBxoaGtLy8rJpbc7Pz2t3d9cwLaIVOKDsITIaoi2iPww31CaMNER+jDxO\na2try5gfKBExKoWOMgR3mpqaTGWItUgkEtrf39fOzk4VRLS3t2friggMrBQOOONWAoGAuru7de3a\nNU1OThpzwTspDFksFjOhbCY+EFmSmQwODpoADN1b/r0+c/LMDNLklpYWE5ap/X/uwU/0RAOWAIbr\nASahCYCAwAccnoeMLfEsIPY9n3twcKCjoyP19fVVQYJra2taWloyipokkzD09/CrXq8FI52fn9fc\n3JylSIjeAlh7cZFCoWDeDM/J5pDOBWXB5uiXlc65lESpGB+4YplMxgQKfLotnYsWY0jx5njx3d1d\n+0x+huqmJGMkgGn61Nb/jI9UfeRbX1+vdDqtsbExbW1tVUVP0nkEj+ele8tXdrknUqbl5WUFg0GN\nj4/r4cOHGh4etp+XZIWkcrnS0ghmSYp/eHiogYEBTUxMKJlMmkGB8wnO+vLlS3V3d1vLKwUD6Gbe\nqVAoQKR4a2tLHR0dVTOQiKg4aOFwWHNzcxoYGLDDQ5W6WCxWkfMpBkHxCgQC1iQRi8VMAZ/r4cX9\neEbD6empurq6rMK8sLCgnp4e2yvhcGW8dzhckeFjjY6OjkwTt7u72+AmzwCAnYERxUBgUEilKbTU\n1dWpq6vL5kxdv37d2iB5buVyuWo4nnceOJNQKKSRkREdHR1pdXVV2WzWzg6/MFJcC38mcq2vr7ez\nBg+VfUrr6dbWlg4PD02AxXeOge/W11fmZ+GAyLZ81IxxxAZgD8rlso0fB08meqbQRyciWbCnyOEE\n+F6k+65du/ZKNu21RKQeK4SakUgkLGKMRqPKZrOG94TDYatesjB4K1KC1tZWEwFGGRyjyUH0OCqR\nL6n44eGhtYyBQXkjSEcI1UQWg9Se+yKSBJfioENv8vde61G5Rt5L5OYjS+l8xDOz5qPRqDY3N5VK\npUyKz8MGHESuf25uznAkhILhW9IWSAGKyJ7x0Lu7u/r617+uH/3oR3r//fcNFqAHfm9vT++++65m\nZmb0ne98Ry0tLbp+/bpGR0eNg0mUg6HgnnhWyLeRgoLvUWBaWlrSlStXVFdXp3w+r9PTyqiQ9fV1\nOzA4PrIG8LXT08oYX+hQRH0calpp2T84L4wObad1dXW6ceOGGU6I8F1dXcYwqKurs/ZQ/j2fz6uu\nrs4YFrUMBTqLENcgWm9sbFR/f78xDGiagKf54MEDdXV1Gd3PF1VYf/Yshj6fz+vmzZt6/PixYblA\nblJ11AlZnayLz/Z735PdcQhE1nSY+QDIBwe+I43zCa5aS+Inxed6KFoy180XOjljBANACwRnFCql\nCkPHXx/P61Ver01Gb3p62iLFbDZrqQ6pou+f9saQaMMbV48VIrqAsg+UGDwXi8W8HgRC8KiSbLGg\n6wD8E+kR3UCLYoNQadza2lJnZ6eRgT0liQ3ui0IeMvDGHtjCdw5JMjiEe/VFHYZ91eLGvC8ajaqr\nq8uidkj9kowkjbMAl15YWFBvb2+VKMj4+Lg++eQTjY6OGqbM7B/ERd566y0lEgl98cUXKhQKikaj\nev78uVXwidjpAfdD6jxFxaeomUxG77//vo6OjvTZZ5/ZqA3+H2fDz3PgwXGJ2ojK8vl81bPluTMd\nNhaL2fwlojMix+3tbXsPAi8YSvYkXUzg8awveCL7g3UqFAqG1yJuwr4/ODgwzQEcVyAQUEdHh3p7\ne20PEY1hFDCO/hyQwTCmHMK9h65qeZw4WL9HPUvkq+oWBAUETRhXqvZE0OCTrA9GEjy6sbHRIuLm\n5mYTqvZZHIpZXqeCa/DqXtDVsBNcj8+UgsGguru7df369Veyaa8lIsULUU0lnSwWixodHVUmkzEs\niwcpySrZRITgWYT8RKjw/zBwhPps3NoqJoaOze8xITBVX8FjYagcsnFRZSftIUr0eKU3qlK18rjH\nSIE9Xrx4oTt37pjhA14gAuC6MPSeI+qjBp4VB50DBRXn8PBQa2trFqGBYdLLvba2png8bjSa4+Nj\nXb16VR9//LGpQ1Ggg2EwNzenhoYG/fZv/7Z++MMf6tGjR/rt3/5t/Zf/8l905coVuxcOUjAYNKV7\nT1uCHhMOh/X2229rYmJCq6urunz5skXDh4eHam9v1/LysjldDlNDQ4M2NjaMswxDAw1LOLish+8g\n41DitCQZhhcKhWyuE+NRiKxLpZLS6XQVG4W9L8ngBp/iRiKRqsyMrIn3QgskYj8+PrYIi59hT9K9\nhSoVBkeSwQgUo+D9su+88+IzkCv0DtozQ/xe9oECBoozwr/7yJf96SNpfsdY+jUCImCN+TwI/QRV\nfA7Piv1MxsBzITL2wc3/a0T6WkRLuMGmpiYVCgXj9nnFdd/NgtFBHIFUCLoNkVgikVA2m7WD4Gkc\npGTew/uoVqoWlfUGb319vaoST7pEscqn+RgpDgmG1htM//LfxffxfqI/gG8iLs9lpOhG1ZUN7zc6\nf+Zg4rzW19cVjUa1sbGhRCJhh5aIDa2CVCr1pVk+R0eVEcYdHR367LPPNDQ0ZNgqxHMOy6NHj3Tz\n5k11dnZqcnJS//Af/kPrtMHwlMsVgWYoSqwz9LGLFy9qfHxc9+/ft8IIcIXvafeYGX+mIYFIjBeV\naWhCPDccKevrOZYNDQ3WLdXa2mqQD+LRXoO1ublZHR0dVmVPpVJKJpPW7IABA+agmMr+IYqCqgP9\ni0iNYhDX6Q0RRHhqBuwpnJanEUnVzBHWhcIt1Cb+31OF2MO1/1a7B/3Z8XCA51X79/vzgm3weDjR\nMUaQoiXiM1tbW1pbW9Pa2poVluGZdnZ2Kh6PK5FIGCZKTcZjuFC4XuX1WgwpBywSidhhpj+eoWc8\nMDwVFU2wHAwOJH7pPALD89WSuzGwkOnZiH7x2FB8fjBYae3jIJKCeE4pB1Y6N6bw9zwJ33vbr9os\nHAT+/eysIppxclIZieK9OE6I7wLH9GNJatNV3x2ECAabk3XAk7P5QqGQDZeDF0n6jCJSS0uLHj9+\nrK6uLgUCAQP8PcOCDGF2dtaKSwjTIGO2ublpMm/cP7gt2DhKS2DNPFuGmrW2tlY9Z5yML4qxJryH\ndlUwMnBKHAL7EMeLo0mn09rf3zcVp+3tbStm8L0eRmB/ADM0NFRGK6dSKQ39stMnm81qZWVFgUDA\n2hz5RSTmGxyAodirfr3JNnzxyWOcp6enVhPwEEgwGDQq1Pr6umZmZmxyBVEiz0SqNsJcA9/jawIY\nbaJT9ilnyu9ZTz/jPaThfA5nlJ/zsEMgEFBra6t1wfF/PkPgs/z6xmIxk9hDDP5VXq/FkErnYzp8\n5OXTAd5DdEC/dKlUssgrm82qv7+/KqUkgkWtyI+N8OkbaREjKjiQeGsWxgPnGGRP7vbG13Pnurq6\n7LvYRD6d95QPHwlz3/y5tbVVCwsLBoojSwYOx89xn1TX/aHyzxwDQiQNDjo3N2eFiloPDa5EREfP\nf7lcViaTUV9fnw4PD7W0tGSKXNJ5Vf7k5MQ6h4A87t69q5cvX+ru3bt64403jBLj8bTNzU29ePHC\nimoHBwcmeEEkxgGgAEHq5rE46Vxshv3mDzlYGWpHGOWzszPrVwf/BlIpl8vWOQO8Ar+Vot7+/r66\nurqqMHcOPYf6+PhYm5ubWlhYMH3dr3/96yZoTSYEidyn0jgafiFzhxGn08o7Jn++GEfNXifNZ19G\nIhENDAzo/ffft5lqNHLA5WafftW+gkzvswQP5bCm7BX2qO+aks7xbj9ChsCAKN5H9p4u54uWXIOP\nlmsjYYq8PMNXfb02PVKMKKMhSFfwMng0SSaezIaXZET6YrFoA/EoVNTV1dlMHPAXqRqXZKN4grH/\nv3K5bAfi7OzMRB2Ihn3Pto9IOdDQtjC2flN4DImXx538c2Jh6Q4CkPdYJYeUg0Bfuf8uPgvncHx8\nbNxFDN3Z2ZmJXDc2Nqq7u1vJZNKM8+XLlw2botoeDlfmxd+4cUOrq6vK5/NGCYLWI0nLy8va3d3V\nnTt3lMlkFAgENDw8rC+++EL37983zFGSZmdntba2pg8++EB/9Ed/ZG2crEM0GjXD7rVOWTs+i8OB\nM/TYME6BtJdnSTp9dlYRUaZZg30ErhgMBi2Kx4ES/XE9Z2dnxrXFCFB8ocGAoh6p/PLysubn53X3\n7l3DfgOByngdClfeefM9sVhMra2tGhgYUHd3tyk95fN563ICZ83lciqVShobG1OhUDD8GOnAcrls\nz+Hw8FCTk5N6/PixiVmjMk9AQlXdN0BwBvnc09NTq4UQoeNcWRNsgsdM2fPBYPBL46nr6+ttbhtn\nrLm52bIsDzf47MxH47XRut9LXxWM/F2v16qQT5dSLablq3sYDFI+IgLIzxiQWCymlZUV2/SRSMQO\nLFELBwqvF41GlU6n1dHRYZQqDCJhPxAEGxE8zXdTSOdGj0X2HEvu7as8oK+QflXKv7+/b0YUWTW+\nD/FpyPak0PR7e5zX41L82eu1trW16dmzZzY1lO4T5A2J2sFZwWbZbKenpxoYGNAnn3xi+CXz4Eul\nknEnP/nkE7333nsqFApm3EZHR/WDH/xAfX19ikaj+vVf/3XF43F99NFH+pu/+RtFIhEjptNBhfHy\nRgKuJc+aqIU0GMOL7uq3vvUt9fb2amVlpSoiYf1wIJKMWcABxtlQAEUAJxKJWBQJ9u/TUa6DLKep\nqclGAR8fH2t7e9t0Au7+3/be7Lex7Lr+XyRCsEGlAAAgAElEQVQ1j5SoeaxZVd1V1eXulN3tIUZg\np/NgwEiCIAjyECD5n/IUIHnJS2AkRhIYdgI3HA/J12W77Wr34Bpb80RKJCVqKI38PQifzcXbaruC\nflDwAw9QkIoiL+89Z5+91157OG+8Ecn9pD3xOSgk9oh3uaJBycnJWXOe8fHx8Lyy2azGxsYiSNba\n2hoKDuPrXdiQF8poccuhavCOQPr8RPZ8T3mKE/eNoXPuFoXmAMj/+X7zggGyaZK8Ns/GtR1I+Z7z\na6dSKU1NTb10G70LUaQLCwtaXFyMhcSdZCQfSlJd7h2VIkNDQ1ECSk18EomBZAlkOa/T3t4eaSsI\nuruACDcuA2iHJHaPOvJ+Fu3k5CQoAOc/k+4KwpH8v3OuHGXi+XOnp2e9IwuFQhxpISn41CQPhfJL\npVJ1kUv4Vc4iomE2rrt0VpYIN0kDaEh+Ngf3NDExoV/+8pe6fv26JEWCPCksMzMz+tGPfqSPP/5Y\nn//857W4uKjT01O9+uqrymaz+vnPf66HDx9qe3tbU1NTGhkZqUuD8bUk6Ma6pFIpXb16NToWubGi\nbLi1tVXf+MY3tLy8rH/+53+O6igyO1BU3rqQ9YL3xcUmhYm/4w0kaR/n+lFSZJ1wbhWy4s2daYfH\nZzxg4zQV2RsoYAJhhUIhvIPNzc269oB00Ee2CeyBQpEdPDZoCPI7+ZwXs3A/Toc5n+mynnTd3RPF\nmDkQ8H3mg+t41N33F/PvVJqP5H5zpT89Pf1/ux8pmxrlkHSTpVpVEuQ61gP3xNuatbS0RL4obg59\nQImo8z6UH5+nZnloaCjqhcmHRFE4z+lBJKnGDZ2engZHi9JxFHjeAibpBBcUFhj3b2lpSa+++mqd\nYndrDk9IpQtBNhdGzv5JpVIRaOvr6wuBp1mDE/Ac0eF8EWe/wxmTYwk6uXnzph4+fKjf//3f1+zs\nbNyndHY6wmuvvab19XU9efIkCjJolnJ8fKzXXnstlL0nWL94cXZUMs9B4+GNjY04RuLevXtaXl4O\nY3B4eNa5ndZ6X/nKV/R3f/d3Ghsb0/3790NhgjyT+cZ4KhhxZIwUPOSSHE2ajMBpkl7DHHvwiYg/\n3Y1SqVT0RMWjcKXmHpCkOhSXSp3lk66vr0eWRWdnp2ZnZ6Oe/MWLF1GSeXJyEgFUOPDh4eGYW6Lk\npFrhVpNmhPLNZDJ15dTMEcCBe4OCwhCRooTCc1feU6XceCDnvNe/w8FOEsl6TqnHX1yxs0/43qTC\n/l3jwo5jTpbDeRRcqp2DfXh4WNeQmLw2EsSxRjTkwOUgZ3B7ezuir1K9dSMthuqUwcFBLS8vh7V3\njg16AB4RRYsia2s7O5edHpf5fL6Op5NqVUs8tyNQH/698Ji+4CBJntlblTU3N4fbRkoT13NUVC6X\n64of9vf3Q5Hl83nduHEjOjAxX6lUKvoiUCcNYuN7QLr9/f168OCBbt68GY0oOMWR8tm1tTW9/vrr\n+slPfqI333xT5XI5OiGxAdra2sIwsfE4LXZxcVFHR0caGhpSS0uLfvCDH0R1i5cKzs/Pa2ZmRqOj\no/r7v/97Xb9+PbIXPDDm68LaYHxZZ4968xMeExcTRcPfSCVDxukrkcvlVC6Xwziy3hgwp5v8vlgv\n71TW3NyshYWF6J/gCocmNJz0MDg4qN3dXc3NzQVyh+tk71Hq6fmdyDB1/1KNqvBAKwbGaQgG+8g7\nrnFdvtvdbf87MsFcgUJBnR7xR259v6EDfJ8x3PN1YPOy48JKROGYmBAWLcnnJV0at6qQ0FzPj48A\ngXr9uHMncCzcg6ToqM8Z8l51IZ3lHc7OzurmzZt1r4NW2MATExN1kX2pVhniGwJLeZ4L4/dLXfjW\n1lZdMjE8L8E6Dm6DS3OBILoJSodfdlfVT1clcZ82Y9wXXDPKlMbKIA7pTHgHBga0vr6uDz/8ULdv\n3471mZubCxRGms3nP/95fetb39Jf/dVfRd7i//t//0/Xrl0L5JvNZqPzE8G2/v7+8FqWlpYiJUyq\nFS4sLi5GZ6jvf//7euWVV6JpjXNkzLejEd9I7vazwZORZu8w5QGu/f19LS8vB7pDrjhAb3BwMFKu\nMBTZbDYMHR4bFBT7hdxXUgOHh4eD415dXQ16YHt7O4J9lUpF1Wo1vndhYSHSrCSF98daep4miBID\nJSnQJb+Dpk9O6vsc4F5z/xS14HG6x+Oo1oNq7u4To/BMBvSH87CeLYOxRIkzfE1R7lABLzsuRJHS\nKILkZSaAgTLc3d2NJHwED9eFqBuROk9IZgGc2PfGtiy4B1A4bRT0CVfKhkThe3RZqq/cQAARHDaA\no093M1D4vCfJ8Ui1lBX6X169elWbm5shOM3NzXFMAkKFK+buy/j4uEqlUlyP90LAE5EmurqysqKZ\nmRltbGx84h45V6hcLse98jysS0dHh775zW+qXC6rXC7HmVdDQ0MRtOnv79fTp0/15ptv6rXXXtPW\n1pa++93v6m/+5m906dKloBv43sHBQWWzWX388ceRvUAO6LVr14LnhdP9+c9/rj/5kz/R/Py8fvnL\nX0Y5q7uhriyTnLV7Bp4XCydJEYSnILW3t8fRJ01NTcrlcnHw4dHRURifvb09bW1tqVgsRrMNN8ZQ\nDih3T/FxOQHdTUxMqFgsBrhAUXFESnd3t8bGxiKvkoDi9PR0nGRKfwFHcXgE5LB60I09i2GgmxWc\nbyZz1uIQhce8u3zTrd+Rpu8jvgPvi3lxessDuZLiOiBl9jpGiXl1g+hADnn+P49ISSKHWMda8Tvc\nJ0n6PmnwqihKR51SrYkIE+tkMwEijwrCiZIChPIjV44UDXLWyFd1ZCkpAg/8HReG72PhfNEd4TA+\nzc2nQQellWw4DmYj3Ytrc647ln5xcTG4ae6X+8O4gP5OTk7U29urzc3NQLkg6HT6rEAB6oTqGXIY\nJyYmdHJyonw+rx/96EcaGhrSBx98oC996Uvh4vtZXScnZ8dLjIyMqKurSzMzM2pvb1e5XNbo6Gic\nnECgQ5Ju3LgRyfDMA/mwv/71r3X37l1973vf05/92Z+FC3v16tVAr6S1SbXgiBvzpDuLsUV5U47K\noXLIMx3bi8Wi1tbWlEql9PTp0/AEQGfuPsJRJ7M2vHjEURn3iOKpVqsaHh7W+vp69HuFV3dvolqt\nBlKl5WQqldL6+npd6TSeC5/Z3d2NxtKsvyt3jDCKp6OjQy0tLUG/kNhONg2pawAjuroBWvAWdnZ2\nVCwWVSwWg2aYn5+vixsABPhO51hB7fCtBwcHUaPP3BJUdkDjv6MLXmZcmGufyZydTT8wMFCH2GhF\n19x81pndCeStra0IJGHRMpmMyuVyvO5NQhBChCZJLEv1lUj9/f1xf+RJ+vG0ZAUkXYlqtRruraRw\nv2kIQu6hVEuKd+PA9ZJuiZPqRKux1FAP1Wrt1M3j4+MI/njlUyqVCqsPCvd0MDrwkx4DKiiVSurq\n6vqEe0UD5/7+fi0tLeno6Eh37tzR+vq65ubmlM1m1d/fHxz37du39fjxY73xxht6+vSpRkdHtbCw\noN7e3rpTY997771oksJccT45lTUcAfLKK69odXVVa2tr0VA5n89rampKDx480F/8xV/ogw8+UKFQ\n0KVLl0LpEESBGnIk4wUEzDn5kJw3T2/Y9fV1LSwsxMbmaF8oEld4yB+K2Y09z+keSNIV9vfx94OD\nA3V3d8fRzd4/03tDsM7sA5Q6yg+DyN+9NSRew3l0B3+HAvAMFkfz1epZkJO8au4PcEEFXaVSiX6t\n3C/eRmdnp3p6ejQ5Oane3l51d3erp6cn+gm8ePEi2vQVCoVA/SBXntdT5ZKxCwyQ77f/84qUJrt0\ngEfIj4/P2qGVy2X19PRoc3OzTnGsrq7GwXf8I/pJw2BSY9zC4Kon+T6QGG374IEIEFA3Lp0JZLFY\njIi1VO+yU5lDzivJ/vx09Ok5hQjwedyOBxNaW1vV19en2dnZiAxLtR6i5KyS78ffeUaewwl8nwsQ\ni5+U2dPTo3w+r4GBgbomEZlMJgT161//ulZXV/X9739fV65cib6yrAEuZrVa1dLSUhy7MTU1pZWV\nFUkKpdDS0qLe3l7Nzc2Fcn/8+LHefPNNSfVdr+bm5iIxnLaJ1WpV3/ve9/TXf/3X2tra0ubmpmZm\nZgKFUp2EwUOZsOasU1dXlzo6OqKKx49PGRwcDE+lp6cn1hCl5EE9n2P3uFxRuYF348l1PF6AUq1W\nqxodHQ0U7BF1/yyK17+XZ3YqjH3iKUMMAAPPiFL34I/vBTcQLufnIdh0+qz13enpWSNzvoNreII+\nY3d3V6VSKXhhKqi8aQsn4Pb19WloaEjZbDbWHI+BAhueESrs6OgoOk39b8aFKFK6ZHvqExNYKBRi\ns3k3dalGFsOBgC6kWpQfi8JCS/Xd6JORQjYS0UU/BM6bCxNppdqE17H4bkl9c3qbNISbnEhPUOY+\nPfLY2dlZdwpAS0uLFhYW9Oabb0bEnHujGAF6wg+HS3I9KDrfFAg90XXIfFe2qVQqXL0bN25Ikj78\n8EPt7e2F60ySv1c+lUolXbt2TQ8fPtSXv/zlCLyQG8zxw37gYWdnpwqFgv7yL/9S77zzTt0ZOtvb\n2xodHa0LKG5vb+vx48f60z/9UxWLRf3gBz/Q66+/rq2treDWPNjocy4putzv7e3VndVOoIv54kQB\nd2f9Oo4aPVOEtXfj6TLoc8zrKAZ39clgWVxcjHZw7qIyXCklo9WsC0qNgBG0Gd+FnHgKGgOl6lwj\nBgKvzbNf+IlC8/t1l9zl0bMk/DrcC8Ysl8vFPUHbAJQWFxfjuKJisRgxgKGhIV2/fl0DAwPq7u5W\nPp/X7OxsnFhAjORlx4UhUqwQwiWdTZDzZ6T1pNNn5Xh+miGurJ+3lKwpllS3wAhkUnmxAPA0uHfk\nAaIYUZgIrlvqo6MjjY6ORlrOwMBAKNZMJhOfQcAczTIcpSAI/E5wyAWV+3FEC+La2dnRyMiItre3\n6/i/pGvG70RiaXbMBiQwmE6f9d+cnJwMREgebi6X0/Lystra2uJccql23AeHEXIw3eDgoFZXV3Xl\nypVw8Y+PjzU8PKxf/vKXGhsbiy5WH330USDRnp6e4Jhx0zKZjO7du6eNjQ3dvn1bk5OT+od/+Ae9\n+eabYYSq1eonmmR7hQvBHhQLPHJSCfH3pIF2RZlEZS6HjlqTSs+NvbvHXBf5IyWNkwb8PT48IJqM\neKP4PK0PJYdxxuATh0h6Tg4OXE4lBQ21vb0dGSe8B9nyBP7T07NjkMkYODk5K4smMObBY57Nexf4\ntQBZPqfQA8PDw3VpYWtra5qfn1e5XI7ClEuXLkVGw7179/Sy40Jq7UkD4aFYOLjDo6OjQIAs5M7O\nTvTDxFKAYPxIZNz4JKfDtfwni0jknyi0pDohyWQy2tjYiOt6pBv0QSQTAh/eEsXn6RxuyZOb0r+f\nCCXVJplMRqOjo6HYQLB7e3vKZrNR3cJ9eIu9JCfE/7kn749JbmFTU5NWV1e1srKigYEB3b17V/l8\nXh9//LG6urrCLYN34/Pwoyh5vpeTNTlSgvJU6JB0Oh1KLJfLRbDh9u3bQS+8ePEiODa4zOfPn6tQ\nKKitrU1/+7d/q0uXLtVVHHkU1+XMUY8XLzD/vkbu1jqq9efj/6yLz6+7wYzzjKZzmf667xHP+uD+\nkvKTpA4+7e80Dmlubo6jQ/BE+G4PYibXlXumeIKYAzQbDW0AAgz2+e7ubgSeZ2Zmwgu8fv169M+l\nF4F7AngjSTTvxhJg4fNA0JI4THt7u8bHx3Xt2jVdvXpVqVQqAqX/+I//qJcdF6JIge5uhRkoHi9B\nq1QqEd10l6mnp0fFYrFOSAiagE6Tigor5haVxhVOM0i1qiXy3QYGBuJauPJuHUHLLBLI0YXovJ/u\n1jA/7opKtRy9jo4OPXv2rC7Fhk5WuE2dnZ2B6PjupAuGMvH1QHG3tbXpww8/1Nramm7evKlvfvOb\nKhaLevr0aV0zCjYTxozMBYJtKEm+b319XZ/73Oe0srISxRLeYo//Y7gGBgZ0dHSkX/3qVzo4ONC1\na9cixQd+HC7z9ddf1//8z//o3r17QRkQlEFWvHggiczZhMzHp62V/x1ZYV79Wu6SOsp0OU8qu+Tv\noEJH0e7muiLjvpKKPGkEkoqVPUYtPt6g7xt/Pu/khAx4oAyky/towdjR0REpcL7/mpqagkZ6/vx5\n5GEfHBxofX1dV69ejebb5XI5CkH29/fj5AKnUDCaPBtFKqwJz+JZIMyt1+339/e/9Jn20gUpUlCe\nVH+OEsrVSznZDJQ0JgMw3huUQEsS2nvHH0cSXB+yOdm4BAvsZ7+TQJxOp4M/ROF66ZvzOQg2tMF5\n7phvzr29PfX19dX1H0BR4wa1tbVFFgFzQC4i/8dNB8V42sp5yoANVC6X9cUvflFf+9rXdHh4qG99\n61va399XR0dHoFX/LD9B3ryXuWIwn9wX6IPsjGKxGO0HP/roI127dk13797Vq6++qt3dXT158kTf\n+MY3dHp6Ggj0wYMHunHjhp48eRJc2fHxsQqFgo6Pj6ODPIaP+UmiT5dDZMI9Fl8nVzKudF0BJl9P\nZmXwHleIvhbnKb4kInaE7fecVPiuaBwVO4ID4dN7gteYF+IHgAQABPLM9/veks4493K5rHQ6HZVV\nKGtXyplMJnJWNzY2IrhHkQPpZr5vCQ47X8tADmkC09TUpHw+rydPnmh2djbO+vIoPog6afReZlyI\nInXX2oM/WAWPNIKoeECQU1NTU6Q9uaC5ICbbZHENt9ZsrFQqFcEM3wQobP7mCfde0+4bD14QV5W8\nN54RRZZEOrihdB7a399Xb29vFC+wgciFgxoBifJ/kJcXNDhKcmPh7mc6fZb0Pjo6qr29PX3nO9/R\n3Nyc7t27p+7ubq2srER0U6pXJJzrznG/dKXyOWWTjI6ORpZEsVjU+Pi4Dg4OotN9uVyOuX/+/Lk2\nNjaUTqc1NTWlb3/725qenlZ7e7t+8pOf6Pd///dDIQ0ODsbz9/b2RkQXL4bNj+E9T5E5qnPknnwf\ncwCax5tBdr0skpF00c+7FkUm/joGlPlO0kIezUchnIe6kTFfO9INPbOFdSPACfBhLkgJ9KAp3we4\nIH2Ia5+cnKhSqWhiYiJyopFbNypcB4rn6dOn2traChAwMDCgzs7OuqpD1tJjLeyjXC4XFYkDAwP6\n8z//c/3xH/+xvvzlL2tsbEyVSkVPnz7Vb37zGy0uLsa5ZOfxzr9tXFitPYtwnpuBRWDC4cdYSLgc\nDssjdcXzwEBhNGaQ6tOV+D6phgLI93QrW63WH58h1XL9KC+lQQoKH5RIxyOONCCSTmXL6upquDt8\nhuvQd5OSR6kmcNlsNlqlgZRJXfK2e4eHhxodHY1EeHcD/bnJ0SVbolgs6tatWxoYGFBvb2+c657L\n5aI5jNMgbF4vPSWrgjWGgqDzPOcANTU1BVeKh0EHq7m5ueit2d/fHwUJ6+vrKpfLymazunfvnr79\n7W+rr68vKrd4LubFA4JekuuuXpJeQT48OJlEifzugabktfx3V2jIoweVnBpyJes5yK6MvaDCr4/h\ngHrCC0lek9ecH85kMurt7dX8/HygxCRSByxAn6FMmXuUqYMfrrW9vR2eDX0tvMOWGxmCnXiZtE/M\n5XKRJlkqleI5uU+Uvweepqam1NTUpP/8z//U9va2bt++rVwup+7ubnV3d8cxMdVqNeICfk7b7xoX\nokhRdKlUqq5e3nlGNqfnqUk1F7elpSX6SmIxvd47lUpFpx0E0NGqbwa+m8+ilKvVs+gop426S5xO\np+t6X5J2BKqiXO7p06dh4UCV/n0jIyPq7u6OqCEbnzPad3d34zRJNk86ndba2pru3LkT76egYHl5\nOQIGpIJwbegF5gZjRYCJlCU2CaWeFE60t7fr0aNHunPnjgqFQtAYuFhUdlGNAj+FMmLNOeGgWj1L\nuC+VShoaGtLCwkIch8yJoqCWiYkJPXz4MJqrTE5O6v79+/qnf/onFQoFXb16NXIq2VjUkLsB9Uiv\nezBJntJRvMsLigQZ43eXJUeDUi331kGDK3y/jiu9JD3giC1JDXjsgNeS3p7fKwG7ZFMU3z94RQAC\n9p4rU/dyHDl7INnnPpPJRPBpbGxM+/v7UfjhFWaOcL2Y4uDgQIuLi1Gccf36dW1sbGh9fT3SwSQF\nPegZLgRCb926pXw+r4cPH+rKlSuamZnR1taWHj9+HOsxPj6uP/iDP3hpnXYhrj0TI9WEhPQjhAsF\nRoNabzjgqRtSzb3yxgdsBtxyNnKSH3RLDeeDlcfN4Rx051ndnSJNy9OhmpqaNDk5qevXr2tmZkYz\nMzOanp7W2NiYRkdHNTk5qdHRUR0cHKhQKASnU62eJVujjLxmXqovoXULznPwzOn0WREDaUK8Rr10\nb29vKEvvU1mtVgPZwnPmcrk4vtfzQ6XaSZ1Ef8kucF6aDcV8S2cBMVKOuAYbmobVnEKaSqU0Nzen\nVCql6elpraysqK2tTR999FGkXz148CA2D7XqpEt5qS7uPRvea69d0aAIXEa5/6Si9L8n3UFX0qyf\n85nJz5z3u9NWGCNPb+I9jsocpaIAfThS9QAseb2gRIwlNfM0BnJQAvLz2AfXZO79O+BZt7e31dTU\npKmpqSjw8H9uSDwCT2+AfD6vx48fq6WlRffu3dPAwEDd0SNOy2AM0um0VldXlclk9MYbb6ijo0Pf\n//739ejRI125ckWTk5MBPjY3N/Wy40IUKUEZNj9oEm7EgyqkNjnq5CwaR7JcLxm8wvV3ntVTS3xT\nYP3o6wmi2traqkMFCCA15iw6KMi7AMGfer4nG4S0DxLve3p61N/fHxU/zscy2PQc/8t98+xJ5Lm5\nualcLhe18FQQVSqVMDCOdkHxoFDcKTgp7o88xnQ6HU1SqC4iP5gcVjYSA8PHgO6gTwHI48aNG4Ga\nKbldWlrS8PCwhoeH9Ytf/EJ9fX2xASgtvXz5sg4PD1UsFtXR0aG+vr5QyMxPEom6YkMukijQg3JJ\nBJtEltKnR/19LR1Z8h7/PfkZ7i/5N67jz+FGPam0k8EvV7wcoeLl2plMrQl1R0dHGGanu4gXOBom\ng+O8YBT7eXNzU1NTU2publa5XP6EsWJOPCULr5QG1r/61a+0v7+vu3fvanh4OE4RxVgeH9eaHLE/\nt7a2dHBwoPv372tmZkb//d//rXfeeUednZ165ZVX1NfX94m5/7RxIYoUyyLVminQHESqNYmgtBCL\nijKiusibT0j1nCcKFmXni+nWGMXk5WggOElxXIY3mvDN5SWsuD9+XQ9ysKB0Gfc+A8PDwyqVSlG/\nzVk2bu392eh/yhyhBEGTzIc3tiZ9i6OVEUyuyyAI4ffc2dmp/f39qDiikQvzRWAPt42/sZ6OpDAw\nNHdhQ1FwQf4gQatUKhUVT0dHRxofH9f8/LyuXLkSm/X09FS9vb169uyZfvrTn2piYkLSWTPoxcXF\nQOouEwx3p5PKEAXFa670/O8ug0kl4IrXXXM3zMyTf4+vSdKd5/ckWiaFjc84yk5mjCTvh/XZ2tqK\nBt/cBwbt+PisX62XUrrX4QfUOfhxT06qT0NsamqKPO3p6Wltb29HoxynYzDGSeqC41oODg70s5/9\nTPl8Xl/60pd048aNKB+FksCANDU1ReUaxzbfv39fX/jCF/Ts2TP967/+q37605/qZceF5ZG68LW2\ntqpYLNa57Fg+3D44GNDJ2tpapM/QvJmJRTjZNF5T61wrLqgLFyQ9k05PRcpRKW0FiabT6ThEDdTr\nqIfrZjKZCPjQ3oyz4U9OTvT48WNJigAMwRwKE7hvbweIwsQlQ9Ht7u6GwKKQafwB5+pKVFKd0PK9\nuOkE00CYKFE/jMzvgzPefT6cVmHeBwYGtLa2VtffIJU6y57IZrNxXlRXV5eks4q43d1dFQqFaGLM\nGeRtbW3q6urSrVu3lM1m9ezZM7W0tMSxG0dHR1pfX9f+/n4EBKWa8vK5SPKizL/zfUkX3ufRkSLP\njIFN8rHuEbgCdlc2Se2c950M/u7f5c/FXnKKAdlCcXIIIJV9rG0qlYojpCn+oL+DUwsex0in05HG\nB7rFCCSfG7701q1bGhoaUqFQqKP1eD72KfcF6mxtbdXQ0JDa29v1wx/+UMvLy7p3754uX74cgA1w\n414SuazLy8sql8v6yle+orfeekv5fP7cNT5vXIgiTQoN6Mf5LI6VcA4LN2F/fz9qo70ptKepSAqE\nxCZ1Lox7ALHh9tNOL5PJqL+/X6VSKTYkeXaVSkVjY2ORHiIpItTQDNw338XRExDinDhJb03Oree+\nUdJ0PaLbE5tPUh168aMbyNVLpVIaHR3Vzs6OSqWS2tvbA1Ug7I5efH1w2UGifOfR0VlH+uXl5bpW\nZWx40kdQHKBf1o8AAg1pCFqBpDKZTOTRknQt1WiOL3zhC3rx4oWuXLmizc3N8GJAGfT8PD09jQgx\nlV8UMUCngLaTcukbnE38acrHXeQkynOjjhJzWeM9zn26UXLqyec4iZiTNAOv+3PweTwi9wqdEnMe\nkoCkI2CpVm14enpWZok3AGrFQ3FUybyRukiVoHtw3D/BpDt37kTAlbnmZ5IuYX9zraGhIXV0dOj9\n99/X/Py8xsbGNDIyEuvNT/ZMtVoNI/H++++rUCjo7bfffil9Jl3gufZSjSuBBGYSSMAHcTKBKAJP\nNE+6Mkn3nmt4WpVbdSbx9LRW55tKpYJ/JMCCBaV/4vr6ura3t+ssJKk7npQPTXF8fKxsNqve3l4d\nHh5qbm5O1epZBQW0gfNUWG+U+9HR2cmgzBtIIXnkxM7OTpzGCddZKpWUzWY/kcXgypMIrCd7Y7Cw\n3vBmHOkCQgHBV6tnLeVQUqBhNilGh1zOdDqtXC4Xbrf3mgUdHx0daWBgIAIALS0tevfdd6OZCIgz\nnU5raWlJmUwm8lIlBX+7s7MTZcCFQodGmDYAACAASURBVEE7OzvBlfmmTPJyGF7uyRVoUpbdQCd5\nU3dRk3ylVG88/XrJveLIT/r04Je7sXzO04QcETrthdHwbmn+OVfutLnb2dnR+vp6XZCRtKaDg4O6\nfFFHpO6e86yAk2KxqMXFRc3MzMRZVBhipyuSaB0ly/N1dXVFU5+VlRVdvnxZIyMjUR0HmkWhn56e\nRsrVBx988Eml9SnjQhSpo0xHe5Ii0AMiQRHhkjkagJdhQzD43fkYT/I/jx/jH4ICiY3yckTS3Nwc\nUW82CylAvBfOsLm5WdPT05HPubCwIEnR3CO5YRACqAwQbLVaf3idu/rcM3wpVImfaYXCSxodRzvM\nGQLrSo1N7s/lGwQknkqlImDAnBDscwGHIx0cHAy+G+Tb1tamSqWilpYWtbS0aHV1Na4BpZDP5yOn\nuFAoxJnu8/PzyuVyun//fmR+cM8khJMe5s8l1SslD+gkKZDzeFJHnv4+fncD5TIKCvRy3fN4VR+O\nIF2p+vWZZ6gUp1eSCseNQzqdjqwJngVZdDDiig+udHt7OwwuCgq3n0APqJxr4Pp7tF9SBLPm5+d1\ncnKi+/fva3d3V/l8/hNgKGlU/LquZzo6OvTw4UM9f/5cN27c0ODgYF2Ta59XEOrLjgtRpOdZaqmm\ngHgdIaFuG+tJniaC4S6xuyK8hlV1lOoBHGgBukjt7u6qvb1dhUIhlCN8EaiOkzVR/HBaCC7W+fT0\nVI8fP45u893d3XWuGPPhc8NnvZQRZZ3cPM4/gc4JwHR0dOj09CwnFYTtiCfpSjIXCDXP1NPTE0oO\n5JjNZiNdygNHbLSmpqaojmGuuC+Em7XyvrSOjCSpr69P29vb0Vlqc3NTIyMjUaNPlD+fz+vFixea\nmZnRe++9p9XV1WiX5r1bUdDIAFxgkic9D+U58knykucpyOTnzlt3n6/zFK17KcxP8j3nKXXW0HOj\n/T0uUwz2HUrRC2ZQ+M4Vu6HAWO/s7GhtbU2Dg4MaHBwMegRKiXOmeJ3n8vl0Jd3a2qpyuaxnz55p\nZmZGk5OTWllZiQCjK8AkreLyJJ15tByt8t5772lhYUG3b98Ol58gNHPkAOd3jQt17aUaAQ5HWiqV\n1N/fH8ntNBlOp88S4FFoTB6bwo/3cItOhY3nqDJhNGhG6LxXIl3OQb2kT8CFUttOfT7pRSgfFG4m\nk6k7UfE8TpLhAgH68tfZiAgIgs1xxtwTOak8b1tbW7j3SVTKcP4NZdfS0hKVU16qKynycwnE0aug\nWq3G3IGOeS/eA0oUbwREwoZk3l+8eKHBwUGtrKyop6dHXV1dkdLCOmxtbQXaQLFS448xIbuDIAmV\ncH19fdEwRfqk8nRFgZz4BnMe09eO4dyif4ZB4MNpAf+crw0o3u/pPLTqQIL7xY1Nomu/T0d1BFD9\ncEAUrrvT/GN/wK22tbVpdnZWq6urcYgf2Sv0u2XuuLajep+3VCoV1N/s7KwkRYvE9fX1eGbf2+5d\nSjWvbXt7O3rljo6OamBgQO+//74ePXqk8fFx9ff3q1AoqFQqfcLI/K5xYcEmXE6PqLMoRAJPTk50\n8+bNiBKDjGh/5e6DB3lAhZIijcoTdUG55Iqy6UCBra2tevr0aXQiQplyTYQSSmFoaChcJzYG3+Fu\nEM95HkpJDner2EgI9unpaaBg6SzQNTQ0FMoJjtk3EFyvGxSP1rKRuAZCjPvs98/98l1Uv3Dt5eVl\nSWeNd0ulUjRgcWsvqS6CTmYAid9QMcgI3wWtwny0trZGQQP5uBxyB+8LYoYHp8oFOUtyh6yLKytk\n0z2C5LwlAx687qjSUacHmPz7nFaQasrNg4vnyZKvpXt9AAf/Dq7jqC7pybmCcrn2AJsH0tzDg/pa\nWFjQ4eFhVCCenJxElaCnSvk9MI+OokG8lUpFz58/182bN3X79u3gTnkeLwzweXLAdnBwEMY0l8tp\naGhI8/Pzmp+f12uvvaZbt25peXlZlUrlE/vy08aFIVKqgRx+U4t+cnKijY0NSYqywZ2dnQiY0MwD\n916q8aDu9qTT6VAEfA9oiw0m1fgYUFh7e7s2Nzfr6vQJMjlJD2pEIMm7RGCcf2U4okF4EG4EiOF/\nh6Lg+zo7O3Xt2rUIpLDZUqmz8s9cLhcJ9yAzpyp8U3nairvd0pkQ0iuU70DAu7q6tLm5GU1CCCBB\ngdAF/+Tk7GheT0/DMJHcjdCenJwEAiG1jd6u5XJZTU1Nun79ekSLSUfjTCDml9r75eXlSH9K5s/m\n8/lAUD6SiMuVjK+/r5O7lUmFmUSO5yFXV6hJZOrGy6kPv+5v43GTitoHihHZ8esAIvx7HCm6svYo\nuCPizs5O7ezsaGFhQW1tbdHukQPyKpVK7Htkk/3hHCffSRXes2fPtLOzoy984Qs6ODgIz9XvBd3g\nrzGQL+iwrq6ucPm3t7f1e7/3e/rc5z6nlx0X2kbPO8twRg95iBMTExofH4+cQndRcLEhsFk0P5eI\n10CYUALwoaenZ5VJbPBk1D3JCe3t7UXaEEqZ3ptE9cnj5PooHwJE3JtvMufJfPMmO+OkUrW+pgTA\nlpeXlc/nwzVCsfATNx8BBMVhxJJIJxkoIUthb2+vLq8U4ZYUSH99fT0MCzmkuEfknnpnHUnhCaRS\nqTjimXVqbm6O00rJV93Y2IjD+DY2NoL7pocBbno6ndbCwoKmp6fV1tamra0tXbp0SR0dHVH+SINs\nNjLPk0xD4npJZCnVymRZH4avMUbJkaujWl7zz/l13PAmaYSkMvP78LVMRsaRK+7Pcyt5bqrNkgiX\ne/W94bykyzVGAGNFk55cLqempqbIFScTh+9KHlGSpFucjyVwNDU1pUKhEHvEqZZkgNYNkxu7vr4+\nXbt2Tevr68Gzv+y4sMomNnC5XA43fXd3N9DT9va2fvOb32hwcDDKFAly4I6BoFhA+nG6JceVAM4T\nMAE9kWKTTqfjSAI2rFRT+o5eSe1obW0N8jyVStUFXHD9JdUpX3dvXRj56ZFNBJSu8NlsNhAnnBTH\nMXhuIhwUBge0znUxQKBQvovB63CNpJH4gXp+fx4h5X7ZIAcHB5HIT6Tf0Q3GDYXK5obLTHJfPT09\nkhQcNGuMEa1UKjo5OYkjiulGtbu7q4GBAY2MjOjdd98N44m7xzP9Ntfe0bsPfx/XcISafJ09kESH\nLre+Ju7in+e5cD3nev0eMBJ+TUeyjoZ9XbmGKyXnWn1tuM+kbHDfTU1NQcnMzc1pe3tbw8PDYST9\n+8iySFJijs5RuMfHx3r8+LFevHiht956K7wklw2nD9E7jlDx8nZ2dqI158jISMj7y4wLUaSuKLz9\n3NbWlnp7e6Nv5djYmLLZbLjw+/v7kb8IDyjVmrx6PiOvV6vVOJCNc5Q43gBXg2DE3t6eent7o0Y7\nKYi4yQSWWEyPsqMw4KbYrF6t5AKIm8nCJ13ESqWi3t5eXbt2TZubm3X9Wqna8qANwnZ4eBh19Vhp\n0L43Z/ZmIY6ICM6AKn0Du7sHxQL/SuYDHgTpW3w/m8rzWSmXJbfTc1oxLvxtaWkpDr+DckB+ODGA\nIGJLS4vy+Xxw5DSruHv3rubm5j6BTHzzM/zvSbfbh3/uPMTj7/u01867PsopmTvq98yau/J0peOK\n3K+NgjyPw8crS77ur51nfHndjYij/JaWFvX396tarerJkydxugLABUBApaKDpWq1lovL9clbrlQq\nev/999XX16c7d+5obW0tMjTYw3yWPVqtnuWsT0xMRIDY5+3/fPoTEUgmNpPJKJ/Ph4Xa3NyM1BQi\ncyg6osQnJ2enZxIpR5G6mwy6kRQpLpJCSDhwi8i7v9fdcbdijppAUihNEsZZdBQvvA4GAOHFpeKe\nXYnhcl65ckWZTEbz8/NKpVJ16Mmb8vI776EhysbGRhgs6AKvNT8vcME8IMCelJ0MsJDexEYgqd4T\n2Zkv5tg3MNft6+tToVAIikdS5I52d3erXC6rr68veqK+/vrrKpfLdScWHB8f1/VIIJtgb28vGmyT\nzfD666+rUqloZ2fnXGXjI4k4ffimTr7/PHc/6ZIznJt0Q8o9JQNYfi1/v8t/Mp3Mr8nvTl3wuqdZ\nnccH+zWScoI8unvtnDv/b2lp0cjIiCqViubm5nR6eqr+/v7osobXRGHJedSCGwwq1paWllQoFPT5\nz39enZ2dyufzsSe84g7Z6+np0fPnzyXVYiVOzb3suBBFirC7MuLY3HT67MTQ6elpVavVyFsk2OMT\n2N7eHmc0JTdAUpGyuZP9FkF1uCecSuqRXJArdf785NwXrBwpSNVqtW7RQHSeK+hRzlSqFrQij7Wj\no0NTU1Pa3NyMs9x5fr8myt1RIhkPra2t2t7eViqVinPDuW/m3jciG5N7Q5hQ7DSLSc4xSNfb8nFf\nrAuGkAwMzyMdHR3V8vKyLl++XJf8LUk7OzuSFDwtvN3u7q4GBwe1tbVVh7ChcqrVanBwBJaYF+ms\n8/pXv/pV7e3txWZzJfRpiJKRVK6uYBxV+j/u77z3JPnFpCy7MnMD5VRAkhdF3nywpkleFg8AReoZ\nIq6EuZ7z3H5vn6Z0k8EeqJqurq5IO6Iyra2tLdLfKpVK7C+QpBt9nh95pvruww8/VDab1e3bt1Wp\nVFQsFuu8q4ODAw0MDETvCbw4/y6nRH7XuBBF6kotnU5HCzU2LIEojm32PFOCTSwwbqsLVFKgpVrS\nPRMJ/8ZRFCBg8sxcAFH01P2m0+kIjI2NjdUpbacDUqlUpNl4eaC7KihPXNyjoyPlcrloqJzP54Nm\ncGWJsuM+vL4fASZlqLu7W6urq/E9nNvtidAYAP/HPZKeRJs7D3pg7EjgZt5BOsy3By1wVVF23Pv7\n778fwTLctunp6VCg9GvF+B4eHur69evRk5J19EYpdOLnyBYaCJ+cnOjp06d66623AuXyTEnXmd9/\nm9vvSNPTjVwe+RvyyHD05sYniUyT6DP5d++4lVRwrnh5Th/O1SMXjtLdU3HqAuXrQUtH6b7mPj+8\nl2tDsZF21Nvbq56enlCo7B+8FEe4XvFIsHJwcFCzs7OanZ3VlStXNDAwoHw+HwacVDnAjj+L782X\nHReiSHG3CPAsLS1pdHRUvb29Wlpa0tTUVNRGE2jiwUCUCKsPFigp9O6OO50AauOoC0mxCSVFsj+B\njc7OzrpSxsPDw7CYIFdv2UdU2sspXdCxsGQMDAwMaGBgINK96GoEQgYtSIrsAneTybHleUkrgV+m\nUUpLS0ugSwTnvPQQpzTgsrH+KEjex70SKOKZ3UVKbiCP5re2tqq/v18HBwcRrc9kMlpZWTl33Tnx\nkfzR5eXlCCQyHzw7xQgYaq8tn52djTSy2dnZuk3qz5dUDsnhSthdR1eS5ykxvsMRHq+fpyyTgSbW\nyCkUT/J3o+Dz53LIdeARuXd365kXP4vJnwUDhzF1b/A8asGfj+9oampSX1+fqtWq5ubmtL+/r5GR\nkTj0jqwR/7wrcH++3d1djY+Pq6mpSY8fP1Z7e7vu3r2rcrmsxcXFoLoIdvnzJNfiZcaFKNLe3t5o\nTgCiPDw8DDeU89i9mQcnAbqlTbr0jvZcoTqHBoojsgx3xsbHYu7u7kbzYxQAHZzcjUcBeyURgkiS\nP8LviBELT+d5D27xWdwcP9KBlCQUnx98h+JC8XGECDwiqU+42cnAj1S/Mb1TVDqdjm5KySbV1Wo1\nsipYB1dIXgRQrVbDdSNntFgshqIrFApxvhVrhPHzEyipTJqbm9Pdu3dVrVa1ubkZqJXvojsU1VGg\nWYyTJD158kTT09N66623ND8/L6k+IOPcuCsPN+TnKQhvL+eGxxVxEu3xHq7Da04FOMLDpYUu8/tx\n5eX7wu8Dz8b7KzC3nhLF9bxy0FG1p1Hxd1egboicSvIgq3+ur69PBwcH+vDDD7W/vx8ggwpDPgPV\n5oaE9dna2tLg4KCGh4c1NzcXTVBu3Lihjz76qM6wORo9L2vgd40LUaTFYrEu4IMru7a2Fif7wX+i\ngOAuvSM99AAC4KR03UMaIuIzdIknSXtra6sONYBGJQUXChVBmpSf4V4qlaJske9BSHBdpdrGPDk5\nifOHmpqa4qx4EpcRDlxwF1CUlm+6pOvG5sxms3FvrtxQUo48nCLhPh0x0WkJZezf3d3drYWFhTiL\nHrSPMfHn9jZu1epZR/3e3l5lMhmVy+VYM5QuB915FgTVMpVKRUtLS3rjjTfitElkgsAeAYz19fVI\n4yIYhQdC4cebb76p5eXlc9HgbxtJCsCVn9M3SXfZkaIb/vM8quT3uSLAa+JvSaV/nqL3oJQrc5pz\n4wZjwP1+nK5JggOnfaT6U1CT8+V7lHvkdyr2tre39dFHH+nw8FCDg4NBNaH0AErsMb/G8vKyWltb\ndfnyZe3u7mpxcVHd3d360pe+pL29PRUKhbpYgVMV3tzod40LS8jHWuNyojApy5Rqybf9/f3RlxIl\nA7Ig0RyBSRLECEuSXCdJn3ZsLCJKD5R4enoa7fskRRUOVhHlShoHVp6Bu+QJ37j/tH9rbm7W3Nxc\nlFOClHif81coZ5CZBwg8mAVlwDz29PREuhBGjNJJFLMjSoSKteA76SuA8Dq6qFarYWCSCAzUilKV\narm0R0dHKpVKn+iuTmXU9vZ2eA6gDoKMBPXW19f1la98JQ76q1ardR4MLlw+n9elS5dC4XogcGNj\nQ5VKRXfv3tX8/HzdxkxufNYyOdyonYdceQ+ejysb3ptUxq58mR9H/Y5Wky60K1RXxs4x8n9XxPv7\n+3V0jr+XZ3dvD5oK2Urypf7sINdkShfv81hAKnV2ftvw8LDy+bw+/vhj9ff3K5fLhXGHUmIv8lkA\nysbGhvb393Xz5k2dnJzoww8/1NLSkiYnJ3Xjxg09evQoGrNLCjrt/3ytPa6882fFYjFIf6mm0FKp\nVB18lxQ5nJJCITr35t8DMuF6Ho3G6qRSKZVKpToeLpVKhbuORUaZQQnwGrmL3iLM3XiMBu/j6Nem\nprMGx+vr64HK+QxKy9GlowjnKVGuKGnunwAbz0WZrSMN/y4QuCtu/o8SRyGi0Jhj7seDa/QuhQ5J\npk45ogJ9c6IqDVPYCFS7SLUy0kqlor6+vqBa8vm8crlcoAwoGQoY+vv71dHRoadPn2psbEybm5t1\nyJpOQ6VSSV/96le1s7MT6VGOJpmTpJLwOU0qxE9z091QIbP+HleISfn2gVw7qvV9gCz4vnBF7Yiw\nv79flUol+so6ek4i2+Q9n3fv/M4+4vckSqVPraRoDF0oFLS2tqZCoRB76t1339WTJ08ihcoDuShT\nPCA8Ek4fnZyc1Ntvv639/X3Nzs4qk8no61//uvr7+9Xf3x9VlIuLi/+rDvkXchzzyclJHNtLd55K\npaKpqalwK1wgvF7eLat3QUI5nMfHSIocwmTakKRoiEJSO+iA+6QTO8oYeoG8M6m+tp/vI7BDhPn0\n9DTy4o6Pj7W5uRlHZICCfZN1dHTE58hFbWlpiYwD+FsvACBKzzxxzn25XNbJyVlLvMePH2tkZCRS\nmZJdhRzl+KbkuJGurq464p91oL6f58EFZ0OCnJPlvfv7+1pbW9PNmzdVKpW0vr6uiYmJOoPpzUww\nTltbWxoZGdHCwoK6u7tVKpX0yiuvaGlpScViMdLp8HbgEilXHB0djU79zDXfNz8/r3v37unZs2fa\n2tqKIAhrcx5CZb78PUkD4j8xcnyvG3npk0rTaYDzAlbuIbhydODAfeMlJYNXx8fH0XGLY2tYL/9O\nBxj+ee6RPeQGAGPvrvTe3p52d3ej6Ka1tVWDg4NxDj3Xx3NxI7W2tqbNzc1ArU5DEVDGc+FZZ2dn\n9cEHH6izszMOcmRekLGWlhaNjo7qrbfeOneNzxsXokixHFtbWxobGwtBY9JwzXgvfBYKxTcH0bck\naS6pTmj8fVKNL21tbdXq6qomJiai7h4hT6VScShXtVqNBsRwf5xtA2eIZZTqeR7KE6n62dvbi5Qv\nvxfmAIUB6gJxoiw5K8fdQkc+pD3xLM3NzRHEOT09jYyA4+PjODvK8+YcfSY34+7uroaGhrSyshKn\nLDJXbW1tWlxc1ODgYNwTisIREwYRgwaN0tvbq0KhEFF8uE34Y2gTN1qgX+nMi3n69Gmcfrq3t1dX\nUooyYF7z+bwGBwdVKpVCqbFRDw8PNT8/r0uXLun58+daW1vT1NRU5Bp+Gmr05HM3Qj6HrFPSHXV0\nn5z35PUYyei50zL83ZEh+wKU6q473z0yMqJf//rXUdPux/G4Ak3SAaQmch0OL0QJAgRYq/b29jhO\nm2fY2dnR4eGhVlZWgp5CTpJZAJlMJgwcMkWQmn2FF8prPT09kb0CHZY0JtXqWZ4p8ZOXGReiSCWF\nUsIt45C3arXWTZuo9fr6ugYHB2MxvDwU1IOi5RqOrNis8CAoPZK3KbNEODyv1StiHPmyMChvXH2+\nF9oAlMi9oKzp0o5i8PtGkfr1UJDksfLduOYod6lG7kMloIjoIzAyMlKHxjEIfsQLc41HgJIh3eg8\nXu74+Ow4lc7OzuC0Ozo69OjRI925cye6kfNcIOf9/X2Nj4+rXC7Hs6RSqVB4tPFzDo3nOzg4qKvX\nls7q7a9evarnz5/XdWb3bIhcLqd8Pq9CoRCotqOjI3qWsolnZ2d1+fJl5fN5PXr0SJcvX461l+rP\nzWIzO/fnHkvy/T4XvOZud1KZuofGWrBOyLjzi3497sVjCUmOW1LUm3d0dATF4l5cuVyOpjd+LHN7\ne7v6+vqiLJlrc2z30dFRpPVh0Dy10GUdKgbA4Sc88B4yIZJ73vOQk2vk1JgbENbB14s9/LLjQhQp\nDVVJR+HUSa8bR5EQDWZyOD4Cq+eRcRYAtOakP6WnLCoTBZJ1VwQa4ejo7CwXItwEcxAkgl4gZhYH\nXilZx85Beo4EHIlLCtedtCpP7XClmURkvId58Pe7oFQqFQ0NDWl3dzcUUjp9dmoAmRJwms6tOYrx\n5HunYKrVqgYGBrSwsBBuPpFVkLmjAJoyY5joINXd3a1isRgK3QMieCLMH7SLZx7s7e1pfX1dk5OT\nevjwoYaHh9Xc3BxnCLEhOdxwfX1dQ0NDyufz8T5kpLOzU0tLS3HY4dOnT6PqDoNHQYS75MiO37tv\nXmRXqp3v7kYVmfTMDebbr+EBNe6Ze3AeMklFeNUT106nzw5bfPvtt/XOO+/oypUr0dEsm81qaGgo\nDBJNtJnLFy9eaH9/X6urq6Gw2CeXLl3S1tZWGLHzULajVf7e2dkZTWckRWwhlUrVff/x8XFE2KvV\nWgUhXcGc7mOek/EMB15JBPwy48Jc+2KxGOeUM8EoLxcit6IEjTy9KJWqBa6SPBTCQ9qOn/cunfGY\nuO6OXFhclKFUC8Cw6eFvcLVxT+BVy+VynctFM1tHFmwCV0apVCrOMkpG0ZkbR2YgdO6be/AIfjqd\nDt4ylUqpr68vgjC0AdzY2Ai+Vao/ZdHRHHz2wMBARNMZCPHq6mq0QNzb29PNmze1tLQUnfO5rlM4\nKHxKWdfW1nT58uXgZOGuQF5sxEqlosnJSa2urkYuJf1Jm5ubdefOHc3NzUWJLXmSpLPRt7RcLmti\nYkKrq6tKpc5KahcWFqIIY3l5WSMjI7p3757ee++9OO6E+UZpMAfkSTvCpNmNp8glgy+stysbLzd2\npZCUd0dbyAey6+91xIpSZPT29qpcLuvWrVsaGxuLRkHr6+sqlUp1itBTDvHoMLo8f7Va1ezsrLq6\numLfsP7crweIHKSQHULLPMp5AUHutfb29gaAymQyodh9P+RyOUlnOd+0mGQ9uCfWyw3Wy4wLUaS4\nujRQhjvEdeXwLfoUklbkKM8n0gXQFRKWEcvirdcIYK2trSmXy4WS9Qgl106iCrd+9G0cHByMzxIM\nkmrpTigDhAchxyXmu5NUwOnpaV31E4rOUSb3muRM+f4XL16op6dH5XJZ/f39mp+f18HBQaSd8Vwo\nUhdyro+R4T46OzvjHCgGHCqUSLlc1uHhoSYnJ/XOO+/oi1/8Yl3hAhwqHb28qQkFD0TmqWTifpKK\nhpMQWHsCbGxg3HVcVXKDW1paNDw8rFKppGKxqKmpKc3Nzen4+DgCXqz/+vq6uru79eUvf1k//vGP\nlcvl6nhunwdHpMwjmRHw9Sj0arVadwSLb2zn3pFHl2vnsz1dxz0K5pXWhHgIuVxOuVwuUvp2dnZ0\ndHSkx48fRzoY9+2HNfKMPrgnBwcYErJunMrwfFP3JlC+Ui0jh7Q9P/XV4wIErcgFR15R3ICTx48f\na3d3VzMzM+GtefCSuXSa5GXHhSjSSqUSaTgEPNxlY7Ko4UaRojhYLB5cUuS9OQ/i3B0uMgqY1/b2\n9oKfcyXl7pILhwsJSFqq8TCeWI0gs1ggOleSHmQ4PT07Bx4y3COdKBZGkvvyAIALK+56NpuNQBBU\nCHOJ0YJf8vtyLpSgHRVSSSQknXFs09PTUQLMHHpjE9/8IGI4XFx++C6QIx2hQJTMH71r4VE9KJdO\npzU3N6fx8XFtbm5GAIQ0G2gHgl2VSkUrKysaHR1VPp9XW1tbBJ6gU4rFoo6OjnTv3j0tLS1pa2sr\nUmYcKfLs3n9AUijYavWs6so5RQJkpFyRTsbnHElKNUXr6MmVCBVk8Jk054DekKSlpaWQF4w2ig+P\nqFqt1vVYYJ6RH3eB2RNcD6TqGRGeLZDs8eBzBSBxl9ur5JwHlVQXgOX70THkgvM5+HmeEYPmlEuS\nDvlt48IUaW9vb5wL74qRB2GTwJWBWEBrbsnc1Zdq7ounR/HTUd7p6Wld4q1beQTUu0VJNcuLsqFp\niNMBLghwvh4MYwO4YPqz0FABRYzlPK9HJMJFmSvv8+iuu+X833M+Dw4Ooq+o0waulDEg5IeyOTBe\nbmhGRkY0NzenXC6nw8PDOOWgVCppeHg4Gj0zn6wfKU0oN+Y5yadxf9XqWQFAqVSKlCzW3lHazs6O\nRkZGVCgUJNVOhEXOkJ2enh5tQ9mGQwAADgVJREFUbW2pVCppZGREy8vLcd4UXCDHhO/t7enWrVv6\n6KOPtLm5qeHh4ZiXJGXDcyLDyA0eBgCCORkYGAjX2NGod2SiCToGxqvloBHIRkgqWVAX84BcTE1N\nqbW1Nc6oR/5bWlrU09Ojzs7OyKFmT4Jy6bCEXPMsNCVH/jwzgnnhn7vsLlP+HubPUSnP5u/14eAM\n7tZbZTrHjTIly+Nlx4VxpMBxqeYKIdAIlm9cXDKpPrrphL+nNyWF2KOlp6en0TwaK+ZReHdD+Lxv\nTGrucR9xkaX6iLKjThcWfneeF8qgr68vKnxAVuTY+fO49XYEykbGeKCMcLfZPBw0xz1R5kpRgFRT\nODwDmwOh6+3tDWWQdIcKhYJGR0cjUtvT0xN5eqAhVzgEllKps67/nDxASSdGgs3g+YWtra3KZrP6\n6KOPIkHb6QqKLZyOgKNFbphr0tk49nl2djYON6T+H/qG40zW1ta0srKi4eHhOkWPvLnMs9bModNU\neAc7Ozt168ZzQhVAi7ls06CF86mc/gA48DvK2dd+YWFBN27c0He/+13duHEjApYACzhHyrUxJiA5\nUO/k5KQmJibinK3t7W2VSqWg1TyVyik0vx++00fSy+Q1nvM8xctnPDccHYEHQ2c3aIDW1tYIXnL6\nxMuMC1GkRKY7Ojpi80sKgSCIAe+FK55Mk0AoHTV55JPBpLLhEdrDw0P19vbWbSSp5p54VoBf0xXz\n3t5eXXoOaM9dLtCMo08S9qvVavBl/f398XuSAgBlnufSoOT8dacXmJvOzs7o6wmydwoFNOF5uQSq\njo/PThZA8Hd3dyNB37tdpVKpUAQgqpOTE127dk0//vGPdXx8XNdIhfkAXXIMsOf34QaTreFBCm+F\n5vXmvrmy2awKhYImJyej2xSoje/BdcaFp27//v37evDggSYnJ0PpeqBoe3tbY2Njam1t1cLCgkZH\nRz9hMN3lZ/BsKDvv0ZpEayBZlIyn/UADITe8jkyADnkPsuEy/eLFCw0PD6tYLEbGAvPh8sR9wfNy\nbj3fh7F7/vx5tJ3c399XW1ubhoeHNTY2FrXy5XI5coalWkANLpf96idonEc3OV3Ha65Mk/uAvznX\nTIoWMoSce+/d3zUuRJFyeqA3a2bAv4EkIJ/hUr0ixjlINgO5dV7GCNpk8nBnHfViqd21cPeTBUCQ\nq9VqcHgEkrgfnon7wCrCk3qisVMJHDcrqS4VzBUr9yN98mAz7sGDRTwH87azs6OBgYF4fpQ89yDV\nNjnIkRM6Gen0Wa4tQRpXEuTrjo6OBrJG8To3hjD7/ynZ9DJBd4cdjTpiaW5uVqlU0sDAQF0Ajnsl\nsDY3N6fr16+HovTqM0mhbNra2tTX16dyuawnT57oypUrkQLl7QExzKVSSe3t7ZqamlI+n48TVZPy\n5OiJkZwHNz7n8YcMuG+fV9Zdqp1DlDwuw40ximR2dlbf/OY39R//8R9R8eaUStJAOYp0pMiaNDU1\nRcmlG8Stra3oKUEF3qVLlzQzMxOVfsViMeYWZUauM3uXHG+8OPYSoMVRK9dwZctz8HeCWgAy1x0v\nOy5EkXIwGuitubk58hoRIkozSf7mOAtPUWCjM9waMxwFdnd3x1lGS0tL0QAFlOGfcQHhGi4sLJRH\noVnopMsOH8uzovRdidCjlc+iPIgsu2vI9zu1kdwc5JiyIfnpGQgE3Hg+gm8oFn+/0xt4DuSBsulA\nDScnZ12nPN/UO+fv7u4ql8tF2SrzxzNns1nNzs7q9PTs7PNcLhcHC3I/HlggaDA9Pa2f/exnun37\nduQYulHo7e3Vxx9/rOvXrwetgeL3wBJcK3X7zc3NunbtmmZnZ4MTdkVNsUZPT098BzxicrCZ3Q1l\nYGhBkS5r/M4JA7RfdIXm1+EemV/osSQgePHihcbHx6PZi+e2JumqpFFIoj++270TnhWDncvl1N/f\nH9eVpAcPHiifz+vg4EDZbFaXLl3S+Pi4WlpatLm5GUd+EyRMpc6qHSlu6ejoUGdnZ/wt6QE4beeG\ni3vb2tr6RDZQck5/17iQpiU0s0B5+qJ4dYi7MvzdI2/Vai35Fsvnr8dDpmudixAQFJZHrz0X0xWw\n58c5Epbqj4w4OTk7AgO05+gTi5pEVaRhgSh5VpC1VBNqntu5IYTcN5S7L7jYpGx58jq8pM8T12eT\n0gSa1BOpVkoIj4TiQXCZZw6eo6plZGQkNiwnvvp3I7husAiI8SzMDUaXzxCkAyE6ImdtMQDLy8sa\nGxuro2EI2ng3sdPT0ygh5dTL09PTOu4MmkaSNjc3dXp6qomJiagCQvZYJ18bnpU5xRhJ9d2QoKIw\nwPz/POPq1BfrCBfs64oBzufzevvtt/Wzn/1MIyMj8VxJMOIIzWXQZcKNi8cGnL7zfQWd0dXVpenp\nac3MzGhqakrHx8d6+PCh/v3f/10/+clPIkj56quvRpD68PBQIyMjunr1qoaGhlSpVDQ7O6tyuRyB\nQwdBIHbnjZln+GUGhjkJ1H7buBBFirJEybhCYONTb+1uq6MvJ/WT7hJujQuMVKuhhR/0a3mEzi0R\nyhkERCWF812+QFhNIuUYB9CRu9NJV9cFlcVkAzFccft8Jt1dRw58NxuKIJu7MjwbAsccHh4eqlwu\nx9lJ3DebQKq1O/TNRToaBRQvXrzQ4OCgtre3o+SWRr0uE5lMRhsbG1HWyrog8Kx1MlVOUuTJwoGi\nJLkG60OAYXBwMOQsk8mEASRYxxqOjIxoaWlJh4eH6uvrC0+JtWekUqlA2ePj42pra4sD/fg7a42M\nuewgb5JiPpFn0LMDBOf5+D+fh1NNyiv5sxj6gYEBPXr0qG4u/Z+jSzdOGOOkPCIbrlgBHsjOeTKM\n7MDPZrNZXb9+XTdu3FBfX5/m5+f1L//yL/rhD3+og4MDzczM6NKlSzo6OlI+nw8DNj09rZaWFhWL\nRRWLxTCWROaTAAjj4nvZjfXLjgs7/I7mzVhsqWbJOM6DdA+Uq6MWtzBSfYMSv5bziAQxcMc9nQqy\n2xWku+tcBxcCdMDfUH78Q2mxKLjMCAvfQ6DKAw1s/iQKYPhmdOTpgp50cRDwTOYsJ9WrlVDoPnc+\np7i9jlbJ7XWFxrNLqjt6BGPW1NQUivT4+Fg7OzuB9Pm+09NaLi2ZGs79JtE5vzc1NWltbS3OeFpd\nXQ05IqjJs7W0tESeKAUVrOPe3l5Eb1FgR0dHGh4ejhLX/v5+lcvl4LVBL47+Dw8PNTQ0pNHR0ei6\nj0y6guTe+TsKkBQdZB1Dt7e3V1fd5TLH/DmqdVnm+1DShUJBf/iHf6h33303Gs0kr5e8b0e1KHZ+\nplK15Ht/Jj7j3839c29OA2DYkTdk8Nq1a3rllVeUzWb1+PFj/du//Zt+8YtfqLe3V2+88YYmJydV\nqVQCKPT390dcJZ/PR/8HOoC5d+jo3RH9y44LUaScUe5RYEkhQBDujuhcaUj1XW5YCL8O/2fzeUCn\nVCqptbU1vkeqIQs2hZ8JBKFN3h73w7lS3IejDKJ/cJW0l3NhdYWZdMvhbZM8pf/kd6dCXADdMPCs\nBCC4Ji67KyfnLXkfTWW4JknduLZJJQwfRvDMeeFU6iwhenNzM9rXgR79vSTpk6DvEeskepIUAYzF\nxUVls1nl83lls9k6D6RarUZe69OnT9XT0xPBFYwaqVfQKxh6SkVTqVRQGjQidwRI5Bm+9XOf+1z0\nEXDEmSwhRe7IufQUKRS65wInU9y8ZNM/hyfmSnJ/f19TU1N68uRJVBYy3GV3qoB5x1VnT7BXff/g\n0fAThO9uvoOEJC2AbIOokW1osq6uLr366quamZnRzs6O/uu//kvf+c53tLS0pMHBQV2+fFkTExMB\nFHp7e5XNZtXS0qJCoaDV1VXt7OxENzfPenFj9LLjQoJNw8PD6unpqRMMEMzm5mbUxUPg08RjdHQ0\nNtPx8bHW1tZ06dIlZTIZ3bx5U6lUKhRQX1+fUqlUNEvo7+/X8vKyuru7o/aa4y3canJtCGoECYWK\nVe3q6tKDBw/iiGE+i7UDDfX39+vDDz9UOn1W4vbxxx+ru7tbmUwmFJpb9FQqpUKhUBdxdfctiWpO\nT081MDCg8fHxKFN1a+rltbjNKDRazBEE83Z35N4hvI68CVy1trYGuuWeXSmTq0rFEk0khoaGdHR0\npEqlovv37+vZs2efaDRzfHysoaEhbWxsqKurSzMzMzo6OorUKRC0K/uDg4MICo2MjEQXrxs3boRR\nQvkQid7f39cf/dEfaWVlJQoFjo+PVSgUwqM4OTnrEobRqVQqunTpUng32Ww2lAT3w0/k/K233tKP\nf/zj4GIdBLjxQ9G5IXOeL51O1zUVZ11JSTo9Pa2rHyfx3BVlJnOW3P+1r31N3/72tzU+Pl73PSgu\nlH5S4Xl2ADLpcuoufZLDdfn0eEfSq+K6vr783eeYOezr64tA4Pb2tj744IOoinzllVc0Pj4ez0YG\nENkku7u7EYxj756enmpmZualdVqq6vCmMRqjMRqjMf7X40Jc+8ZojMZojP8/jYYibYzGaIzG+Iyj\noUgbozEaozE+42go0sZojMZojM84Goq0MRqjMRrjM46GIm2MxmiMxviMo6FIG6MxGqMxPuNoKNLG\naIzGaIzPOBqKtDEaozEa4zOOhiJtjMZojMb4jKOhSBujMRqjMT7jaCjSxmiMxmiMzzgairQxGqMx\nGuMzjoYibYzGaIzG+IyjoUgbozEaozE+42go0sZojMZojM84Goq0MRqjMRrjM46GIm2MxmiMxviM\no6FIG6MxGqMxPuNoKNLGaIzGaIzPOP4/wcZUAwU/cQYAAAAASUVORK5CYII=\n",
-       "text": [
-        "<matplotlib.figure.Figure at 0x507cb50>"
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "plt.title('GPU')\n",
-      "plt.imshow(cvimage_gpu, cmap=plt.cm.gray)\n",
-      "plt.axis('off')\n",
-      "plt.show()"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "display_data",
-       "png": "iVBORw0KGgoAAAANSUhEUgAAAVIAAAEKCAYAAABACN11AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzsvVmM3flVNbrOPM/zXNMpl0+VXeVye3Y7ScdxGugMkCii\nFQkihBCCF15aERGQgBAPESBeUEDiIQIioqCGhKTTKIkTuz2PVa7x1Fxnnud5vg9mb58K9/tuX/oT\n7ns5W2q1XT7n1P/8h/Vbe+21908wGAwGGMUoRjGKUfyXQ/iyD2AUoxjFKP6/HiMgHcUoRjGKDxgj\nIB3FKEYxig8YIyAdxShGMYoPGCMgHcUoRjGKDxgjIB3FKEYxig8YIyAdxShGMYoPGCMgHcWHOr79\n7W/j3LlzUKvVsNlsOH/+PL7xjW8AAL70pS9BJpNBo9HAZDLh2rVr2Nra4n/7wz/8wyOfdXh4CKFQ\niH6//9/+PUbx/+8YAekoPrTxF3/xF/i93/s9fPnLX0YqlUIqlcLf/M3f4O7du2i32xAIBPjyl7+M\nSqWCaDQKq9WKL33pSwAAgUAAgUDwcr/AKP7HxAhIR/GhjFKphK9+9av4xje+gV/5lV+BSqUCACws\nLOAf/uEfIJVKj7xeoVDgzTffxNraGgBgMBhg1LQ3iv+uGAHpKD6Uce/ePbRaLXzmM5/5376OwLJa\nreJb3/oWFhcXAWDERkfx3xojIB3FhzKy2SzMZjOEwhe36MWLF2EwGKBUKnHr1i0MBgP8+Z//OQwG\nA/x+P+r1Or75zW++vIMexf/YEL/sAxjFKP7vwmQyIZvNot/vM5jevXsXAODxeNDv9yEQCPDWW2/h\nT/7kT/7T+8ViMTqdzpGfdTodCIXCI+A8ilH8n4jRHTWKD2VcuHABMpkM3/3ud/+3r/tf6aBerxeH\nh4dHfnZwcACPx/N/6hBHMQqOEZCO4kMZer0eX/3qV/E7v/M7ePvtt1GpVNDv97G8vIxarfb/+P7P\nfe5zeOedd/DjH/8YvV4P8Xgcf/qnf4o333zzv+HoR/E/LUZAOooPbbz11lv4y7/8S3z961+H3W6H\n3W7Hb//2b+PrX/86Ll68COB/XVQKBAL4p3/6J/z+7/8+TCYTLl68iAsXLuCrX/3qf+dXGMX/kBCM\nBjuPYhSjGMUHixEjHcUoRjGKDxgjIB3FKEYxig8YIyAdxShGMYoPGCMgHcUoRjGKDxgvxZD/R3/0\nR2g2m+j3+1AqlQgEArBYLCgWixgMBtBoNBAKhajX60in00in07DZbMjn87h+/Tpef/11yOVy1Ot1\nVCoVaLVayOVyiMViKJVKHBwcoFwuQ6FQwOl0YjAYwGq1Ip/PQ6PRYGtrCzqdDmNjYxAIBNjd3cXq\n6ipEIhEcDgc0Gg3EYjG8Xi8qlQqMRiOq1SrW19chEomg0+kwGAygUCig0WhQLBZhNptxcHAAiUQC\ni8WC69evw2g0QqVSQalUIpPJYGpqCtvb2zCZTBAKhfB4PKjX6/jhD3+Ia9euIZPJQCgUwmq1QqvV\nYmNjAzs7Ozh16hRcLhdKpRLS6TSkUin6/T46nQ5MJhO2trag0Wig1Wrh9XqRSCTQ6/VQKpVgMplw\n4sQJqNVqyGQyrKysQCQSIZlMwmg0ol6vI5PJwGQyAXjeaqlWqyGRSCCRSGC325HL5VCr1VAsFqHX\n6yGTyWAwGFAsFlEul3maUrFYhFgshlqtRj6fx8c+9jHcu3cPKpUKCoUCJpMJ1WoVMzMzeOedd7Cw\nsIC1tTWMjY2h0+kgmUyiWq1ibGwMIpEI3W4XAoEAzWYT7XYbNpsNjUYD8XgcFosFKpUK+Xwe+Xwe\nZ8+exc2bN3H+/Hk0Gg2kUinUajWYzWbkcjnMzs5ic3MTarUacrkcrVYLIpEI8XgcH/nIR3Djxg0E\nAgHs7u7C4XCg2+1CLBZDKBQiHA7DZrOh0+lAr9ej3W5DpVIhmUxCqVSi0+nw/ZfNZuHz+SAWixGN\nRiGVSiEQCCCVStHtdqHX67GxsQG9Xg+NRsPH0ev1+LsaDAY0Gg30+310u13+DiKRCCKRCEKhEBqN\nBvl8HgqFAoVCAWq1GoPBAN1uF4PBAGKxGAqFApVKBXK5HAKBANVqFTKZDGKxGL1eD71eDyKRiOcS\nDAYDSCQSdDodiEQiiMViCAQC1Go1vh/a7TY/x1SnpuNqtVoYDAYQCoUQCAQQCoX83QaDAUQiEQQC\nAaxWK9bW1vi5rdfrEIvF/NpIJIIvfOELePz4MeLxOHw+H9rtNl+TXq/Hv7ff7/PvHI5utwuJRAIA\n6PV6qNfrUKlU0Gq1bKWjUCgUSKVSfDwSiQTZbBa9Xg9/9md/9r4wTfS1r33ta/81OPyvx9LSEgaD\nARYWFiCRSHD79m289957EIvFCIVCuH79OoLBIF9Qj8eD1dVVDAYDLC4uIhQKoVqtMiA9evQI+Xwe\nxWIR9+/fx+nTpzE3N4e9vT08evQI4XAYmUwGrVYLxWIRDocDarUaz549QygUQrfbxdTUFMbGxhAO\nh6HVatFoNHDjxg0cHh4iFApBr9ej1+vBYDAAAHK5HLRaLfb395FIJBCPx2EwGDAYDNDv93Hs2DF0\nOh0sLCxga2sL8/PzSCaTsFqtMJvNMBqNuHPnDqampjAzMwO9Xo8f/ehHmJqaQqVSweHhIQwGA2Zn\nZ3H//n0kk0m0Wi30ej1IJBIsLCxgMBhgcnISbrcb4+PjMBqN6PV6aDQaAIC5uTnI5XJkMhmsr6+j\n0+mgXC4zAGezWahUKhSLRYyPjyOfzzO4tlottFot9Pt9bG5uwuv1QqVSoV6vw+PxIBwOY39/H06n\nE48fP4ZSqcSJEydgNBoZBA8ODmA0GvmmjcfjWFtbQ71eh0KhQK/Xw9jYGJrNJgqFAmw2G/r9Pnw+\nHzqdDlqtFmq1GmZnZ1EsFuHxeLC3t4eZmRn0ej3k83m4XC7o9Xqk02mMj4+jUCggGAzi+PHjkMvl\nqFaryOfz6Pf7CAQCiMViUCgUSCQSMJlMsNvt6Pf72Nvbw9mzZ7G3t4fFxUXkcjn0+32o1WqoVCpk\ns1loNBpe/NvtNvr9PiQSCRQKBQDw9+z3+0gmkwzEtVqNp1HRd2+321AoFJBKpfyg6/V6BotOp8Pg\nQgDeaDQwGAzQ6XTQbrfRbDb5XCsUCvT7fchkMnS7XZTLZQgEAgYZAli9Xo9arQaRSIRmswmpVAqh\nUIher8fHT6BEwK5SqSCRSBjchUIhxGIxBoMBv7/VagHAEbCn1wCAVCrFYDCAzWbD8vIyzGYzXx+p\nVAqpVIp6vc4g+vDhQxQKBTidTnS7XQZ9+k70ZzrmYTCl1/b7fb5OhBWtVgvtdpuJEPAcdKVSKU6c\nOIFSqYSdnR0oFArodDpcunTpfWHaSwHSd955B1qtFltbW/B4PHC5XBgbG4NKpYLVaoVKpUKn04FW\nq0Wv18PW1hYmJiag1+uxtbWFWq0Gq9WKer0OoVCI+fl5hEIhtFotuFwuLC8vI5fLIRAIwGAwQC6X\nw+12o9FoYGdnB61Wi0+iXq+HQCBAp9NBLBZDr9fj3zU7Owufzwe9Xo+lpSXMz89jfX0d1WoVDocD\niUQCZrMZfr+fmW+1WkUqlYJOp4NcLsfTp08xPj6OYrGIWq2GZrOJWCyGiYkJZhvxeByZTAaXLl1C\nPB5noBKLxWi321hcXIREIkGhUEC/30cul8Ph4SEKhQJu3bqFbreLpaUltFotCIVClEolqNVq7O7u\nQq/XIxqNMhM/deoUQqEQ6vU6dDodrFYrPB4PHj16BLlcDrVaDZFIhJ2dHc4KpqenmRHVajUIhUJs\nbGyg2+3C4XDg1Vdfhc1mQzQaxcbGBkwmEwaDAdRqNdxuNzKZDDQaDQBgYmICmUwGZrMZMpkM0WgU\nBwcHUCqVcLlcEAqFqFQqqFarsNlsUCqV2NzcRKFQgE6nQzqdxsbGBqanp1EoFJ7fxCIREokEM8IL\nFy6g2WwiEonA7/fj4OAAbrcbwHOQKxaL0Gq1mJmZwcOHD+HxeFCtViESiaDVarGzs8MPXjQaZbau\n1WrR7XbR7XZRKBQgl8uRz+fh9XoRCoVQKBRgNptRKpXgcrkY0Ewm0xEWRcAnEAhQKBSgUChQr9fh\ncDiYVdLriWnGYjFoNBo0m03I5XIAgEwmg0KhgFgshlgsRr1eR7/fh1QqhUQi4Z8DYIZI90iv14NM\nJuNzQiBMIERASAy03W7zewh4iEUPBgO0Wi1mvhT0Zzomo9GIZ8+ewW63QyKRoFar8RSvXq+HTCaD\nL3zhC7h58ybq9TpnpsRo6T9i9wT+w2yUjl8mk6HRaEAkEkGj0aBWq/H7iW0T4yfiEIvFAABjY2Pw\ner3Y3d3FtWvX3hemvRQgffToETQaDe7evYtUKoWZmRmkUincvXsXMpkM7XYb165dw40bN1Cv15nB\nVatVJBIJCAQC+P1+WK1WPHjwAIVCAZ/97GcRCAQwNzeHs2fPQqlUolKpoFwuo1wuIxaLQafTYXFx\nESaTCcViEY1GA2q1GsViEVKpFAaDAWKxGJlMBvv7+8jn81Aqlfxv3/ve93D+/HmYzWa+0ZvNJjO3\nSCSCaDQKi8UC4PlKR6xFrVbD4/FApVKhVCqhWCxCoVCgWCzCaDRib28P5XIZFosF1WoVHo8HOp0O\nkUgELpcLvV4PXq8Xfr8ffr8fr776KgKBANbX13Hp0iVEo1HkcjksLCzAarVieXmZU8rx8XFUq1WW\nK9bW1mAwGFCv1/Hs2TPMzc0hEongk5/8JOx2Ox48eIA33ngDXq8Xk5OTiMfjODg4QDwex4kTJ3D/\n/n2cOXMGU1NTODg4QDabxcHBARwOBzP3TqeDXq+HXC6HbreLSqUCt9vN5zqTyTBjEwqF8Pl8yOVy\naDabAIDd3V2YTCasrKzAYrFAIBDAbDbzOD2lUskPyv7+Pk6fPg2hUAiVSoVCoYBut4tEIgG32w2j\n0YhkMol6vY5CoYCJiQmIxWLEYjHY7XZeoA4ODmC1WpFIJCAUCuF2u7G/vw+VSgWj0Yhut4t0Og2Z\nTIZWq8UZgFarRSQSgUajgV6vh1gsZvaoUqmY/cTjcSgUCohEIgYDlUoFgUAAiUSCYrHIqX6z2eRZ\nAb1eD+12GxMTE2g0GqjVaiwZ5XI5lEol6HQ6AM+ZX7vdhlAoPJJmE3sTiUQMjmKxmAGQUnpiePR6\nAsrhVH34tRKJBK1WixfgRqMBiURyBLQJ1IPBIMbGxtBut4+8jmSdz3zmM3jw4AHa7TZLSMSk6TvQ\n9xGJRFCpVJBKpbxYdLtdzqRqtRpfi2q1ina7zeweeA7ucrkcBoOBARsAL2RbW1tQq9X42Mc+9r4w\n7aUY8v/4j/8YMpkMi4uLePfdd7G5uYnp6WmcOnWKVwutVssTgPL5PFKpFKRSKaanp1Gr1bC3t4fd\n3V3Mzs7i6dOnqNfrOHfuHPr9PhKJBLrdLuRyOacNOp0ORqMRkUgEiUQCk5OTvLpHo1FemSYnJzE2\nNobNzU3UajUkk0n4/X6oVCr4fD6k02loNBrE43FIpVIUi0V0u12IRCIsLi7i/v37qNVqOHnyJEql\nEoRCIWw2GyKRCDY2NvDmm2/i+9//PkQiEfx+P6c5LpcLhUIBHo8HWq0Wh4eH8Pv9ePz4Mebm5pBM\nJjndq9fraLfbCIVC+MVf/EVmiVKpFGtrazh79izfuNlsFvl8nuWAcDiMbrcLq9XKD3yn04FOp8Pa\n2hqCwSA+//nP889jsRgSiQTeeOMNCAQCRCIRzMzMIJPJIBKJsEZFuikANBoNlMtlBolAIICNjQ1U\nKhU4nU54PB7s7+/DZDIxMDWbTRSLRQYphUIBq9UKkUiEcrmMUqkEuVwOp9OJeDzODGNsbAy7u7uY\nmprCkydP8NGPfhShUAhqtRrRaBQ+nw+hUAgulwuNRgNisRgymQy5XA7ZbBZnzpzB+vo65ubmsLS0\nhOnpaYTDYVitVgAvJJxGo4HZ2Vncu3cPPp+P9UClUsnfGQBarRZrpiTDdDodqNVq1Ot1SCQSVCoV\nvi+JgZMG2el0IJPJUK/XoVQq+bqm02kYjUa+1pTK0++kVLbVajEDk8lk/HmtVos1T9JQKfUlwKL7\nmECL/k6ASZr1MLMDnoOSWCzm1w+HQqFAq9VCJBKB1+vl30lA3+l0kMvl8Mu//Mu4efMm34vDQE7H\nVC6Xkc1mUSgU+NwbDAYYDAao1WoolUrIZDIGZ9oNgeQGYraNRgO5XI61f6FQCL1ez7UBWtwHgwHe\neuut94VpLwVI33rrLQQCAUilUuzv72N8fBwKhQJbW1vY2dlhwDKbzUgkEtBqtXC73TCbzXjy5Akm\nJyehVCr5Ync6HSiVSjSbTajVar5Bq9UqcrkcNBoNMpkMlEollEolp+U7OzuYnp5GvV7H2NgYstks\n4vE45HI5Hjx4ALvdjhMnTkAkEuFnP/sZZmdnIZFIUCqVAIBXRLlcjmw2i1qthsnJSfzkJz/B1NQU\n2u02/H4/a1LRaBQnT56ESCTC2toaer0eJicnkc1mkclkmGF+/OMfx/Xr12GxWDAYDBCJRHD16lVU\nq1VIJBKsrq5CJpPBaDSiWCwyCzOZTIhGo4hEIjCbzRCJRFAoFJienkav10O1WkW9XseZM2dw584d\n7O7uYn5+Hm+//TY+/elPs2Ymk8lQrVZhNpuh0WjQaDRYvH/27BnOnDmD/f19uN1uGAwGLoLNzMzw\nohYIBCCRSHB4eMgswOl0IplMQiKRYHx8HPV6HfF4HBqNhjXTfr8Pu92OUCgEAJzOq9VqdLtd1Go1\nqNVqloZIGybwi0ajkMvlsNvtfNyNRgPNZhMmkwmZTAYLCwvY29tDNpuF2+1GPB6Hw+FAo9FgzZiK\niisrK1hcXMTq6ipOnDiBBw8e4MyZM0gkEpy+7+zswO/3IxQKQaPRcNrb7/eh1WoRi8Xg8XgQj8eZ\nubXbbajVagYVtVrNGjaxVQJAp9OJYDAInU53JHXt9/soFAqwWq2cAZDGSkDZ6/WOaK69Xo+Pr9Pp\ncAGsUqlwOk+gCDxnuMQsqchWLpchk8n4+aPnjUBKqVTyIjIYDFAsFo8Uw+gzu90uqtUqPvGJT+DG\njRt8zmUyGdLpNGKxGLrdLgwGAyYmJmA2m6HVaiGTyfg+rdfrqNVqyGaziEQiqNVqfA4EAgF6vR7/\nLuCFhiuTyWCxWOByubgAlcvlEIvFUK/XIRAIIBaL8Vd/9VfvC9NeCpD++q//OiQSCYxGI2w2GwaD\nAQ4PD+Hz+WA2myGVSlEoFKDRaODxeLC9vY3NzU1+EDKZDN8QVPXrdrtwu904ffo0nE4nUqkU8vk8\na6UAcOfOHSiVSigUCqysrGBiYgITExPY399Hv9+HSqWCWq1mLcfpdEIikeDJkye4fPkyKpUKBoMB\n2u02KpUKPB4PisUier0e1Go1az7EpqempvDOO+/AZrPBYrFgfHwc7777Lo4dO8Yrc7vdxsLCAr77\n3e/iE5/4BLa2tiAUCmGxWGCxWJidUbX63r17zCyJCVy5cgVPnjxhLU6n06Hf73MBbnJykvUfm82G\n3d1dXLhwASqVChaLBUqlkuWJ7e1trKyswG63Q6fTIZvNwm63o1qtolKp4JVXXsHjx4+h1WohFouR\nTqc5pet2u1Cr1Th//jyePXuGfr8Pp9OJVqsFnU6Hhw8fYnJyEnK5HPv7+9DpdDCbzVhbW+MiXKlU\n4jSavnsqlYJYLGadLZVKweFwoN1uo1gscqFJIBCwdKBSqVCr1dBqtWAwGKDVarG+vs4FKWK8VFkv\nFApQqVQwm81oNBrIZDJwu92chtdqNU4RnU4nDg4OYDAYkE6nmRkR2JMmXS6XodFo0G63IZFIGOyH\nAcZgMKDX67Fm32q1oNVqkc/nodVqmfn2+33odDpeOOv1OgaDAer1OlwuF9LpNORyOTqdDjsFiBm3\n221mxZTWkzRF6Xq9XmeNkyrwBMDE7OjzCTIIsChlJjZHC3K320W73YZWq0Wz2WQWS7WEbreLz372\ns/jXf/1XrqR3Oh2Mj49jcnISWq2Wj4sWmWQyiYODA84EKT33er0wm82QSCRoNpuo1Wp8rLTAELgP\nL0T1eh1SqRQ7OzswGo04ffo0xsbGkMvlsLm5iS9/+cvvC9NeikZaLBYhEAj4YQReWBl6vR5+8IMf\nYHd3F/1+H6lUCidOnIBSqcTCwgLGxsZw4cIFmEwmXLlyBXK5HEqlkplftVpFPB5HpVJBIBBALpfD\n9773PZTLZUgkEuh0OohEInz84x/naUKFQgE+nw8zMzOIxWJYXFxkxvDs2TO0220kEgnMzs7CYDDg\n8PCQ01W9Xg+DwYBCoQCRSASlUolCoYB0Oo12u42TJ0+ybWh9fR1+vx+NRgN6vZ5B4sSJE3A4HPjO\nd76DK1euwOPxIJ1Oo1AoIJVKYXl5Gb1eD3q9HufPn4dKpYLf70cul8PVq1fZJbC9vQ2n08kiv0wm\ng8vlQqVSwcmTJ5mBnDx5ErFYDPl8Ho8ePUI2m8XW1hbS6TSWl5dx/Phx+P1+JJNJ1jJtNhvEYjH/\nu9lsRrlc5iLhmTNn4HQ6oVQqIRKJkE6nuVCwv7/Pi4lOp2OZwmKxIJPJYG5ujhlOoVDgYpNCoUCz\n2YRAIIDFYoFMJoNEIoHBYMDTp08xNTWFdDoNvV6Pfr+PdDoNq9XKVqRgMMiLDTE0qVSKRCLBjpBO\npwObzYZcLgeHw4FwOIxWq4VsNouxsTEEg0FIpVKIRCL+s81m4wxHKpWyFk8ALBKJYLFYkM1m2QVB\nNimtVstVeAIkKkISmNbrdfR6PTSbTYjFYkgkEnZj1Ot1dkIQOyWGB4D1SJIxaIGkCjqluKR10uco\nFAoGzW63y+BJrI6kil6vx+xzOI2WSqVHdFNiv8PgSwtIrVaDXC5HIBDA3/7t38LtduPs2bOYnJyE\n3++H3W5Ht9vF9vY2gsEglpaWcHh4iFarxbq/y+XC/Pw8FhcXYTAYUKlUEIvFkMlkUK1W2dGgUqlY\n4iP5hIpMvV4PZrOZszmLxYJQKISbN29ic3MT4+PjOHv27PvCtJcCpN/+9rfh9XoRDAZZr2k2m9Bo\nNFhaWoLX68XFixeRTqextLSEn/3sZ0gkEnjvvffw7NkzZDIZNBoN7O3tsWWE0vpoNAqXy4VcLoft\n7W0YDAbY7XY4HA7WnMrlMhKJBDMhhUKB06dP41vf+haWlpZw8uRJTgW73S5mZ2fhdDqxtLSEsbEx\nLtKMjY1BIpFgf38fZrMZrVYLjUYDOp0OXq+XK5QCgQDHjx/HkydPsLCwwH5LWv339/chEolw7tw5\nvP3221CpVDg8PMTc3BzEYjEmJyeh1+uxvb2N3d1d3gju7Nmz2NnZQSgUgtlsxurqKsRiMbsJqPAg\nEAjQarWYZeVyOWZPtIqbzWZUKhWcPXsWlUoFDx48gFAoxMmTJ6HT6XgHzqmpKezt7WFychIPHz5E\nqVRCqVRCNpvFjRs3oFKpuEqvUChgsVhQqVRgt9vx7rvvAgDkcjn7H8mm02w2j1S5G40GWq0Wjh07\nBolEgnK5jHQ6zUUcAkTSlYcruFSssdlscDqdyOfzkMvlXPihajcBFXkICQgorU4mk9BqtZBKpUil\nUjAajWwhIpvd7u4uxsbG+DNVKhVnN8lkEna7ndNLs9mMZrPJKTvJJsOLEo0IFAqFsNvtyOfzDPjk\nKqjVaqxtUsWcgI/YnkajYT1TLpczONJnyeVyLtYBYD2VFpyftxpRFZzAmSr8AJhlCoVC/l3kgqBC\nkUQiYZ2TsoFQKIQ33ngDdrsdwHN73MOHD/H06VOUSiUuMms0GhgMBigUCi6AyuVyRCIRpFIpPn69\nXg+5XA65XH7E20r3BrFTAnWlUolkMsk2NGLY5DYpFArvu9j0UoD0Jz/5CYLBIObm5pjFEKC+9tpr\nsFgsaDabcLvdcDqdMBqNOH/+PHQ6HVQqFZxOJ7RaLbNP0kra7TZOnTqFu3fvIhAIwOv1cmGBGC+x\nMrLbUFV3a2sLk5OTbHTe2NhgjxuxA5FIhL29PT7mWCwGgUAAk8nEr6MiAJn0W60Ws2GLxcLMiVIT\nj8eDra0tOBwOXL9+HVevXoXH44HBYEC1WoVAIMD29jZEIhGcTicCgQB0Oh0cDgff4JVKBQcHBzh7\n9iy2t7c5LUokErDZbJzqz87O4tatW1zQq1QqAF4wItJ/5XI5xsbG4Ha7Ua1W2bAfjUahUqnw5MkT\nWK1W+Hw+9oB2Oh289tprvLARezk8PMSpU6eQzWZx+vRp9mR6vV7UajUEAgFkMhmk02kIBALY7XYk\nk0l4vV5otVpeJEKhEOviwPOH12q1Qq1WQ6FQMDPqdDqo1+vodDrcWEEPTiaTgdVqZdsOMRy3241Y\nLMZVXmJ0k5OTWF5exsmTJ7m46HA4kE6nYTKZoFKpsLe3B4/Hg1wuB6lUCqVSib29PZaIotEoW9yI\nwfV6Pdjtdjx8+BCzs7Os8ZnNZhweHqLX60Gj0XC1HgCDGtUEaCGm+24YyIh1DVfdCcjIXE/A3O12\nodFo+LrT5xCLJDAc9qxarVY0Gg3+bABcoKGfE2mhwhWxRZvNhomJCdhsNqjVaty9exdPnjxBLpfj\n608+b9J9qfmiXC5jf38f+/v7qNVqbKCnZ5r8ocS46bgI8Id1X7FYjEKhwPfUcEZM7xUIBLhy5cr7\nwrSXAqSUHgaDQU5HNRoN3nvvPQwGA+zs7KBer2N5eRmRSARKpRLVahVbW1tYXFxEPp9HOByG2+1m\nnVKr1cJutyMYDOJzn/scHj58iHw+zxVNp9OJp0+fcjWZUg+62RKJBGKxGJRKJbxeLxcNcrkcJBIJ\nqtUqAoEAA4nP50O9XodarUYmk+EbfGxsDPl8nnW6tbU16HQ6BuWDgwM2JzudTpTL5SMaJLEsuVyO\n7e1ttNtteL1eZrtSqRQ+nw9OpxNbW1uIRqMIh8MYHx/H7Owsp8zJZBJOpxNPnjzB2NgYIpEI1Go1\n/H4/267m5+c5pTSZTOj3+9zJlclkEI/HkcvlIJfLodPpOO0zGAyYn5/nQhGx4H6/j5/+9Kf8gJXL\nZRgMBix3HXv+AAAgAElEQVQvL6PVanHl12KxcHqdzWbhcrm46wQAF9HoAaZ0Uq1WI5FIHAGGRqOB\nUqnEHVJ0rOVymRkvfd9Op8NFNHJcSCQS1jQzmQwvjDKZjFNDOvfA8+JXOByGz+dDqVSCUqmEXq/n\n7qJ8Ps/gIRAIkEql4PP5IBQK+buGw2EA4G4+YokOhwPb29s4duwYuxWGmzwqlQrUajV3LYXDYZhM\nJu4MoutD33/YLjQMFvRzAmMADESUtlOQNkpWPoVCwZXuYamACk8kRVAtIRwOo9Pp4MSJEzh16hTG\nxsawtrbG1kZqipDJZMxyBQIBe5qbzSZSqdQR475Go4FGo+Gq/zCgDx/TsJWL/o2aKaieQcybCqLk\noaXXv18gfSnFpt/4jd9Ao9HAb/3Wb6FarWJtbQ0OhwMKhQIPHz6ETqeDQqGA0WjkVbzdbsPn82Ft\nbY1tRVRcMJlMXLklfUSj0cBoNAJ43vao1+tRLpf5RoxGo8we8vk8rly5Ap/Phzt37sDr9WJnZwcn\nT55kLykVVgqFAmZnZ1EoFPgCaTQabG9vw+VysXE5l8thfHyc2wDb7TZcLhdu3bqFK1euIBwO8+rX\n6XTgdDphMpl4cXG5XMjn85idncW7777L1i6qXKtUKmg0Gu68CYfDyOfz7Nk0GAxwuVzMNmKxGIRC\nITNxmUyGcDiMqakpBINBtoDcu3cPv/Zrv4af/OQnsNvt/OC0221+YE0mEzqdDkKhEFQqFdxuN3w+\nH6eym5ubiMfjOH78OMsIsVgMJ06cQCKRgEqlYn3q3r178Hg8Rx52qVSKZDIJs9mMWq2GXq/HnVhU\nYSXtizy3W1tbMJvNqFarnE5SQZIeNgJevV7PRQyq0qvVanY1WK1WDAYDlEoltmbpdDpeDIjJ03eg\n12q1WhSLRW7nLZVKsNvtqFQq6PV6UKlUR1od6b6h80KMkgBYp9NBr9fzeSadksDQarUimUyyRYqk\nCXIK6HQ61ldJShlO1Yl5kcRBwENARK3I9BrqyKKFja7XsKxCJn7KCLxeL4NjLBbD6uoqfD4fM04K\nSv/JlzoMdMSuqRuMLFV0nel3U/oO4IjGS6+h95GndLjVenjxo+MBgK985SvvC9NeCiPd2tpCIBDA\nV77yFezv78NoNGJnZ4dTRPIhkpGdhP4f/vCHbGVJpVKIx+OYnp4+4kt0u92QyWTw+XyIx+PMJCQS\nCaxWKw4ODjA7Owuv1wuDwYArV67g8uXL3L53/vx5yOVy7goiRkKp17Vr1xhQnU4nG90tFgucTicK\nhQIuXryIlZUVyGQyyOVyhEIhyGQyaLVaqNVqRCIRtgZR8YAAi4z36XQaCwsLaLVaMJlM2N3dRbVa\nhcvlgsVi4XNEBYpwOIx2u42pqSl8+tOfZpZeKBRgNBoxOTmJcDiMQCCAdDqNO3fuQK1WY29vj72e\nOp2ONbt8Pg+DwYBEIsGsk26+TCaDWq3GXWOdTgdbW1uw2Wy4f/8+SybZbJZdDGT/IeN5tVplW5PX\n62VNjVJxssuo1WoAYF2v1WpxcYW6vYhRmM1mhMNh2O12SKVSZubEQEkf3dvbg8/nQ7VahdFoxMHB\nAXdekVeSdHt6mMm43m63uVtrfHwch4eH0Ol0KJVKGB8fR6lU4kWbwE+hUCAUCjGjGgYHhUKBbDaL\niYkJ3L59mzV7u93OVjySLugaEIj0ej0Ui0UGX+pUIpmGNNFhzybJS6QhEvjS50qlUphMJgZ/cmSQ\n15QYKqXyw6yPUmZqQBAKhcjlcojH41wH8Pl8bL2i91GhkbIPAFxVJ2AkuWNY96T30/cb1nSH+eFw\nCyp1cNGxD2vH9BnACyD+UKf2//7v/w6NRoNf/dVfxSuvvAKHw4HZ2VnMzs7CZDLxTRiNRnH79m00\nm02cO3cOV69exfz8PGZmZjA5OYlz585BKBTi9u3bbNpOJBKw2+2IRqOcprlcLjx69AgnT57EYDDA\n8vIyr0TLy8v4u7/7O7zyyivY2NhANBpFo9HAiRMn+MbZ39+Hw+FAvV7H22+/zZ1JdGPE43GuOGez\nWZTLZczNzSEej3OqbzQaeWGQSCTw+XxcrKLOpmazCaVSiX6/j+PHj3P6UqlU8KlPfQp2ux2JRAIA\nePhIu91GKpWCSCTCq6++im63ix/84Ads48nlckilUqyJZbNZCAQCXL58GVNTU3A4HJBKpbh//z5K\npRIDTiqVgtPpRL/fR7lchlKp5B53gUAAj8cDi8XCFrVyuQyHw8E2pXA4DL/ff8RQT8WVZrOJiYmJ\nI7o1PZhCoZC1K/IEAmAg6Xa73DpMDyFZe0gD3d3dRaPRgMvlwt7eHjMv8lS63W5oNBrU63U+h1QU\npK4blUrFqTJVuKkyTllQKpXioh114KjVarRaLRweHmJmZgbBYPBIyyWB1PDxOJ1OhEIhiMViTE9P\nI5PJcDGp0WjwjIdsNsvSCB0LLTQEOiQBUDdYpVLhar/VakU2m2VpBAAXnEjfJD8vDTsZNun//CCQ\nYf1xGAyJARIzFQgE0Ov1rL2SDk0DVMhZMAzuBI4kEej1egA4MpQFeNFjPzyEZLira9jMT0SArjPZ\noX5+4Mlww8Grr776vjDtpaT2X/va19jOQTe7QqHA1NQU71ter9dRrVaZuUQiEV4xrFYr60DNZhM+\nnw8ikQjVahX7+/s4e/Ysnj59irm5OdYxKVXSarUol8tYXV2FzWbj4QlOpxO7u7tclEgmk2g0GnC7\n3ZiZmTmikanValgsFrY5LS0twel0QqVSIR6Pw263w2Qy4ebNm7h8+TI6nQ6CwSBarRa/j1inUqlk\nkb9cLsPlcvGqTmyq2+0iHA5zJVomk+H8+fPY29tDvV6HVqtFu91mHTQcDkOv10Ov18Pr9eLevXuY\nnp5mQMzlcmg0Guzdm5+fZ2ZL3UWxWAxj/9GkYLVaIRQKEYvF2DdL5nAaaqHVarGysgK3283955ub\nm5iZmcFgMEA8Hsfc3Bz6/T4ePXqEQCAApVKJfD7PTIoYEbFoAjkCWJpMNQyuQqEQqVSKWeLExARy\nuRzq9Tozd+o2Iq2aAID63Um+GQyeTwmj8+N0OpFIJLgKTA8r2X3ooSYmXSgUuLuL9GDSUamFc3jw\nCAFOo9HgTioCGuB5b//e3h5qtRpsNhsqlQpMJhNLUmazmU3ypFtSIZWaN2ihoYUJeLFVNdmiSDoj\nuaFarTKYEchScY6AiaxNlIJT7zzduwTswwb/4VZTAqvh3vxhvRUAd4DR4jSsXVIMgzldI/pcIgVk\npaPX0uvpPQCOMOthcP6DP/iD94VpL61qr1arYbPZsLq6ik996lMAgM3NTRweHuLx48fY29tDqVTi\n1NZms8Hj8cBsNsNut6NcLrMNQ6fTweVyAQCmp6extbWF1157DQcHBwCAbDbLVe6nT59Cq9XCaDTC\n5/Nhe3ubJwJFo1H0ej1cunQJZrMZU1NTiMVikEgkWF5ext7eHmKxGLRaLf7+7/8eS0tLPH2Iil3x\neBxutxvRaJQZ5Pz8PPb29iAWi2E0Gnmlp37/ixcvQiKR4MSJE8hms/xzMjGTX9Hn8yGTybD0QOZv\nu92O7e1tHuJCgnogEMCTJ0/4JlpdXcX09DQikQh0Oh0/3NSocHh4iFgshk6nA5/Ph1QqxQ99LBbj\nQs3CwgKq1SpbfWi60smTJ4/4B8+fP882E5lMxoW06elprKyscAcMVYMVCgXkcjmzRRp7SCyVQJQe\ncmJH1JlD+igBLDUC5HI5fj0N3iCga7fbfBwymYz9oMQuaQEl6YdYDQEHAQv1jpP+Go/H0e/3YTab\nkc1moVQqEQ6Huefe6XRif38fPp+PP5sY4ebmJssQVLyRyWQ8Q8Hr9TKADtupCPDIKkRsr9VqQa/X\ncwcXnY/hFlVaSCj91ev1DKLU9UQASdoopcX0b3Q8lCkMz1IgYKJjJCAdLm6RRknOCzoGyqaGU31i\nr8RkgRdNBsR26XNoIaQMk95Pv5PYNfCCzVLzxdWrV98Xpr0UIF1fX0elUkE4HMZHP/pRfOc730G3\n28X09DRmZmYQCARgs9k4HaLOJbLVhEIheL1eOBwONJtNlMtlrK+vI5vNwuPxoN/v47333uObSalU\nIpVKoVgswmazMZBVKhXo9XrMzc1xZ4jdbsedO3d4dF48HgcA/MIv/AIMBgMbjq1WK44fP47t7W1M\nTU0xY0smkwgEAohEIjAajdje3oZWq+Ub12w2Y2lpiSvsHo8Ht2/fRrfbRTweRyKR4GlRxLLJ+mGx\nWJiZyeVyTExMcDFjamoKuVyOq8hkAXK5XBAIBFzY+PSnP4379+/zXM2pqSn+TvV6HceOHeOHl6QF\n8ucVi0XuGKM2PpfLxRX/w8NDyOVy9rw2m00sLS2xXYu6mQqFAk6dOoVWq8UOinK5zN+ZPMFkayNg\nlkqlbK+ih5oAjVhfNptltkypMXW/ERshpktpXblc5kIOFXxIgyRdkrpoSBumCVtkzi8UCsyAqcBI\nzo14PM4tsQTw1DlGLZOxWAxOp5O/O90b8XgcoVAIly5dQrFY5DGQu7u73IxCYEIgQM8EpeLUJDIY\nDHj6FkkXpKfSeR8MBmy9o/uPLELtdpvPLTFLStfp3FIRi6xlxHaJuQ+DITFGAjHKcGj2LJ13AMwy\nhwtcP+8aoN9HrJoWGzoe4D9rqsCLsYEE2u12mxejD/UYvZ/+9Kfo9XpwOBxYX1/Hm2++iWw2i6Wl\nJRSLRTSbTVSrVW7bA8BdIVT1JW2H/KTUQ/748WNO/bvdLnK5HE/pGRsb4xVaKBTC6XSi0+mw7eX4\n8ePMOPV6PSwWC65duwaBQIAnT56wLkmgSBXT/f19JJNJDAYDGI1G7O7ucv+zQqFg/9/KygpKpRK3\nFk5OTqJWq2FsbAwHBwcQi8U4duwYer0eXC4XJicnmblIpVIEg0E0Gg3Y7XY0m02sra1BJpNhc3MT\nU1NTqNVqcLlcaDabcDgcuH37NrdDZrNZLC4u8pSqqakpHv1HgJzP5wE8v9kePnwIjUbDHSUEylqt\nFg6HAxsbG5icnMTdu3e5s4iq1jQKUKvVwuVyIRgMwmKxwOfzodvtwmg0IhaLsQmfxiISMyS2Qo0W\npVIJKpWKu8X6/T4MBgM/aJSmkqVpamoKxWIRGo0GkUiEp3r1+32WVsh/SSyFFg3ySxLDJBYF4EgP\nOkkalDaWy2Xo9XpO5WkBIsuV0WhkZk36dbfbxcbGBk6ePMk+SnIR+P1+7O/vswRB35+OgxZLGsFH\nC8Sw6dxgMKDVarHbwmAw4NmzZzyTlM6JUPh8ePWrr77KtQUA3JhAxSNiuATQ9LuoMASAZ5aS3EGL\n0c9X1AmAiaHSe6VSKaxWK7P84fM/DKKUCQDgRZVcGJlMBgD4OtA1JYZM7xnWUom90rmmwfMf6mLT\nj370I654UnpKvejhcBiFQgEOhwNerxfJZJJ7uGOxGNxuNw8EoVTLarViZmYGP/3pT3nSEz08BDoi\n0fO5hMlkkjWXSqXCehxNQSc/JK3YhUIBmUwGZ86cwZkzZzA/Pw+NRsMm4OnpaZ4ZSrYtAhVKc8jE\nH4lEMDc3xx5AlUrFcz8vX76McDgMiUSCSCSC3d1dPHv2DMFgECaTieeXks5TLBbxS7/0S7hz5w6m\np6fx/e9/n0evUYcTSQV2ux2lUgljY2NYWVmBwWBAKpViYzbZm8hyNjU1Ba/XC4/HA5/Px949moQl\nEol4RoLdbofFYkEkEkGz2eTzIxKJ8MMf/hDj4+MYHx/H6uoqLwKpVIrlBmILjUaDHRD08FMHzPj4\nOACwHNFqtRAKhViaoLSd2Abp69QBNdw2STYh0gkNBgOazSZPUKc02WAwHBljN1y1JieHVCpFo9Hg\nATsOhwMAmLHT+D6NRsOkoFwu80KiVCr5syilJpY9DDA0RpEyKhr7R2k8LZb9fp8n9JMUEo/HodVq\n+RwolUpoNBqeOGWxWJDP52Gz2XhYB1mX6JhEIhFyudwRKYHmDxBYEiOkYiMxUTp/w4yR3kOskBZD\nhULBWi5V5kkvpvv+561OtHhQFpHJZI4MzCZZYFhCINCnz6CshRbTYe348uXL7wvTXgqQhkIhBINB\nuFwu1qGMRiPcbjfOnDkDmUyGu3fvMhCWy2UemEFzTJvNJvL5PNLpNFQqFTY3N3Hq1Cn0+30uFkil\nUigUCiSTSSSTSR6I2263US6X+aGkdJSm45ONIxQKIRqN4tGjR2g2m4jH47hz5w5raTSKzeFwcG+u\nQCDgB2t7ext6vZ59rseOHYPFYuGHjtJwqq5Go1HodDp0Oh0EAgFemaVSKRu1LRYLjEYjF7M0Gg0k\nEgnOnj0LjUbDemQ2m4VIJOLtVmgK0/r6Ok6dOoWZmRnI5XI8fvwYKysrPGKw1+vxNCrqIAmHwwiF\nQjh27BgPoaZdB6jIQQ/Y0tISM55Lly6hWq0im82yp5S6miqVCneykDGe2lEtFgvkcjlKpRIajQa2\ntrZQLBahVCqZ8Q17KAuFAj8oxKBKpRIEAgE/nFtbW2y0pzSVHupGo3FkmxaqardaLWbJVIWmQcTk\nCKEBxCKRCAaDAQ8ePIDX62WGSR1CQqGQGwMmJye5W42uPxUxV1ZWWAagSUqVSoW/f6VSYSZOffxU\nfaaUmFiwy+U6Ml/AYDBgb28Pcrmc/Z1UlKKFnvRLAlCSO6iaTzILFSWJmRLQkTY5LDfQ/4kNDtvK\niPmRv5syDjrHw+yYdNFh6xNZyCh7oWMiuWG4w2m4EEUASh5l6mqiohq97v1W7V8KkN6+fRv5fB67\nu7sIBALw+/0IBoO4fv069vb2AADj4+M8riuVSnERiXyC1WoVx48f50nWZM5WKBSQyWR80y0vL2N2\ndhanT59GJBKBUCiEyWTCsWPHIJfLEQ6H4XA42A9ZrVaxu7sLl8vFFfiJiQneamF+fh63b9+GyWTC\nJz/5SdaixGIxnjx5Aq/Xi/X1dUxPT8NoNHKleHt7G36/H0tLSwgGg9x3HQwGWau0Wq2ckh4cHEAo\nFOLq1avodrvw+/2clpdKJezt7aHVanFamMvlIJPJ+JhpCw2Xy4W1tTXW3xYWFrC5uYlgMIj9/X2c\nP38ely5d4v72U6dOsd4YCoUgFArh9Xrh8/mwurqKcrnM+1+RNlksFuF0OqHT6bhbiwY8t9tt9vnK\n5XK2O9ECRDezTCbD+vo6isUiT/CndIyYaLFYhFAo5JmUMpkMGo2Gu66kUinPSCD2u7u7C4/Hg2Aw\niKmpKbZ/Eetot9u8txV5PYl9EjMjbykxLkrvaYIR+W8BcMtlMpnExMTEES232+0iFovh9OnTiMfj\nmJiY4NZXAjoCe/JRi8XPp/4TaNPoRgJTmstqMBi4jiCVSlEulzllpQKoQqFAtVrle4HOp16vRyqV\nYkAntk2LDrFHnU7H2R1lXcPFuGGQGnYGkEOBzs+wlktaPJ1vYpn0mRTD3tDhAhHpoTRbmJwLw/an\nYRcBMWCqG5A2DuA/sdEPfWr//e9/H8ePH8eFCxfw9OlTRCIRbpGTy+WYnp7m1Hh/fx+XL19GKBTi\nrhSj0Yjx8XGeWUg90GazmaUAWsECgQAqlQrW19d5e4tCoYBQKMS2qvn5ee4majabmJmZQbvdxtzc\nHG9IR62VTqcTLpeL9aZ0Oo2JiQn0ej0efmG1Wtm/ePPmTczPz/OmasMDMoit2mw2PH78mPcE2tnZ\nwYULF1AqlfDo0SOk02k8evSI9ePJyUk+V8PVdPp3AJx2DgaDI50usVgMg8EA09PTbDBfWlrC/v4+\nD4FZWlpCp9PB/Pw8BILnw5xpOhBpjBaLBV6vF41GAwsLC+wiIOZBI+5I65TL5Uin07Db7Zy2Enum\n6jxVxIezAnrACBgAwOfzweVycaEplUrxzgP0ENL3jsfjDLQCwfMpUrFYjFsSychPoEoyAbFBsvc0\nm03+DAJYkk3y+TwDUjQaxbFjx5DNZlljpYKpUCjk9thms8mfSRsXUpZFuy6QJEN2M7Kv0TUmjyVZ\nzoaLNgD4810uFzM5+mwA7GKgAg8VYckNQ9IGdQaSHEBuCALx4QIOHRcxVMqKCOCGK/NKpZI/j/RP\n0k0p6PzRn+mzJRIJ68nksKCusWEwBF6MCmy32zwshr778DHT+wjAP/RAury8jGg0ilQqxYDncDjg\n8/kwPT2NH//4x3j48CEuXrzIfzcajaz5hEIhvnH8fj98Ph/u37+Pfr/PAzpIx2m1WpwiEmBqtVqI\nRCLMz89zW2Emk+G0jW5Y6lJ555132DAtlUrx6NEjmM1mHo1GHjySDqLRKF577TUuktDYLwA8t5Gs\nLxsbGxAIng+T6Pf7MBqNcLlcePbsGQ92OHfuHC8Yy8vLSKVSPB1Hp9PhwoUL2N7ehkwmw+uvv45o\nNAqtVovFxUUcHBzw1Jzl5WVcvHgRFy5cQDKZZPYbi8XgcrngdDpx6dIlHDt2DBqNBsvLy9ycUKlU\n4PV6sbe3h8Hg+SZmRqORC2fj4+MYDAbY2triOZ40JpHmCNDAZrLjkDYXDAb5YSSz+rBVRiQScYWa\nhp7QcWi1Wp7DSt1hNJmf+utJFyWPKIE2MSYa/ELshK49FVHIkE9WMLKXtVot9gPT9jWDwYAr5OTH\ndbvdEAgEvOEeLUjNZhMWi4UlAyqCEVjSKD7qlKLzQMBD7goCRplMxhvVDU/Xr9frvBEhnR9qt6Ui\nbrfbRTabxalTp3BwcMBb3lDbJgEYbQVEwDM8+5RmAJAEQNIJ8MI/S1kGfSbwgnm2Wi3YbDYe1kMA\nOFyhB8AaLMlXarUa5XIZ9XodMpmM9wyjhb3VarH7gOobwwBKKf2wvYv+7UMNpHfu3IHZbMazZ89w\n4cIFBqNkMomVlRXodDqcO3cOyWSSWRJtULWwsACXywWz2Qyr1YrV1VUkk0mM/cdeMCTIU2q1trYG\ntVrNKyh1DwkEAsTjcRweHvI8U6rY22w2bG1tYW1tDWfOnOE5pF6vlwcqUwXV6/UyC3n69CkWFhZ4\nCAZNcScNhh7a2dlZ7uEmO4rf70c2m+ULT0NRhEIhT3Sy2Wys2USjUaTTaeh0Oty6dQsymQyPHj0C\n8PxGowEtT58+RavVgsPhwNjYGP7xH//xyG6hVDWmrViuX7+Og4MDHBwc8JCMaDR6RDukBWVpaYnP\naTAYhNPpZL8uWXVIr6ICis/ng9Fo5AIJgZzH42E/7s8brElLbLfbqFarvF+SwWCAUCjkRYH8tqSP\naTQa7tGnYgSNFRz2MlK6R+wXAJvTqT++3+8faRSgij8tglRAIv112Cw/3EBgNBp5QhLwHESq1SoA\nsOuDBnTQdiGUntLQYhruQSBJKS09I8R2iaU3m02eekUdTvQ5NEWpUChgZmaG9zijXUvpd1ObKIHQ\nsEmeNGS61rRAEdGgCjul+3QuKIanV1GDws8XiAhYyXNLe7lRFkZzLarVKorFIr+HNHxyTRBoDrNR\nCvoddC0GgwE+8pGPvC9MeylAeuvWLXg8Hrzyyiv4xje+gbNnz3KVNp/P4/Tp0wgGgwxaFy9eRDwe\nx2uvvYZ4PI733nuPvW60pQZVEI1GI8Ti53s+UbVSo9EwiyMAEwqF0Gq1cDqd3D1x+B9bIK+uruLK\nlSu8ud5g8HyauU6nw8HBAT/4wztJlkolnvLz8OFDBINBAMDi4iK2trbY4kTtqmQuJ0Y6NzeHYrGI\nXC4Hg8GAf/u3f4PT6cTNmzdhNpuRyWRQLpdx584dGI1GLCwswGQy8aDjxcVFvP7661Cr1RAIBBgf\nH4fZbEYgEEAymUQkEkGr1cLp06eRTqchkUjg9/tx8uRJRKNR7qIi9jQ7O4tLly7h3Xffxfz8PO/1\nTvvC09Ql0mKFQiFb08iNQeMFqRAzGAwQDoexsrIChULBXVt0zGRjo/RKLpczAyIvscFgwNzcHDwe\nDzKZDBKJBKxWK2cftNMm8KIFkzTcYDDIW9EQYxkuYNDDS1u3jP3H3l20wydN70+n03A6ncxARSIR\nHyfNyozH47y9NO3V1G63eVwgDc4gfT0ej8NisTBQUYsoAV6n02EApc4lAtBcLgcADCp+v5+BNJ/P\n81DsWq2GRCIBh8NxxFNL7JfsVvT51WqVmTMZ7gnce70ezzugjIwWMbrmVDUnNkpEAniRSg/7Q6mu\nQWk38MIqBYDPmVwuRy6Xw2DwfHv2dDqNZDLJiwtlQQD4GSEWP9zRReBNWc9wQQrA/6sW0ZcCpPfu\n3cOzZ89w8+ZN/OZv/ibi8Tj3ZLvdbqysrODq1atcrS6VSpibm8M3v/lNqNVqfP7zn8fKygpXEA8P\nD+F2uzklox7zdrvN/e80CYc2dcvlcigWi4jFYjAYDNje3uauI9pJkyYrGQwGbiWlm5oGgVCnDg1c\nSSaTOHfuHF/AWCzGqbPBYGBT+8zMDLfPCQQC7O7uolwu8xzVyclJPHnyBL/7u7/LQ4K1Wi0uX77M\nTgdqGPD7/YjH47h79y4ODw9x/PhxtFot3LlzB1NTU6wrNxoNNjofHBxAq9ViaWmJq/G3bt1iUNrY\n2MDW1hauXbsGg8GARqPB/lHyhxL7djgcmJyc5MWJpuHncjkUCgWeMZrL5eB0OjE2NsYTkkQiEU+t\noqn6xBhoiAtVpSltpIYOhUIBj8cDpVLJ3kYqUFLqToySAJR2CaXUkhgX6W40vZ2ym+PHj6NcLgMA\n35/b29tssUsmk1ygIcAHcGQs23C3FbHuYYM/dd6QXWpycpLnHlDqTGkquVHo+9E242TvowYH6gps\nNpuc0lssFgYQOsf0dyrQarVaHp1IaThJG1TgI/sSzSRIJBKYmppCPp/n0XdSqZRbb0kSIJCidBoA\nV9uB5x1qxCYJrGmxo0lnh4eHAID5+Xk0Gg08fvwYDoeDu9yazSYajQbvDkoVePqP2DGBJ/BCWqDM\ngbTtD33V/saNG4jFYvjc5z6HZDKJ5eVlrK6u4vXXX+e2sH/5l3/BYDDAtWvXYDQakcvlcOHCBaTT\naeemE1cAACAASURBVFy/fp2tTjs7O/jiF7+I3d1dToWFQiHrTDSEVqfTQSp9vgspVUZpnyCasEM3\nFI0Mq9fr7CygVkuR6PluocvLywiHw3wRDAYDAoEAVyKpCENm70QigVQqxfv70IMKPL+AXq8XxWIR\nS0tL7D9tt9t4/PgxZDIZpqenUalUsLa2hlqtxtJEPp/HysoKWq0WXnnlFdTrddy+fZsLMtvb2zg8\nPMTi4iJu3LiBRCKBj3zkI2g2m7hx4wbMZjNisRi++MUv4tixY0gmkzz5iQZcb29vs+WJ9pJPp9M8\n+ajX62FlZYUN1KQN2mw25PN5BltazKiIRIyJpmhNTExw80SlUjkyi5QKPwTo/X4fGxsbePz4MTY3\nN1mLA15stzHMpMiiJRKJkMlkuMo9XAEeZjRUYCIf8sbGBk6dOsVsiDzONpuNO7aMRiMXc6iwRxOy\nhodkECCRz5X+LxQKUSqVoFAoeH8wAEdm5wI4Ml+VtjEhtwC1N1LlnDI96vRxuVzY2dnhiWX0bDUa\njSNdSGRwH96njApHNCmfFijg+V5gpFMSYNLCR8/X8NQmmvRP4K/RaPDgwQOcPn2aHRs6nQ42mw0H\nBwfY399HNpvF5cuXUSqVsLKyAqFQiMnJSZ6nQPtd0T1ELPTngXS46QN44SsFXoAqseAPNZDevHkT\nr732Gm7dusUg8sYbb+C73/0ulpeXMTU1hRMnTiAQCKBcLuN73/seF22i0SjOnTvH2+QuLCzgr//6\nr3l7EODojUcrGq1w+XwehUKBX9PpdPDkyROcOXOGK+20RTB5C4PBIMbHx9HpdBCNRlGr1aDT6Xhg\nyMHBAZrNJra2triwAzzfm50qu5TaWiwW7O7uwmAwMHugTfekUilOnz6NarWK5eVlnq4EgFPp06dP\nIxqNMruhAkMul8P8/Dw6nQ78fj/W1tawvr4Oj8eDY8eOoVar4fjx45iensbu7i56veezNK9cuYJH\njx4hk8ngn//5nzExMcHT+8nkTbuF+v1+6PV67jYKBAKIRqO8UdqJEyd4GhUNi1EoFCw//F/Mfddz\nW/eZ9gOwVwBEBwEQhWAvIilKlGRVx92Jk73IJld7l8n9/hP7D+xmc7U7mzKbeG0njuPYciJZtkRJ\nFHsnUUgQIBoBEATATpDfBf28PvR8F7mLOOOZSJEoAjjnd973qaygWFhYQCAQkMOAlsjDw0NEo1HJ\njaU8hdo+EjFMeXI6nejv7xc3GEkbTjwsJKTcSqvVynRcUVEhf5YwAskOBkLzgFKpVHL4HR4eIhgM\noru7G8+fP8frr7+OZ8+e4Z133sFf/vIXeDwe0UbyMCF+ycNSpVJJrmldXZ04zyiDMpvNgkly/edk\nBXwbiMIkKW4bZN45QXL1VuYKsFiQAnhW0BgMhgsyJdpq2X+ldDLxM+FU6vF4MD4+jrq6OjQ1NUm9\njNVqxdraGtra2hCNRmWaZWh5Y2OjYM9lZWWSWAVACEBWvPT09MDpdOL58+c4PT2Fz+eT0kaaDzjp\nKy2rvM/5pZRUKZ1NSu2sMknrpcZInz9/LqRCPp/H8PAw5ubm0NXVBb1eL33yn376KQCgr68PtbW1\nGB0dhdFohNVqlai1p0+fYmRkRCo96uvrL+jCuAIR92E4bXl5uVRdcLVknNnZ2Rl6e3uxsLAgjDVX\no8XFRVl9M5kMBgcHsbu7i5aWFnFozc/PX2A5qX3d29vD5OSkZHJWV1cjkUggFApJ/QhvmIGBAUmw\nz2azMv3s7e3BYrEgEonA5XLBYDCgu7sbyWQS8XhcbtjGxkZ0dHRgenoaS0tLqKqqgsFgwOeffy6S\nmNraWiwsLAi23NHRgZ2dHTidTjkEGZPHiYP96m63G1tbW9jZ2ZHqlXg8jv39fdTX18NkMgkTTr0h\n19WOjg7JjGU2JB94vNEIX/D9IJZJaU6hUEAsFkMwGJSQbKPRKDGFJGtoG6Vrjm4eZitQdwmcs8aJ\nREI2lvr6eqnepuSLUITT6RRPezQahdvtltdC8oPFfFy9qSag9pL4KTWyu7u7cj1xKlN693ko8zAg\nGchpjJpNklzsqlKGdRCaohOsWCwKZqj0tnMLoFCdWlk6xXgdcCKmMaFQKGB8fBx9fX0yqTNYh5pW\nOgIbGxuxs7MjjrCqqirs7OyIxrSurk4MC+l0GpOTk+jv74fZbMb9+/dlazQajZLGxfsegMAWygcQ\n33clM6+8vvjF4ev69et/15n2DzlIf/e732F5eVlcBZ9++inOzs5TjihlYHgDY8kCgQDu3buH+vp6\nBAIBCfZQq9XyxDs6OkJ3dzcCgYBITGw2m9wQZEs5rVKwTV+6zWaDzWbD1taWJE2Njo7CZrNJ/qbP\n54PT6UR7ezvOzs6j7uLxOBYWFtDe3i4iZuKpfLJzpR8eHpb0ekb79fT0oLW1VZKukskk5ufnJfFf\np9Ohra1NLjDGoSWTSaRSKczMzECv14tO8unTp0in0ygvP+/AqqmpkR52RgYqHUImkwmbm5tobW2F\ny+XCX//6V4nMu3z5Mra3t1EqleRgODs7QzAYhFqthslkEnyQFSWM3aPLjJMOrXj0yh8eHiKbzV6o\nIub0k0qlpMOeUzmVD9XV1dja2oLVakV/fz8sFovcDIyuowOIE391dbWI3LVarQR1s6uIyUtutxur\nq6toa2tDNpuVZgabzSamDdqSNzY2RPLDWhvqPqlXpTuKr4lTIA/VbDYLj8cjOD7T4QEIkUNSqLy8\nHIFAADabDalUSiY6vm5CFFzzlYEklI5ZLBb5uanfpZ2ajQTMEaXqhE40QlaEDah7ZgtnNptFXV0d\nTCYT1r8pS2T31v7+vmQqsI+KEy9XcH7eZM8PDg4EWmhqaoLD4cDx8THi8TgaGxvFqMH3iA8MGi6U\n2DS/uNYTO1eSXfz/lBP4Sx1a8vDhQ6jVatjtdoTDYfz0pz+9gGsuLy9Dq9XCZDJBq9XC7/fD4XBI\nYC9lTYwXY9LQzZs38ejRI5jNZvT19WFxcRHLy8tobGxEbW0t9vf3sb+/D4fDIUQUcN4RNDg4iKmp\nKbkI3G43nj9/Lv7ySCSC999/H8ViEVarFf/xH/+BH/7wh4hEIhgaGsL6+rpMYwzeLZVK0j8EnD8M\nampqEAwGcXp6KjrR+fl51NXVYWxsDMfHx+jo6MDe3h7cbreQE5lMRg4xTrMNDQ3StGi321FdXY25\nuTkMDQ3JRX///n20tbWhra0N77//Pmw2mwSSZDIZwc64bv33f/+31F+n02ns7e1hdnYWfr8fLS0t\nElpBSdru7q6YCugWiUQiAo+cnp7KA0+tVotaYWdnRwrjCoWC1LQkEgmk02nU19fD4/GIUJ14KYXV\nXq8X2WwWwWAQ4XBYpFTKgAz+R9yOkx0DSTiV8O+Q6a2rq8PKyoqYJlKpFMbHxwUD5lZDbe67776L\nhYUFvPfee5iYmEBdXZ2QMCzJo3MJ+HalLCsrQ6FQQENDg+CN+XxeDjGumdRFWiwW0eBubW1Bq9UK\ndsxMWrqT9vf3pYCRA0QwGBS5HuVQDEyOx+PSFkD9L8kzq9UqWlUefjxw2UJgMpkE86yoqEAikZDD\nm1pmQkV0HnGg4cHH94Ov22g0ivQKgJBsdLNFo1H57JQSKhJzPJD5byjlTtxKlQcpNxlKEPf391/u\nFtHp6Wk0NTXB4/GgsrISv/zlL9HR0SGe7n/6p39CMpmEWn0eGdfY2Cg3is/nw+TkJGpqamC326HV\nakWj+Pz5c2llJNHAYi3iJhRTU5JitVqxtbUlT2+bzSbs87Nnz9DR0SE41nvvvYfp6WlJGm9tbcXo\n6Kg0kTJdKZPJYGtrC6en56HJyWQS5eXlCAaDaG9vx8HBAXQ6HdbX13F6eio33MjICCKRCLa3t+Hx\neKDX6zE5OSlQAgkxi8UikwahkUAgIAHZLpdLWO22tjbs7+/jL3/5C+7du4dCoYCjoyOZvunx7+3t\nlUQopgvdvn0bW1tbuHr1qhwu9MHTdeP1elEsFjE5OYm1tTVRCLBhlNUlarVaiCkGSrN6hQcNNxJO\n/ZS1sUaFq/Ph4SHq6+vls+/q6sLZ2XlgxfT0NPb29qRBVum33tnZEWcW8wCIk5Og0ul0kuD1/e9/\nH/F4HOXl5RKbSGY6Fovh6OgIHo9HMHJmxVIWRl0lJUbUuQKQJH5Ol1arFfl8HuXl5RLPB0CyQrPZ\nrBTvGQwGMUHwQcj/lHggCTf+O/SkJxIJOXBTqZSQRCMjI4hGo4Kz8sFBF1GhUBD5Eg8uRhW63W6E\nw2HYbDaBJl5//XV8+eWXsk3RsqocaggfMLmJv1dRUSH2WXaZJRIJUTnwPNDr9aiurpaHzXfbFoD/\nf2gzcBEC4KHKABkSgy81RvrgwQN0dHTgz3/+M7a3t/Gv//qv+PLLL6HX62E0GuH3+4UIaGhokJWs\npqYGo6OjaGtrg91ux9zcHE5PTyUZ3W63Ix6Pi8OFnvXu7m4Eg0GRivCm4ZOPFyFTzguFAux2u+hF\nGfdG50llZaXAAnq9Hi6XC8vLy7BYLFKt29TUhMrKSvz+97/HO++8g+3tbdHl0aNNZ0ZbWxtqa2tx\n//59eL1etLe3IxKJyCrGjFP2K5WXl2NlZQUnJydoaWnBn/70Jwl46ezsxC9+8Qvcu3dPuqHKyspw\n9+5dnJycwG634/r16xIVuL6+jhs3biAej6NYLMoBplKpMD4+jlu3bmFychLb29toaWmRqZei85WV\nFZSXn9d3dHZ2Yn9/H4lEQmRIZrP5ArGnXDP52a2urqKurg4GgwE1NTUiIk+n04JNa7VaYYGrqqqw\nvLyMpqYmCZ3mtMtOK2XoxtnZt5mqlL1wba+qqpKADx6ENGkwkUqn02FtbQ25XA4ul0uwbLqqJiYm\noNPppGqF1wu3G2qdOYXlcjnBGjlJsmOLNTtscOWKTgxSmYjPyZsKCLZykvVnfitrYPx+P1Sq87jI\nYDAIt9uNZ8+e4c0338TBwQGePXt2obvK4XDINM+NgJ8BXU08bPl+UgtsMBjw9ddfo6urS6rS+XdI\n0rKbXqnbVEIt5D3C4TA6OjokWpOqFR7MDGRXkmVKl9J3CSalwkNZ1cLJl2QdgJfb2fSrX/0KDx48\nwFtvvYVLly5hdHQUlZWV6OnpQTqdlkONNrCTkxN4PB5prKQdUqfTIRqN4vr169jb2xMXE+UhdFaw\nFZQX4fb2NnK5HLq6uuD3+1FTU4PGxkZZBYmRspgvl8vJAUstHovh6GpivmQsFkNLS4t82KwQzmQy\n+MEPfiBrL0OAaW/c3d3FrVu3kMvlEIlE8Pz5c1RWVsqqHovFkEwmsbCwAJVKhddee01S7QcHB5FM\nJhGJRHD16lVpCj04OEAikYBWq8Xc3BwsFgvW19exuLiIcDiMhw8foqysDIFAALOzs8jn81hbW5On\n/uHhoUAXfNhUV1cLXsx+LI1Gg7KyMsRiMVnTlR5zsthk309Pz3ug6JBhVQylZ0tLSxI+w5tNSRAA\nkFBvircJOZAp39nZEXUDQ1Y4BXJ9Y+Qifz5OKlRT5HI5if2jWoCYLa/L6upqCRXZ39+XEB2XyyXX\nEsvvAMBkMiEajaK1tVXMBz6fD3Nzc5K9y+lIKT9iewCnLk7dOzs7kr3LLYTNE2TC19fXRedL2zJL\nDZVZorW1tSJMpwGAWlDisJxCAUhyGgNuXnnlFUQiEWn7HRwcFLxVmdbP+zKfz0t1jkqlkuwJZVvr\n7u4urFYrGhsb0dbWBo1GI4f98fGxMP7Kw5GDAPBt6pNy1WfOKif0nZ0d0SErU/1feovowsIC3n77\nbaysrODFixfSszQ+Pi5P8sbGRhweHmJzcxPDw8MYHR3F0dERAoEAhoaGsLq6isPDQ/T29uL4+BhP\nnz6FxWKB1WqVWuBAIIArV64gGo0K48npg1F3TLKPRqNwuVwXmFbaEolntbW1yQ1NNthut4sdcXt7\nW/RxfX19IpPih5hMJtHa2oqVlRUJnXU4HHj+/DlcLhfGx8flALt+/TrMZvMF4XNfXx9u3boFl8sl\nNRfLy8vY2tqSyYQXzb//+79jeHhYoJHy8vMK6ra2NrmB3nrrLXR3d2N/fx+dnZ0iqj47O0M8HofP\n55MVlbXDgUAAkUgEW1tbwqDHYjHx7TMEmt1XlCHxpuOBx+ZU6iopgiZMwo4qEhicfo6Pj6V8kPIW\n3ixc/Zl+bzabJbOUWC3dVPT5b25uCqZJlxFDsNfW1oQ8icfjuHTpkqT5F4tFdHV1QaU6j03kxMkt\nh9MyN6OysjJ0d3dj/ZsWAR7gvDYzmYxMxXSyMUGLualUIhCjJvautLnSyadc9Q8OzuvJt7a2sLS0\nBKPRiJ6eHmxvb4sgnsRvMBgUC7UyNq++vh65XE7eJ0IIdCMxqpF/jmFBPOC4KhOz3draEiafh3Q0\nGsXc3JxU11DPW1lZKc29TPvnNUEjBfBt8DO/vmu4IExBXe/u7q5sAt+1hvLrpT5IP/74Y8EhTk5O\n8L3vfU9YYIYT037Z19cHlUqFcDiM6upqSbEPBAJ47bXXEI1GMT09jcHBQZlgiUMBkDWfuFo6nZZ2\nzK2tLWlt1Gg0Up3c398vkiGKe2kH1Gg0CIVC8hRdW1uDTqcTCyP9xIlEAk1NTaJAaGxslH6oGzdu\nXMDS0uk02traMDExAaPRiFgshnw+L4yo2+1GPB7H5OQkkskkAoEAYrEY0uk03nzzTZyennfsMAC4\noaEB169fRzAYxODgIPx+P+rq6kTCtLKyArVajenpaSQSCbkg8/k8+vr6oNfrJWS5qakJoVAI0WhU\nPOsAxFTAqmaXywUAglvyvaPHWRl0zUR5OomId9XW1koMIAv1TCYTjEajGCrMZrOQLDy8OVmyHI6B\nwrRqFotFyTug0J6aw+3tbTgcDkSjUdTX10s/ESEg4uFKN5zdbkcmkxHSk0HQZNGV5YEMw0mn03C7\n3djc3ITD4ZADfG9vT7SrVqsVMzMzaG1txdbWFpqamsSYQFKOUxqhC+qZlYcofzZCY2TEL1++jNXV\nVYyMjMjDl4c1GyZWV1dhMBjEnMA6GX4pXVac6plTwAeScpJW5v4eHx/LZ8QMWU7DpVJJtMosgFQO\nBmq1WpKxWltbRbpFvJ24rpJ0UiaBcfsBIJkEhJn4M3zX239ycoI7d+78XWfaP+QgJftO15DVar2g\n5VKrz/uPnE4n9vb28OzZM9y+fRulUkmyN998802Ew2FMTEygpaVFJjLiTDU1NdDpdJiYmBDCiSJr\n5SGRz+eFUBkbG5OJze/3i8Ti8ePHGB4elpBoaiMZ/swkKD4ceIOQGCFu1t3djc7OTnzwwQcitqcv\neHd3V0TUfX192N/fRzwex1tvvYXPP/8cGo0GN2/elA543gAnJyfY399HX18ftFotIpEI7t+/L4zz\ngwcPcPfuXYTDYfz1r3+VgI2TkxO43W50dnbi9PQ85xSAMKxarRYajQaTk5OS11lfXy8XNg9FylWY\njcnDlaL97e1tqcnmg0a5UjOtK5/PIxaLCR64u7srhB1/vb+/L9MgVR6cfolbFotFSXkiwVNfX49U\nKgWHwyFKAa74ACSkxu12C0lJAoIdVSaTSa6Z4+NjjI6Oorm5GYlEAj09PTg6OpKHW29vL9bX16WK\nJJfLoVgsorW1VezMzKHd29tDW1sbUqmUTOS8zu12u3jtmXFQVlaGZDKJ4eHhCzDJ4eEh2tvbkc/n\nMTs7K3ABX2tnZyf29vbE7sr3pFQqiXsLwIVJnYcka7TpcALOJ3xiwBwaKAOjNpfr8/r6Opqbm9HU\n1CRGF6/Xi7a2NhSLRSG7mDOwu7srxBadT16vV4wHS0tL2N7ehslkkuufGw3PEOVUybBntssqDTrK\nCEBO9iSd1Gr1y32Q/va3vxXtpN/vF4y0rq5OVoyTkxO88sor+OKLLwT3TKfTWF9fR0tLC+rq6vD4\n8WPcuHFDcicZKNHQ0IDd3V3k83nYbDYYDAYEAgGpPj45OYHL5cLY2BiqqqrgdDpxfHyM1dVVDA4O\n4unTp3A6neIXt1gsAICtrS3kcjkpJWtpaREsVplOQ0afIcjMe4zH4wgGg9BoNCL5iEQicLvdePLk\nCW7fvo1isSjCca5VBoMBwHni0+TkJO7cuYNAIACDwYBMJoNYLIb79+8LWXL37l1hydva2iTCrb29\nHSaTSdwumUwG4XBY3qeGhgZZAYvFIsLhMFpbWy+QDgz1sNlsYpOkEYJP+uPjY/kcCA2YTCaxKvIQ\noxuJ8WdWqxUWi0WSsw4PD8Vayz52/gzEpFdXV6XOuKmpSaAJ3lS0QtJfbzQaBdcmfsvrjuEhzc3N\nyOVy0Gq1Mt3x/YrH43C5XOjp6UE0GpUMXCo7OEU/evQIV69elSxYi8UCs9mMsbExDA8PCwzEf1el\nOu9e56Scy+Wg1+uxubkpoeWNjY0STO31eqVxtrm5GeFwWMLI6Xo7Pj6Gy+XC5uam1Ig0NjZiY2MD\ner0efr9fWkWJ73MQoLf96OhI5GcMFkkmkyiVStI0S4MFISheC3RuMcuCn1kmk0FFRQU+++wzTE5O\nijSM/WuUcVGSRq12fX09DAaDSP6qq6vl81PipEoyjEMMk8hoF/4ue0+LMCd7SqFe6qoRRrQxjYf2\nNOD8SfngwQNcuXIFf/jDH9DR0YGBgQG8ePECFRUVGB4ehkqlwtLSkkTbff755xK7R4lIZ2cnYrEY\nuru7xWnEN5oOJr1ej1Qqhfb2djx69Ah9fX3isGlqasKzZ8/Q39+Pr7/+Gq2treJLVqvV0srZ19eH\nYDAoVlGmT/GAZS4qV4ju7m44HA48e/ZMvPmlUglXrlyRkjsmL7W0tIjtdH5+XhpW79+/j8HBQakq\ncTgcQqhQBJ3P53Hp0iWUSiXR45pMJiHbSK41NDSIkoAFfh0dHWhqahJBdjwel9WadkNWgHDtJjbI\nwry+vj5sbm5K+eDR0REymYz0QPn9fgAQ/R5wLvXhJMC/Z7PZ4PP5YDabZUPgxKRSqXDp0iUphtve\n3kZra6tgscQ7z87OZHqy2+04OzsTLJw3u9lsRm1trcAgbDZQq9XC2tOJRfdUMpkUArOlpUWm+o2N\nDdhsNqhUKjx+/Bg6nU4w8Xg8DqPRiJmZGTQ0NMgKzgxQrtQ7OzuiJSXur9R2EsqgVpkmA7Lz/f39\nFw5hTpaFQkHca4FAAD6fT6ZWq9Uqm04+nxdjQHl5ucjcqDxhm6tWq70gwaqrq5PMWavVegHTJfGn\n1+sxPT0trb+vvfYajEajYL7U6tIiq4znY013sVgUdQc1wVzrOQ1TRcCEMYrsld56fnGzIZHG1/1S\nC/KfPHmCdDotgtuzszOJHFtZWcGrr74qNzpXla6uLkkhYvgvQ4WZOMRVzO12i9tidXVVNHTMkkwm\nkxKLxiAS5jTykHnx4gUGBgawvb19oYKWYumjoyNks1nBexwOBwYHByXhiBAA8SfiVCRKPB6PYGvV\n1dWiAPB4PPjb3/6GSCSChYUFmM1mNDQ0oLOzUy5im80mq3JtbS3m5+fR3t4Or9eLhYUFtLa24pNP\nPkFXVxeSySR+//vfy/SfTCaluZRdPgyz0Gg0UsgXiUREPjU8PCwkC/EoYpNkwzc3N4U06e7ulocN\n10MSb5yYGBbD9ZQEHmtEWJu9v7+PbDYrOZTxeFw+W2pSiX3xQcebuFgsCobI9tbd3V05pFnwxjK5\nTCYjyVnl5eWIx+M4PDxEa2srwuHwhXpoKgrC4TCMRqNAMzRCcHrjg6myshKRSEQgkt3dXVgsFiwu\nLoo8SqvVXtDTJpNJ2aCA8wOGRBTxUGW8IzXQsVhMEqRIDtF6TclcdXU1QqEQurq6ZAPjqk8HncPh\nEOyTw8Lk5CRu3LghmRU00fCQCoVCaGhoQHNzM46PjwW+ofV3cnISwWAQVVVVeO+99zAwMCAqAsJ6\nlCxxMlXahIvFImKxmOhLiUmfnZ3JQUj7N0nH79aJKLFQrvMkrfhe835/qSfSR48eoby8HH6/HxqN\nRogIhiC7XC589tlnaG9vBwAMDAzIakC94NnZGex2Ox49eiSp8BMTE7Db7XC5XBIsQX8v32R2LOVy\nOWSzWfh8PkSjUZlOeQGQNCJRUSgUJAavsbFRLmbCBIVCAZ999pmspHwqEkSPRCIwGAwoFAowm81I\npVLo7e3F//7v/6KzsxNVVVXiMimVShgeHkYsFpNai6+++goOhwNPnjyR+DbiSWazGRsbGxIkMjEx\ngffeew8ffvghTCaT2Fl58L/yyiuYmppCa2urrEQGg0HstGR6e3t7YTKZsLKyInIfQiZMYeeBVF1d\njerqarhcLmQyGUxOTspNqFyxWM5G2ymnXN7kXI1LpRIikYi8Th5+TFnK5/MiZ6KImwoMeuAZzMJD\n0mQyIZ/Pw+PxYHV19QIR4/F4sLy8jM7OTnFYmUwmWK1WafwkPkoiaHNzEwaDQcruGF3X0dGBaDQK\nh8OBtbU1uZnp2KN2VafToaWlBaFQCBaLRVhyQhckS0g4NTc3i0qCNz8P07q6OtTW1kp3VyAQwOnp\nKTwej2xpxFOZyqXMjKWrizDV6emp4NJ6vR5TU1Pw+XySCZvNZiVYhdCEXq8HACHdiEcD34renU4n\nBgcHYTabEY1GsbCwgOXlZcHMlZsj8G17aGVlpRzQ3d3dsjHwfaBZhdpf5lwov5RWUAAC/1CzDnzL\n9FM+9VKnPy0uLsJqtYpG8+joSNi327dv4/79+7h69SrGx8fR3t6OlZUVwUR0Oh02NjbgcDgwPj4u\nuYSTk5PSjEmf/sLCAvb29tDU1CQYl06ng8vlQllZmWjWKJmh/YwEEg/DxsbGC2A4u2FIarASlyG4\nTU1N2NnZETmQshvo+PhY5COZTEbYbvqPGxoaRGnAxH4mKpE0o+iaUhlCCnwCm0wmzM/Po7+/H5lM\nRgKhXS4XAoEAPvroI5jNZuncaWhoQCqVwkcffSTxfDwM0um0vAdc6RhSUlFRgWw2K42XTHYqOXI+\n7wAAIABJREFULy9HV1eXhIzwfeZ6xcmW2wjZWUrOdnd3JUFfr9dDo9GIPTKbzQomy8Qf3uwOh0Om\nSUIG0WhUcESKyZm0VF5ejqqqKoEuqAtNpVLw+/0YHBwUuRW7vnjD062WTCZhNBqxtbWFk5MTYdCV\nMjxe283NzbIuU/UQiUTgdDpRWVmJWCyG3d1d+Hw+MTTQBMJriRpkYoCtra0YGxvDlStXsLy8jLKy\nMnR2dqK2thYbGxtIJpNobm5GKBTC9evXsby8LNZsfs9AIIDGxkYJCYnFYtJIS+iL9xTfH/rRaRCh\nBI46a0qr9vf3JUid+u6JiQlpmOD0vbW1JQcYNbScDk0mk2DnzHXgQ0FZKURBPROreHCS9ed9x6lU\nacpR4urAt8EmL/VB+vDhQ9GBNjY2oqGhAbFYDH19faIrXF9fR0dHh+AZMzMzuHHjBvx+P2ZmZqSu\nQ6vVYmZmBhaLBR0dHbJO8CBjWn6xWJTDlxcoBdOdnZ3w+/1obm7G9va2HHBk3el1z+VyQiJxFaDV\nMRKJiO+XWBTZex4m4XBY9IBarRbhcBgtLS0olUqYmJiQtcViseDk5ATxeBxXr14VEoxaw9/85jdo\nbW3F/v6+tImyHvfs7Ayjo6Mi/7DZbGhsbBSH1ODgIN59913k83mk02m4XC787W9/Q11dHVpbW1Fe\nXi5yF5PJJNgkAPFJU/zNSmXeVLzgOf1arVYcHR0hFAqhoqICsVhMtKDK4GNOxS0tLaisPK/Q3tjY\nkBuD0wbF3EySp9SnsbERfr9fqpMZSELrKwDBj6k1bG5ulhBmNnTS661SqQQ+4fZAJxZXyLq6Ong8\nHiQSCTnUjo+PkcvlcPXqVSwsLGBoaEhMHdlsFgCkSoRqh9PT8yriqqoq+bPEkzs6OhAMBmGxWKDX\n66FWq+Xnm5qakixOpt+T7KmoqMDCwoL0QTU2NkpOwvo37QXl5eXSopDJZATy4uFJyzbfa7qOiBkf\nHR1Bq9Xi9PRU9NG8d6urq+VzrK+vF0jt5OQEBoMBbrcbFotFMG9OnJwCucozyWxnZwfZbBa5XA6F\nQgHZbFbuN2VKGHXJwLf2TyWJpCQg+ed4sPKLkiwe6i/1Qfrhhx9ieHgYpVIJ4XAYa2tr6OrqgsFg\nwNOnT7G5uYnBwUE4HA6RJ+VyOZSXl6O1tRVqtRpmsxkTExOS9dje3i7ypUAgIK4a4qoMY1ar1dLA\nSSBamUCv1+vlhme1BOU3FRUVEmFH6x1XG/qxS6WSAP52u12IL+pISXCwOC2Xy0kaEokU5SRFAoBV\nIKFQCNeuXUOhUEBrayt8Ph/cbrfgxbu7u7h27Rrcbje+/PJLYZDZm765uYmjoyO0t7eL8JlpVYwA\n5I0cDodRKpWwtbWF8vJyrK+vI51OI5lMil+d03xTU5NYXpl0FYvFYDAYhMklCVdXVydRfXzQcPWP\nxWLY2NjA7du34fV6ZdoFIIJqJY7FAI3Ozk68ePFCsmrpTuLrYyUKV2Gy4IxvrK+vRygUEoF/T08P\nxsbGoNPpsLCwgP7+foTDYbFnkgx58eIFnE6nfJZsD2DVTCAQQF9fH3Q6HR4/foza2loYDAZ5/yh/\nI6yjdBDRvmw2m7G+vi7SsKtXr+L09FTcdxUVFZienpZMXr1eL0QSraJsve3t7RUdK+VKSjULIS1O\neXQk2Ww2LC0tobe3VyZY/nysU2bS2ebmpihIysrOy+k4oKyurkpxIU0STPLnhsLNgYcaRfnA+UO1\nv78fPp9P3FFKhl7pt6fZQImfckLlNcX3nA9YZdjNS+9smpyclMQjlUolN5tarcb6+rqEZIRCIREo\nG41G7O3tiZ+e4bz0kJOVpHaxs7MTWq0Wk5OTMg0yOcdms8mTk2Azg2iB80AJahStVivm5+dlzSwU\nCtjc3BSgm1FiW1tbkn8JnCsT+vv7EYvFsLW1JQQUI+u4mpJk8vl8MskRHqDTRSkFYeBJLpeTaWht\nbU1w3uHhYcFp+YTu7++H0+nEo0ePYLVaEQ6HsbKyAq1WC5fLhZGREfztb3+D3+/HpUuXYDQaRa5E\nqdPBwQEMBoPIVMh+c/WvrKyUyDzibZwWWEBGwbRKpRLZFNcwymIqKythNBqlEtpms8mNQPyKcAkJ\nhZ2dHeTzefT29uLRo0ew2+3SaaQsSaO33GQyybWo0+kwNTUFu90u2HIwGITL5UIsFoNWq0Vl5Xnd\n98LCgqzdKysruHv3Lubm5kSHyui9UqkkWZuUOJH40el0ojphiV8+nxcXEMNWlDIhuvKsVqvE2dEJ\nxDBlppk5nU6RgHV2dkpTL++t7u5uCf0BIPcMcH6gVFdXi4zQaDQin8/D4XCIIoZrN3FVYqzr6+ti\nO21paYHT6UR1dTWePXsGu90u9zqxdRKNXLF5YCuDqZX1KeQdKMJnlxrNHJxmlbGCAOQAZc6BEgNV\nHp7KFCqlmP+lnki/+uoryUTs7u6WSTQSiaC3txcajQYTExMwm80iJDaZTFhYWJBRnbjkkydPZDR3\nOByYn5+HVqtFZ2cnvvjiC3zve99DU1MT1tfXhdUlHkbW0ev1ioaOZNbOzg4qKipgt9vx/PlzOJ1O\nydtk3QInZh7GR0dHwo4y7o/JRQyjttls2NjYEC1pPp/HtWvXMDc3B41Gg2w2C7vdLhF/SgsjvcCV\nlZVYWlrC3bt3RZPZ3NyM9fV1RKNRRKNRlJWV4fPPP4dKpUImk8Gf//xnXL9+HR0dHfL9d3d3EQwG\n8dlnn+HatWvo6ekRIo0r4OjoqCRG8bXx4CR8AUBsiMyLZNwdWWMW43k8HvFUc/ph/GBdXR30er2Q\nXl999ZWoAmgi4MUeCoUEP02n06ipqREBPm9aVmjQD098DYBMzMS1OTU/ffoU9+7dw9OnT1EsFmGx\nWCSjlP1NkUgE165dw+joKLq7u6XLio2lnN5KpZIklPGBpCy5czqdODs7g8FgwP3792G321FTU4O1\ntTWUl5eLCP7y5csSc8fIvEwmg/Lycmg0GlEbHBwcwOv14sWLFygWi7DZbAgEAhgZGcH09DRUKpXI\nntjY0NDQICJ8su+NjY3y2e7s7CAUCkGn06GmpgaRSETKJE9PT+UhZjQaJfZwZWUFq6uryGaz6O3t\nlVWc0jzlIcqplgMVMX3i8lRa8LN1uVzyuvnAUU6Qp6enF1ZzqkGUwSjKA1WJjSqzHPhnXuqJdHR0\nFHfu3BHr5hdffIGWlhb09PSIwJxhEZQ7MXItm82ipaVFEuXv3bsHi8WCtbU16PV6zMzM4J133sFv\nf/tbDAwMIJFIYHFxUfqLhoaGRONZVlaG9fV1VFVVCf7Im81oNGJtbQ0ulwt+vx9msxl1dXWYmJhA\nT0+P3OB2u13Wo0wmI64WkktkP61WKyorK6X+g51R1MNSVsIKaovFgmAwiIGBAVitVqx/03C6v7+P\nSCSCy5cvY2pqCnNzczJ5saK4rKwMoVAIr732GhoaGuByuaQgbH5+HlNTU7hz546EHpNJ39vbw8LC\ngrhaysvLRbtqMBiEUKBEigdNLBbD2dl5MDeL7wDIYUqpys7ODvx+P1KpFPb29uRipjCaDa7Ly8tI\npVK4ffs2mpqaLlRKBAIBtLS0iHC9srJSrodgMIimpiZYrVYhgegMom2TrHwsFhNHHVe+jo4O3L9/\nH83NzZIHkEwmUVVVJT1HGo1GsHSdTndhjSb7zGATEmnEEuPxOCKRCMxmM3Q6HZ48eQKNRiMaSmqN\nd3d3MTIygrm5OblGaB7IZrPw+/1itOBB8Pz5c3g8Hvj9frhcLmSzWXR1dUGtViOZTGJiYgJ37tyB\nzWaD3++XSmx2SxmNRoFtSKYSQmMjL8O+X331VYTDYbhcLqn54NS3sLAAj8cDt9stmwxVISRIyZor\nnYyU0jU2Nsp9c3R0hOXlZWxubooSg/cZsxa+60oiBvrdaZMTJw9vJpLxsFWy9vz/X/qD9MGDB5ib\nm0NHRwdWV1dRXl6O27dv4/HjxzLNka2+d+8eTk5OsL6+Dtc3iTqlUgnxeBwOhwOnp6fY2NjAlStX\nMDY2hldffRXJZBIGg+HCWsfMQiUew8RzppYzkFkpdWKGZKlUQkdHB7a2tgAA7e3tmJubQ3t7uwRB\nUBu4tLQkAPvx8bGIp0k0sCenu7tb1nWfz4dHjx7B5XJBr9ejublZJo9UKoVCoYCTkxM5YC0WC1wu\nF+rr63H16lU8f/5cKoeJdzJNnw8mr9cLrVaLoaEhzM/Pw2azScsp4ZHOzk5cvnxZfv7d3V2sr68j\nlUrJ4cqNgPFpzc3NcDgcACAym8PDQ5maGFLBUkFG4nESAc5XMq6THo8Hd+7cEb0wANEt3r59W/Jb\nI5GITM4+nw/Dw8MAgHA4LMRRY2OjiO+ZCk/dMsmr09NTTE9P4+7du7JhECOlM0utViOVSkn3UE1N\njSTWO51OhMNh1NfXo6urC+Pj41L3wumZ1zOx/d7eXslGZVau0+nEs2fP0NrainQ6jXg8DrvdLoc6\noaSBgQFJ+2JYstFoRHNzM2ZnZ3H9+nXE43HJpygWi6itrcXg4CA+/vhjDA4OoqmpSUjbYDAIg8Eg\n4npK1tiWGwqF5F6pqKjA+vo6jo6O0NraiuXlZajVarhcLoF5iHESpuKhqAx14ffna2LEIVPxKf7v\n7OyUB2dVVRXm5ubEAcZ/Rzl9Kq8n/m8le68kDJXZrTyMea8D58TTS7/a9/b24rPPPkNzczPu3LmD\nRCIBt9st2kZaRv/rv/4LXq/3whTJoBBWZ7x48QJut1uAZpIoLBFjGIXVapUsSDKUDAnhBMHkc4p+\nd3Z24Ha7RWRNT/by8jJaW1sBQA4ZSnsoq2AXT6lUQiwWE8aeh8/x8bHUpjDFH4BIOVZWVlBWVga7\n3Y5r166JD97j8cBisWBhYQGdnZ2Ym5uT1+/xeJDJZET4TTLMYrHgq6++wt7engivnz17hhs3buDq\n1asIhUKCeS4uLqK2thYOhwN2ux1Go1EE/HV1dcjlctjZ2RHmeW9vT3BRXpBqtVrkWowps9lssNvt\n4vcmocHPm9NFU1MT5ubmEAgERIRdU1MDr9crCeoMGSEm/OLFC2i1WnHzOBwOwfw2Nzeh1WpFgUFN\naGNjI54+fYpLly5hfX0dS0tLeP3110Wrq9PpMD8/D6PRiN7eXkQiEVy6dAmFQkGS7Kurq+H3+8VS\nqKxT4cTMFgEACIVCaG5uhlarxcLCgnR5qVQq0T2WlZ23dTKOMJfLob6+HuPj49KaMDY2hqGhIfj9\nfuRyOQwPD2NtbQ3pdFoiFGtqaoQ4Ki8vh81mw/T0tEybsVhMfOgk7qqrq4XcpPGAsZDE/2lRTSaT\nYlBhJqzRaMTOzo4QuYQKiIOfnJwI3smJkeQlYQvqSBl+QtMBtaF8qJB8VNo9+XucNnlNEhIELpbe\nKf8eBx+1Wi3vxcjIyN91pv1DDtJf//rXKBQKuHPnDmZmZhAKhaRW+ODgAF1dXUilUlhZWcFbb70F\nAHj27BkGBgZwdnaGsbEx3LlzB2trawiHw+jt7YVKpcKLFy8wMjKCnZ0d0XjSBcM8yb29PbS2tooD\nKpPJYGlpCRqNBv39/VJhwnQmXlQAhNE1mUyIRCJC6mSzWVRWVsJut4udjdIo3rBbW1vw+XxIJBLY\n2tpCS0sLwuEwMpkMDAYDxsbGUFlZiaamJphMJszOzuLdd99FIpGQ+lke+ADkgGb4MXV5yWRSdKE1\nNTWYmZnB119/jZaWFkxNTaFYLEoTgNPpxMnJCR4+fIg7d+5ArVajpaUFOp0O09PTWFhYuBDcu7+/\nLwQHnUVcgzhJcILi+8XpnmTh7u6utBQQC9NoNOLqYaHZ6emp6HaZhcCiucrKStHfclpua2vDwsIC\namtrpU6FtS+EIkZGRpBOpxGJREQvyyzZgYEBbG5uyoqXTqfR1dWF3d1d+dxXVlZgsViEqORNe3x8\njPb2drFKtra2Ym1tTZxwJFPUarVofwFI4DFVIzqdTjSyNBwQR3a73XC73cjn86Kx1el0qKqqgtFo\nRDKZRF9fn1hJSZRVVVUhmUyKUymfz8tDglkHrN7Z398X4wOJK6bdl5efNzwYjUbU1NQgFAohHo+L\nG42EHLe9YrEommgy6zwI6TQiyUaNMgAkEgkJFyERxYrrfD4vJBAPdaVLCfhW9qRc2ZUpU/zi73FC\npSSKBK1Kdd6n9VJXjTx58kRsc9evXxcQ/eDgQKybBwcHErzw/PlzXL9+HVVVVfjoo4/ws5/9DBMT\nE1CpVHC5XNBqtfjwww9x7949pNNprKysiKuEqw/1niQ99vf3sbe3B5vNBrfbLSJfluT5fD4EAgEh\nRpizqNFoZCpNp9MYGhqSWhTl2ra9vS0XJ1O+29vbpRvJ4/Hg5OS8TfHo6AgWi+WCz5kkClsU6+rq\n0N7eLioBVkg4nU5EIhGRiNCUYLPZkM1mcfv2bdy8eRN6vR4DAwNwuVwolUrw+/0wmUz47W9/Kxfc\n5cuXcXBwIKux1+sVVw+dRsSqmSPAEJOKigrU19cL48o0rIqKCgmYJu7Eicjlcom8aWVlRWyVnBR4\nqAcCAUlgolGADaK1tbVoaGiQUAtmf5IwiUQiQvzV1tZKUHYwGJSHVEdHBz755BN4PB5RGKRSKbkp\nOS0DkBQoNmVykmGB3MbGBnw+H4xGozDvQ0NDWF5eRnd3t0yYu7u7EnjS398Pv98Pp9Mpkyxtn4RQ\n5ufnxYWVzWYxMDCAhw8fwuv1yqo6PT0tpBalS5zEqcNlwMvm5iaam5ulQoTWaADSW39wcCCNFe3t\n7bDZbBKlWCwW4fV64fV60dPTIxkLvBeoe+UhqrR/Knu/eM8dHx9Dr9dLhGKpVJKm1/Ly80YIam45\nXfLhpPxSrvcALkiaeJgSP+Wvae1l+ho3rurq6pe7auTJkyfIZrP4wx/+gKOjI3z99de4du0anE4n\n1tbWAJyzwCaTCaurq/jJT36Cx48fw+FwiJCdpMbDhw9l1B8aGsLa2toFBwYdPPRk6/V6ZDIZESjv\n7+9jbW0NJpNJXEf0B/NAAyC4Jz3DJA+oGeTkwyc5cSeK8Q8ODuD6JomnVCqhubkZmUwGXV1dmJ2d\nFfwIACKRCAKBAPr7+7Gzs4O1tTVcunQJu7u7mJ2dBQARo3Otp2awWCzK5G0wGHBwcCDv6fr6urDD\nw8PD8Pv9eOeddzA0NISNjQ38+c9/xsHBAYaHh6HVamXVASDlZUxkX1paEqsocVMy+XwQHh0diXGB\nwdAAZMKhzjSTyaC+vh52u11UDWq1GrlcTtZap9OJ8vJykeEQ82VoitlshsFgwObmJmZnZyXDgO2f\nZWVlmJiYwL179/C73/0Or732GmpqaqSq5fvf/75MSnyNhUIB7e3tCAaDwvYvLCzgypUrEqy9tLQk\nDzemWGWzWWQyGcnM1Ol00vzAfIfj42NcuXIF8XhcrL48gFiEt7u7i+bmZkSjUXnA6HS6C7m67PLi\nNRIKhS7gwcQRmXlAedPMzAwcDgdSqZR8nmq1Wh4OXV1doh5gBsPY2BjOzs7EqqrRaLC1tYVYLCZq\nBN4zJpMJuVzuQm2HUr/JVZ9Yv9FoRKFQkLoQbkxUyvh8PtTU1FzAOwFcmCr/f9OoEgf9rh2UZCuV\nIIlEQiRYzEl4qQ/SL774AqVSCf/yL/+Cs7MzDA0N4cmTJwAgdruenh48efIEr776Kh48eIDNzU3Y\n7fYLrg8+yRobG+HxeLC4uIhYLIbW1lYUi0Ukk0l4vV5hbnd2dmA2m0VKkkwmhe1jvmIsFgNwHlDM\nFB86K1wul4DnJFT487a0tEjSEJ0sfDC0trYikUjIz0Dp09raGo6OjhAOhzEwMIDd3V1pX+Rak0ql\ncOXKlQsWVnYOpVIp/PCHP5REoWKxiBcvXsBqtUplCBPYP/74Y7z11luSRPXpp5+KbXZ2dhaXL1/G\nnTt3UFlZiSdPniCRSECtPm96LRQKCAaDAj1wYqTUqFgsIpVKiXyGWkc6tKxW64UEebvdjvn5ealt\nZuHe7u6uiOL1er08WDi5sEpjcXFRMLiqqiq8//77EsVWVlYGh8MhcW8kQIjLTkxM4LXXXpMAkSdP\nnuD69ev4+uuvsb6+jo2NDdy8eVPeO6/Xi7KyMlgsFvh8PhgMBnz22WdSe1FWVoaenh4JQ6Hj6vDw\nUOy77F1nuhEbcZPJpMAeJHFok6V+mJguYQIeDisrK1IwaLVaJVeUB9vly5eFGGMACiuIWRU+Pj6O\n4eFheQ2lUkmMICRoS6WSZPgC586slZUVZLNZLC8vw2azwWKxYHp6GrW1teju7oZWq0UwGJQpjxMi\nD1USuslkEqFQSKAKVmbncjmxHKfTaSwtLcnPQ02tcm1XSpmU8ibCTlQHABCopbKyEtXV1cjlcqK1\npYWZXyqV6uVm7X/3u9+hr68PH3zwAXp7e8W3TI3nzMwMmpubYbVaEQgE0NDQgEuXLslT2mw24//+\n7//Q1dUlFQbLy8viQWe6EgXdfr9fboZUKiUlb5RJ2Gw2rK2tiW1wf39fpkeW3/HpSpnH/v6+hFiw\n34ZPykKhgLa2NszOzuLk5ERshpRVMZDi8PAQQ0NDYlXUarUiju7u7pbEeparjY2Nwel0AjgnuPr7\n+6WKgxmgb7zxhmRKck1sa2vD8PAwPv/8c6leuXPnjgTFXLlyBel0GqOjo0JWEANl/ioxSTKsJLE4\n5VDXx2mKjjM2YIZCIYEtKJpnMnwoFJJD2WQyobKyEvl8HiqVSuy2yvoJt9stPeosPuzv75eVkSEd\n9fX1cDgcKBQKEjfocDjg9/tl87h586Y0Bfz85z+H1+vFZ599hv7+fphMJkxOTko9xurqqhQiksD5\n+OOPpa7b5XLBZrNhdHQUly5dglqtxvb2tuRFcKrSarVYW1sTeyRNDMyDZT4oU5Py+Tzi8Tju3r0r\nE7Db7UZlZSVCoRCsVivUajUSiQSam5sRCASk4iWbzYpN+uDgADabTUwqbJsoFAqi/WXdOD87pmlZ\nLBaBv6xWK6xWK/R6PaqqqsTxRJVHLBaTrUMZngzggo7XbDbD5XJJ9Qu7tyh5y2azqKqqQkdHB1wu\nl0yewMX1XCl/Uq7vdLbRHkrIifACWy9IygIXXU4vPWv/xz/+EWq1GpcvX8bTp09xdnYmN35fXx/G\nxsZw/fp1rH/TAbO9vS32w1AohL6+PjQ2NmJpaQlerxfb29s4PDyE1+uVm7+urk7kN2wutNvtksrP\nTmySCWyUzGQycLvdIpOyWq1YWVlBd3c3otEorFarRM+53W4Bx8lgNzU1YWlpSWRK1GnSDcVuJwrM\n6ZGn/5rrMmtmJycnYbfbMTY2JsHE29vb6O/vF80nHyQdHR3Y3d3F8fEx7HY7BgYGJNWKFclkpPl9\nr127JmEkKtV5Ra/H4xEiq6GhQVw4ZWVlyOVy4rghWcIbhbAHw16A8zBqvqazs/OOqra2NrEOMgOB\nD0B26VAuo2yt5NTNsOezs/PqF6/Xe8HSSEsrg5mZXRkOh9HZ2SlbzOrqKkqlEgYHB9Hf349CoYCP\nPvoIP/jBDzA/Pw+NRiPhHzdv3sTXX3+Nu3fv4sWLF0IKdnd3Y3p6WmqoNzY2JM82l8uJQYE2Veo0\nmbYfDodx8+ZNwdPpsiNv0NTUBADSTDozMyMKDSoEGE/IbY3a1N7eXlGpMC+AsiGGRDscDpmMWbdD\nzJ5bV319vRguWJaXSCTk0CWeSLw1mUzKwcoJkIw9NyLKD4HzlZ/uLIZ7G41G6HQ60Q9TM6pc7b9L\nMpHtV2aY0v7MBx/zTKlIUKoWvhv4fHx8/HKv9kypoaOENw/xCybRUNZEHR+rCtiQWF1dDZ/Ph4WF\nBQHO0+m0kDR0ZhgMBszNzckNGwqF4PF4xPvNcBKdTofNzU3p5g6FQmhtbUUgEBB8hunp1Ifyg+UF\nyEQgj8cjki1iZD6fD4eHh4jFYqKfMxqNCIVCOD4+Rm9vLyYmJuDxeLC+vo5cLoeenh7B+l555RWE\nQiHs7u5KUItGo4FOpxMpTDKZRD6fx+TkpHQWKYX2JpNJSDqVSoW5uTnEYjF89dVXKJVKsNlsmJiY\nEHnP2NgYOjs7BaZg/gA/K16cJEKoF+UBazabYTKZUFZWJtZM6gez2axMt8oULrag0pHEkBgmTjF6\nUavVor6+HolEArOzs5KkxDwDqiZaWlrg+qYye2ZmRvzhlLmxDnl1dRUDAwOIRCKora0VZYXJZBJG\nfm1tDVeuXMHU1JT0i/Gz5VZAa295ebn0EPn9fvm5qFfs7e1FMBiUNkuu66lUSgoDiWFSE9zX1wer\n1YqvvvoKRqMR4XAYbrdb3h/WV5+cnGBychLZbBaxWEwUCFROlEolzM/P4+2338ajR49gMBhQLBbF\nu89DicNJeXk55ufnL0yYfX19ePToEXp6enB4eIi5uTkcHh7izp072N7elmAgGjNo56Sag4YAap75\nIIxGowgEAsLS8z8laaXMF+U0qvw1jRbUCTNkp1QqQaPRXIAcqDLhrxlyUlNT83IHO3/wwQdyiEaj\nUdGOEeg9ODhAIBDA7du3peqWxWjd3d14+vQpbt++LWVa6XQafX19mJqakhgvZZ8LMTe9Xo+lpSVZ\nhZVBGpWVlfB6vUgkEnIAFAoFucBoYSR543Q6kU6nJXRCp9OJlIPYXSAQkCKvnZ0dcR9tb2/D6/Ui\nHA6L2JqC5oaGBhgMBiSTSQDnHzKrHVKplAie+/r6MD8/L+4tavF6enrQ3t6Oa9euIRAIIJPJyJrr\n8/ku5GH6/X45MN944w3s7u5KbfPIyAicTidu3LghMX4dHR3iMuINxX57Ehomk0nkTdQwbmxsiJxk\na2sLx8fHUrl7cnJyoeqZF3g+n5ecUa56DMOgvI2SKE4yrm+yUOPxuJgP8vk8AoEApqencfXqVahU\nKiEaWdRGiOHGjRuorKwUDPyTTz7BrVu3cHJygrW1NbkWvF4vnj17hlu3bklSPw874Jy8CQeUAAAg\nAElEQVSY47bEZoNIJIL29nYhVDQaDV68eIG7d+/i888/x8HBATo6OgQr5EHG6YzMOeucj46OhEib\nn5/HpUuX8PjxY4FG1tbW0N3dLY289N7H43H5vm+99Rb+7d/+DT/5yU+wurqK09NT9PT0IJ/PIxgM\nwuPxYGVlRaRqlDixLWFmZgadnZ0IBoOYmZlBf38/3G43vv76a9kGqcnU6/XingPO4/MoUeR9wFAd\n8gicWIlvfnd9Jy5KzJ4rOTWqp6enSKfTQgKSeyCBquxt4vfnJMsV/6UOdp6ZmRH/fD6fx8bGBgwG\nA7q7u1FTUwOHwwGVSoVQKCQ33N7eHurq6vD+++/jpz/9qQTznp6eCsOu1+sRjUZF0rK0tCQ6Pfql\nienxQzYajdjY2ACAC6Vt/J5Kl4ZKpRKogQceGWauPXQqkdRiYC8j9UKhkMh0CoWCyHeePHkCt9uN\nr776Cj6fT/Civr4+qSUZHx+HyWSSCutbt24hl8vJz9Df349cLodf/vKX2N7ehsfjgdlsxsjICDo6\nOrC3tycr6/7+Pm7cuIEf//jHGB4exvz8PHQ6Hdrb2/H555/jyZMnqKmpkemZDp2ysjLxz1dWVspN\nxixUHp51dXVyoVosFuh0OsmkZBq8Mvmc/uuDgwNx19CHzsPVbrdfgAyam5uh0+mE4CGh5PV6hTDj\nWs91lp8HdaHz8/MYGRnByckJ/vKXv0gwB4NmKioqxFJJsTbbWjmRarVamM1mrK2tSVZnNBqF0+mU\nQBMm8e/t7cH1TRA4w7LLy8vR3t6OtbU1eDweiaYDzg+Lx48f45VXXpEurdHRUbzxxhv45JNPUFFR\nge7ubnzwwQf4+c9/jmw2K+2xavV5/fjm5qYUOvL9z+fzmJqagsfjkYR6GlQODw/FJUVli1qtFlhg\nfX1dwmVYpf3P//zP0q46MDCA7u5uyV7gQ5W+eJJINMXY7XbRXvt8PonpUwaMMGeBhynXb073NETw\n96kcYZQmD19OmhzclAcxD9+joyORE16/fv3vOtP+YV77WCwm8hIWzoVCIYRCIajVaqyurkoeJnMI\nXS4Xent7sby8jHw+LyG0Xq8XGxsbgme98847WF1dFTyHUyBJHzJ/xODof97f3xdJB51Dbrdb8jep\ns6ODqbm5Wbp8yBYS/6yrqxP/P4klfpharRZnZ2eIxWKSnpNKpTA0NIRAIIDLly/j8ePH6OzsxOrq\nKm7duiU9PWSE3377bUxPT2NjYwOXLl2S9yiRSOBnP/uZVJDEYjFhqAmwR6NRyYD96KOPsLKygsPD\nQyQSCezu7uLWrVu4efMmjEajYHRKKRin+M3NTdFsMoGHPmgGblBPy/I0WgFpz+SqR4hEGX9HvHt/\nfx9+vx+bm5ty+HAyZkRcLBaTwycWi8H1TZ6sVqvFtWvXYLfbJYiGjrL+/n6MjIwgHo+LYJ/Cb5PJ\nhLm5OTidTpSVlUlITXn5ebMDg5JZ0MfWWypFuru7JXaPnU4AhIyprq5Gb2+vpOyHQiHpGSPcxKAO\n4vok25jDyQ2DU/Xy8jL29/fR3t6OXC4Hg8GAZ8+e4fr16xKvNz09jebmZpnCCI05HA7odDqMjo5C\nr9eLCYXNsQxYIQlI3qKiogI9PT349a9/LSV/yWQSf/vb3xCPx0UxQ9cg8C0RxMm2WCxK2ywjJvla\nlWu3cvJUru8ktVi4p3Rz8c8SHuDUSuhJOe3SukoJ39bWFt59992/60z7hxykU1NTuH37Nnw+H1ZW\nVpBIJDAyMoLe3l5xKTE1/MMPP8TAwAA0Gg2Ojo4wNjaGmpoauFwuiUpLJpPQaDTw+/1466238Pz5\nc/h8PoTDYWi1WlitViwtLQnWWiwWJdw3lUrJmg9AesMvXbqE1dVVmM1mmWLp0uDNQcEwIQCVSoWN\njQ3BHyk9opyFyfft7e2YnJxEV1eXCKX39vbQ2NgoWZebm5uCPTHkg82pIyMj+PTTT9Hf3w+Px4NI\nJII7d+5gaWkJ7e3tODw8hN/vl3rhH/3oR/j4448xOzsr3mV2TfX19aG2thadnZ3o7OyEx+MBcB4D\nODo6imfPnkmsXzKZvFCjQuUDL3haOSl34k1E14hywuCDR61WC+xBbIoCf5oh2P3e29uLzs5OGAwG\nqNVqyWXY2NhAsVjE1atXZX2srKyUnIXHjx/LBBWPxwUvn5qaEqhEq9Vif39f9J5MI4pGo+jo6MDZ\n2RkWFxdhsVgEfuKEyq0lkUhgeHhYQkYY7EF81GQyCZaeyWRw48YN0V/SqcashM7OTmxvb8Nut6O2\ntlYMGoS8IpEIpqampLa4pqZGApkzmQyqq6vx4MEDfP/73xdZXSgUgtlshkqlkrjKsbExgQPKysok\nwSqVSkGv1+Ps7EwUEtvb20I4NjY2oru7Ww7Crq4uVFZWYmJiArlcDi0tLaILZpYvDzVeQySYlIQj\nhw163pXEktJ+TBcSg494SCsdT/xSRjgSZyVRRTa/rKwM6XRaNOpXrlyB2WxGf3//33Wm/cMS8hOJ\nBB4+fAir1SokzOzsLBKJBGpqahAOh7Gzs4O7d+/i7OxMxLJ0UDidTsHb6LFvb2+XJzj9zTs7O7Ba\nrZicnITrm9ATEhQMXm5paREHBpl8TrP0StfW1gr7zCAMrrDEYEiOcOI8Pj6Wm2dubk6wPmr6qNGj\ny0Sj0Qi7yt/nWsNV4/DwED6fT4ruTk5OJKS3s7MTv/rVr6DRaOB0OrGysoI333wTT58+xfHxMQYG\nBhAMBqXI7PDwEI8ePZKErUwmgz/+8Y9YXV2FxWJBX18furq6xFliNpulRI71uyQJaVlUqc7rqJmb\nyvWeIRKs4+CBQuiGjZnEvcm2Uy+7sLCAtbU1SWEymUyS6OT6JryF0YxDQ0NC/JlMJiGCFhcX0djY\niJ6eHrhcLmg0Gok35EOC/nZOKh6PBw8fPoTFYoHJZILBYMD09DRef/11/OlPf8K9e/ewsbGB5uZm\nFItFtLe3Y3p6Wia41tZWEd2zMiSdTiMajYosp1AoYGFhQbBtv98Pi8WCubk59Pb2ilWX1z+hJ67R\n29vbePjwId5++21EIhGpPaHS4de//jVeffVV2Gw2tLa2olAowOl0QqVSSdMC7co82Pr6+tDX14el\npSXpAmMGrV6vF2iA/U/RaBQAMDIygubmZsHVi8WiTIcAxDqtUqmkLUFZTseHLFd5kktc6TndUlFA\n66ny4FR2NSlTnQjnEQvlZsR0qc7OTiHXotEoCoXCy60j/fDDD5FKpXDz5k2RAHGaWlpawv7+Pux2\nOxoaGrCysiJrVltbm1jmmEXIkA6NRoOdnR0kEglotVo0Njbi+fPneOONN/D8+XM0NjaKhq6trU0I\nidnZWcEPeSCazWaZPKnno0SEN0Q6nRZtXaFQEJJLyYzTtsiwFSaNk7HkWnp4eChBzEpJCTWnJHNY\nepfJZGRVcrvd2NjYwPr6Ovb29nDp0iVMTk6irq4OPp8P//M//yOpQw0NDbhy5Qq6urqkCI8B2FNT\nUyiVSnj77bcFJ97a2hL81+fzAYDIUYidUrlAfJNTmjLpimnlvPCpuWVyD28OknQswKOO0uVyoa+v\nT0TU1JWenZ3BarUKVs4INnrpOYnFYjGZsCh7of53fHwcJycnEqYSi8WQSCRwcHAAj8cj5AahDba7\ner1e8cEnEgkYjUZEo1FYLBYcHx/LVB2LxcROTPgplUrhxo0bWFlZgd1uh91uP78Zv5HtMM+Aza80\nMfCe+eKLL+TaYyYE4ayVlRX86Ec/koMln8/jxz/+MT7++GO5R9bX1yW4e3x8HKenp6IuUG5BbNsd\nHBzEzMyM1APR9HB4eIiFhQUA53APoTNmZjCEh3ZbPpz40KUskas5MUv+WeXhyKmRGKby4OXEyYOS\nWCzfU36GKpVKihYjkQiOjo7gcrnEep1MJpHL5SRs5aWP0VtbW8PAwAD+8z//Ezdu3MDi4iLsdjti\nsRgODw/hcrmQz+eRTCbR1taGaDSKpqYmmM1m/OY3v0FXVxe8Xi8ikQiy2Sw0Gg30ej1evHiBy5cv\nCz7JMAz60onR6fV65HI5YfFJbrHADoAUw5EEYTUF49mMRiOCwaAUiXk8HhSLRUSjUbi+Kdfjakvt\nKABREJDVPDs7b0MNhUJykFRXVyMYDIrZQHkh0uO+urqKmzdv4he/+AVef/11AfoZvpJIJMQDTq3t\nl19+KTf49PQ01tfXJXtzcHBQIvPoA1digvF4XCZsnU4nmaqckildYTA2TQeUnwAQTJTCbf55uraI\nTxEmODw8FJsla2OUf4eJ7IeHh3KT011WVlYm7L7BYBC4gaqKxcVFnJ6eoq6uTqqbBwYGUFVVBZ/P\nB7VajcXFRdTV1cHhcIj/mhXQPp9PamnsdrsEjtjtdszNzeHSpUvSvDkxMQGbzQbgfDJyu90C1xgM\nBiFcqWQ5ODhAS0sLxsbGMDg4KGQRJ/iamhphoOm1pwOIkyw3NZvNhlQqBZ/Ph2QyiQcPHuAHP/gB\nSqWSVNA4HA7U1dVhdXUVX3zxBVKpFBwOh2hU6VKyWCwAgGAwiObmZnR1deHGjRvinFpeXhYFDDc/\nvV4Ps9mMo6MjCaNhwPrKyorwDkoiUqkV5X+lUgn7+/sXsE2u+AAEU1eu6hTrq1QqyXtg1kB3dzfq\n6uqwtbUlgTyE/ugeU6vVL/dB+sknn2B2dhavvPKKaNvq6+sRDAYxNDQErVaL6elpuFwuSZAJBAIA\nzlcHFmLNzc2JA4pFcsw3zeVysNlsIi5m6C7F665vnDpMAmdVRktLCzKZjDwN6e1n2CyJJrp4KLxn\nyO/Ozo6sG+wlp5eaxoNwOIzW1lZJuCFm5vP5LnTMkOhIJBLo7e3FJ598grq6OrzyyivY3NyE3+/H\nT37yEykvA87ttx0dHZI05PF48PTpUxweHuLNN98UTPrKlStCzu3s7GByclKmccrAxsfHsbm5ifHx\ncQwODgrDXCgUpB2SkzFFzwTyaQXkYUjSgr1DvFEoNaFwW6fTiVe8trZWbq71b/qiqIAolUpob2+X\n9P2+vj6cnZ3J9cIbIhqNXggfXlxchFarFdUFLbdzc3PY3t5GsVhELpfD+vo6RkZGMD4+LrkOxWIR\np6enGBwclOmJyfjRaBR7e3vy/WhhNRqNaGlpQTQaFUacGCO3lWQyibKyMgwODiISicikzRoTCvd3\nd3clM7S8vBw3b97ERx99JJMmnXLUUHu9XqyurqKyslLCyX/6059ienoaq6urEnc3NTWF8vJyeL1e\nXL16FRqNBnNzc/D7/QDw/5j7stjG7+vcTxtFUSsXkeJOSdTK0Tb74hmP7RnbcZwNTerEaR6KpkGA\nAC360ofmta9pUBTogqJB09ZNmsZ2bMfGjNexZ9NIM6NdHG1cJIo7KYoiRUkUxfsgf2f+8r0X1xe4\nuLYAw+PxjBby/zu/c77zLSL/ra2tRXt7O5qbmzE3N4ednR0sLS1Jiuvly5fFjKi+vl5GdCUHuFgs\nYmZmRgyDyuWyEPT5Z1lIKYstFArCZVWan/DzAzgiBeXnAQ5dvNLpNLRaLQYGBtDY2Cj+uNvb2xK5\nQjco5dj/pe9IP/nkE4yMjGBzc1M4hw0NDZIJ9NFHH2F4eBhNTU2IRqOYnZ3F1atXEY1GhV7CWFtG\nLbNboEonnU6js7NTCPnsamkesr29LUsgUlv4htGHlHHDRqNR6CHEuKin50KH7t7MFWdUMCNgaeJA\nfInqJNK2aNlHNgAxGtJCisWiuApls1lJBbDZbCiVSnj48CFCoRB+8IMfCN4bi8VQU1MjmGEgEMA3\nvvENuVio/mlvb4fH4xHWwsLCAoaGhuB2uwUrNZvNYjHGEZRFk9BFbW2tLCMIgfChp0kzpwLSm4if\nkZSeTCYRDoclNRI4PAzkFVIAwMVfLpcTAjpt4WgOQlaIyWQSvm9zc7MoXrh0JO2GSxEud5aWlnDm\nzBlxeafhht1ul8tzfX0dQ0NDCIVCOHXqlFB7uCiJRCKSMutyuY5cqNlsVrLlKVlldhNw2GURCuLr\nd/78eTQ0NGBmZgbT09NCx6uvr0dvby/Gx8cxNTUlpj2JRAJDQ0NobW1FT08P3nzzTVFekS727LPP\nwuv14uOPP8ba2poIHrq6usSDgnTAqqoqdHd3C40pEokgHo+jsrISY2NjIkllDhuLIdVJAwMDGBkZ\nEeUWLwZGNvNC5QivVCZxhFdSn5SQAcf9nZ0dUR9yn0CFGSdTPov8GkqlFSeoUqn05VY2jY2NoVgs\nYm5uTrA0djWMjyVYnslk0Nvbi7m5OaTTaVy5cgXvvfeegMLEREhAJuWI+upoNIr6+nqBD6hlpmUb\n82ai0Sg6OzuFh+d0OlEoFIQfmkgkJAGSkRakOhHjaWlpEQmaw+EQIjwPcCKRQHNzszhHtbW1IZ1O\nI51Oy6HmQSuVStDpdLBYLLKJpHUc//zw8DBu376NeDyOr371q9je3obX6xUxwNDQEBYXF1FVVQWD\nwYC9vT25iX0+H7q6umA2myW+hN0B8a94PC6hbewI2FHSCo5SV2KgSp4uF3ZKazMuFnZ2duTnJWuB\noXaVlYfZPnq9HktLS6itrRUVF52cKN/luM9MJh5edpzs+GpqakS9pNPp0NjYiIqKCgSDQaTTacHY\n2NXSwWhubg6bm5uYn5/H8PAwlpaWJL8qGo3C4XBI4dLr9VhYWDiyFKRBMtkUNDrhYU0kEmhpaZFd\ngdPpRCAQkKTV2dlZmM1mOBwO3LhxA263G3Nzczh37hxCoRCam5tx4cIF4eLGYjE8//zzEvgYi8VE\n3eT3+9HZ2SlT4IkTJ6DRaLC/v48zZ85gaGgIdXV1wtGmIo2JukyBWF5ehlqthtlsRn19vVywzOHi\nuWUcDf1vaTgdDAYFp6bFYX19PRobGwU3BXCkM+SZILODryG7SPoVpFIpaDQaDAwMQKfTYXNzUy52\nFmEusggNKIn+yuVVdXX1l5uQf/PmTQGEuY3m8mZ8fFw2k01NTWIgwpxwjs57e3swGo04ODiQMLqq\nqirZoNJ7dGNjA263G0ajEbu7u5JqyNFxa2tLqEe5XA6lUgl2u13IxjR84EKBnQydxNfW1oS8bLPZ\noFarsby8jNbW1iOjJvX89FTkA5dOp+F2u6VwWq1WgS4qKirEzcdut6OxsVEwWXYVTz/9NHp7e/Hg\nwQM89dRTYhJ94sQJ2Gw29Pb2orGxUbrs5eVleL1eXLp0CRUVFYjFYoIhEUt79OgRksmkUFgymQzC\n4TACn2ZR6XQ6tLa2yrjOjoHcUMaIcGtL3iNfOxYxAMJQUKvVcmmR40qrOrpIsYjTgWtjY0PipWOx\nmFC6CDEUi0VMTEyIvSEjsLVarRC2mRlPbu329jampqag0+nEwamurg6tra2y8GtsbMStW7fk0qAq\niT6vdAJzu91wfWp+QzqcxWLBzMyMQDpc2JFPzN/n85BOp9HQ0CBeCtXV1ZiYmIDb7ZZuLxaLCfzE\nZmBtbQ1nz54VaSh519lsVi5oUvXoMpZIJKBSqcQFjIqrzs5O9Pb2yjmora0V+SeLVm1tLYLBoKQY\n0P6QjUMqlcLKyopIUOmSViwW8cknn2BjY0M6dD4bvNg+a3yi1NnzOeBuhXAPF4b8O/v7+wIjEQag\nS5RSX69ccJVKpS/3aD8xMSHjD0eXpqYmMUdub29HIpGQwLb19XWhltDthhK2ZDIpksPGxkZEo1HJ\ncqIBbX19Pebm5mA2m7G/vy+Hg9kvPp8PDodDnMpVKpXogFOpFNra2jA/Pw+LxSJ0FcbtMu6V3pE0\n87XZbOJRqXRUr6iokBu8urpaxvNEIiFLJRZRSg/JpaQL/unTpyVz/p133hFpqN/vF0rYJ598gjt3\n7ghxmpZnyWRSfACMRiNsNhvm5uZQV1cnPpVcFqhUKkkMGBoaQmdnp3Bd6ca0s7ODnZ0dSX/c3d0V\nOEKv18t7yKmD4xsPIceyiooKWUaQm0oiOAs9/1+xWBRVk16vF8I7aVTErwmBMKq4ra0N5XJZMGVl\nkqvJZBLHI6fTieXlZTG0mJubg8vlgtPpxOjoKOx2u2CFdL0CIE5JHR0d4jdAez21Wo1IJCIemCwS\nWq0Wa2traGhowO3bt8VXd2pqSrBDWjgyOeGrX/0qAMgyjdNUNpvFv/3bvyGfz+PUqVO4ceMGIpEI\nhoaGUF9fj4mJCQwMDCCXy8nrzy372tqaRKKvra0hGAzi6aefBnA4CZGzmkql0NjYKFBQfX097ty5\nI5QkFkIyFxoaGkT22traCoPBIOeF/g9dXV0iLVZa3NGTgXgoJz+eq62tLZF2M+GW1C9OQ0otvtKL\n9LP/Vi612PVWVFR8uUf7W7duCRZJOs3w8DD8fj8ikYjwKekUQ4kf/5mfn5cYhFKpJMThqqrDLJ8T\nJ07grbfewrlz5+Dz+WRsUKvVSKVSaGlpwfLyshjpcuOs0WhEU80UUHZUAERaqTx4PLQklpdKJeRy\nOemAefNx1Gpubhb/Rb7RDocDkUgErk8txZLJpFwq5Jwy6ZFqn76+PoyNjYlkc21tDZ2dnXjttdeg\nUqnwk5/8BD09PfiP//gPyasvlUr40z/9U3R2dkKtVuPGjRv45S9/iYsXL6Knp0cKHBcnVVVVuHjx\nIhoaGjA+Po75+XmRpNJy0Gw2C2WJck5uXtk9cqRlYaL4geM80yU5bShdj4iFMxKaWBZhB35+ul7x\na+7s7Ej6ZW1trYyhXE4wo2tzc1M6wVAohJaWFuTzefT29ko6LIn8t2/fFrxxbGwMBoNBYAZexqVS\nSQymGfJHqCefz8NmswkNLJVK4dlnn8XNmzdhsVhgMBjwzW9+E2+99ZZ0cm63WxaH6+vriEQiwmrQ\n6XSy7AEOL6Mf/OAHGB4exjvvvCOXhMFgwKVLl4QPbLFYEIvF0NXVhYGBATz55JN48OAB3G43Lly4\ngHK5jK6uLiH619fXC7eaSj2q4JjdlU6ncfbsWVmutrS0oLm5WXDJUqkkbAOj0YgTJ07IOM3RnBgn\nmxXlBr5cLst7zSUeeeEM2eMHiy+5o4RRAIhtofLrKf0VWIQpCPhSF9Lx8XGUy2UYjUbcuHED3/72\nt3H37l0ZE+7cuYOvfOUr+PDDDzEwMCBbRafTibW1NbjdbpHEcSSsqqoSJxy73Y6FhQWYzWYZqXkY\nCoWC4J90o6F8saGhAYlEAg6HQ6SJ/HvEQvlQcENLVcvOzg6sVitqamoQjUbFtLhQKCAej6O/v1+S\nO3U6nYS08cAzSoKKHo5eVG9wDGTsB5dWw8PDojN+//338bWvfQ3PPPMM/uZv/gaRSAR/+Id/iJdf\nfhnRaBRTU1O4desW3nnnHdy5cwc//elPYTAYoFar8dZbbyGfz6OiogKDg4O4cOEC9vf34fV6cffu\nXTQ0NMDlcqGjo0NoUSqVCsFgUG71RCIhvybGzQ8uTCiNzWQysiTc29uTbT3pZewi2IGyS9VoNNjY\n2BCMu1AoCK7Kg7+1tSWLBCX5O5VKiVFJLpcTLwX+eWq+gcNMLHZCCwsLOHv2rCwNV1ZWpAulMxhN\nx1taWuTyY5HJ5XJoaWkRyhJhCMo2GdCYSCQQCoVQLpdFKEJ+NTX9DQ0NGB4eFh+Jc+fO4dGjRzhz\n5gw2Nzfx7rvvYnl5GVevXhVDnEAggJmZGXnNZmdncebMGfz617/GG2+8Ab/fj6GhIXl2y+WyPOdc\n2tEvlv6o7P7ps0BT6fn5eZmeKMxgJ8pssampKdy+fVuoflQl8b2iJylwyIMlZkretTIrjR/siJUj\nupLIzw9e5Ox+uaTkc6uEEL70hfQXv/gFbDYb3n77bbzwwgs4ODiM4qUxLXGuYDCI7u5u+P1+XL16\nVeSKAwMDCIVCSCaT0hVotVpMTU3h61//Om7fvg2z2SwbXKpndnZ2ZGynG83+/j5mZmaEO0hNezKZ\nlK0preR48LgkcTgcElZGNoFarZYiolRo0OyBDwiDxMrlMnw+H9rb26HT6bC4uIj+/n4ZLTkmcelE\nhQ75gm1tbfI9MDpicnISf/zHfyx679deew1msxnf+973AABXr16F2WzGz372M3zzm9/Eb3/7W1z+\nNEyQkR0zMzOyzDh+/LhkQBH3pAFGc3MzcrmcGIewGyXkQYwLgPweMVF6etbU1MgSjDxU4sjcxKvV\napFwEhKg6xYPYGVlpThocQlFJRWLLHX/arVaGAUMowuHw6iqOkzw5Oi7u7uL9vZ2pNNpoeC1tLSI\nw9LIyIh0VpOTkzCZTMKJLBaLSKVSMBqN8j0QpmBnTOhodHRUIlmIQRNSojaeWCDxbK1Wi8XFRXg8\nHgQCASwtLQm8lMlkYLVa0draKubLXV1dqKiokI70+PHjuHz5siyEKIzh16f/gtlslveMbBJlRDQA\nWTZyIUjLSz4PTH3lAqmhoQEmkwkWi0W8E8igIHeaEylxadpdkj4HHC2gSuknR3r+P/55dqSsDUoG\nCpV3BwcHcDqdiMVieOaZZz5XTftCCmmpVMLbb7+Nl19+GcDhw2QymeQ2v3jxIu7cuSOYJBMol5eX\ncfnyZTx69EjMkkk0LpfLaGtrQ1VVFW7evCnu8eQYBgIBnDp1SvK+XZ/a1jFKglvAQCAgnR8PGOWm\nvGnNZrN0HdFoVMBzjilcZjQ0NIhGngwBbjZ5U5pMJtTW1sJgMIh0tbW1VWhU5XJZSMscQ6uqqsQl\n3WKxSMRGLpfDxYsXUV1djenpaUxOTqJQKKC/v18I5sViEa+++irC4bCMldwAezweOJ1ORKNRjI+P\nY2BgAACOdGAajQYTExPQarXI5/OCfZFQr+QCKg1NONYrKT50YFepDjPgdTqdbFbJGqAZSqlUkm06\n6WUajUY6NXYVfK24iedCjIsuMgNIfuehIg2Ji77KykqJTCkUCpJcmslk5HujAxMD+WgazUiU3d1d\nABCZMS8av98vHrMsSk1NTRgaGpLLnIIF8i2npqbE34Bngpp1skxyuRw8Hg/cbnl7/h8AACAASURB\nVDe6u7uxsrKCBw8eIJlMYmRkBJlMRkx75ufnYTAY8NFHH8ni1Gw2w2AwCFa/u7sLk8mEYDAo/rgU\nFDz//POIRCLCouCykSM4+dksbtwR0K+2WCzC7/djYWFBPGmV6RNsWGpqao44jCmVSsBjHf3/6kNJ\nkwIgz5FSKqrEXZUwIcUQIyMjn6umfSGF9G//9m/h8XhQXX0YLxIKhRAIBGTJtLe3h2QyiZ6eHrl9\nkskk6uvrodPp8MYbb4j/4qVLlzA6OopUKoXu7m7J17bZbGLTxTC7TCYDs9mMeDyO9vZ2+P1+WZ6Q\n6sS43MbGRuHEqVQqRKNRuFwuIf4z4kO5GCmVSiJh5LhJ5QsJ0+xC6ZPKToWmCXxNXC6X0EN40Lh8\noropFothenoa29vbeOedd9DT0yMqGZVKBY/Hg9raWty9e1fYAkNDQ3jyySfR2NgIn88nCxi73Y5E\nIoHJyUmUy2U888wzCAQC4r/JRQOTSimD1Wg08n2TfM8ukpZ4vOVpd8YCx1GPBzSVSommnD8zMU5y\nTYlr8lCRvkPCeD6fx/7+vtj2kb9I7ib5rpQksgPi9MBuFYCojEjSzuVyMBgMgg2TSXL//n1RLuXz\nefFfoIkwJyB2U/QJIP7LYsPiQvnu2tqapDa0tLTA5XJhZmZGPB3IaKGB9xNPPIHd3V1cv35dnLmu\nXLkCk8kkvr8HBweS3Pvuu+/iG9/4BrRaLWZmZjA7Oytptbdu3cLu7q7AZd3d3dBoNGhpaUFnZydu\n3rwp9ntKGqLBYEB1dbU8V/S/JV+YvrFMzS2XyyJIoM8tqUfEPVkslVQoAEcKqvJDqYzif3/28/CD\n+43m5mZsb28jGo2iu7sbbW1tuH///pfb/em///u/ceHCBcEMW1paMDc3h/7+flmc7O3tobe3F/fu\n3YPFYsH09DS++93v4o033oDdbpeiwTHgxRdfRCwWEysvLpToi0kCsU6nw/j4OPr7+5FKpYT/CUBs\n19RqtaiP6KbPgDmS8VkI2a1Q4QMcvnHkwnJxVCwWYTabhbrFAkt9t16vh8/nQ1NTk3RGpVIJsVhM\nLP4YLUzYgKPP0NAQCoUCNjY2UFlZKY48TMk8ceKEYFtTU1PY3NzEtWvXJNjP7/cLC4D8u1AoBL1e\nj6tXrwp5e29vD9FoVKzwisWiwCXEPLkg4D/ERre3t6UIUj2kVqslFZMhb9zw8vPzg54GNHCprj5M\nIWWhpmctKVNcQJAzSloRvTVpgHFwcCCXFSEJALJEUkI1nCq0Wi1qamqwsrKCJ554Aqurq+jo6MDS\n0pJATUpDDT5/pAjt7e1JOmk+nxdlnsFgEBs6ckcjkQg6OjrkUmBRUqvVgjvu7+/j2LFjuHXrFhYX\nF/Gd73wHarUa8/PzmJ+fx8mTJzE2Niash/HxcfELvXbtGpaWltDY2ChdaygUwuDgIFwuF3Z3d0WK\nzUtpenpaMGemgJI3TOpTVdWh56nf7xdrPHaimUxGRCMAYDAYxCKSXgz/O+08PzhF8tzyQ6mxB3Ak\nooQTI5dK9FhNJBI4ODjA8PAwdnZ2cP/+fZn6Ll++/Llq2hdSSEdHRyXK2Ov1IpfL4bnnnsPo6Kio\nk/x+P/r7+7GysiIxHMSRuru7JVRuamoKAwMD4mBEgn0+nxfiscfjEUyS7kWkjfDBZxfFw0LO4fLy\nMux2u3QFZBA0NjYil8tJp8HxgG447FS7urpkJOc4T4FAV1eX4J6UMPKgl8tloSjl83k0NTWJIgiA\nbB4ZdZHP53HixAn87ne/Q1tbG5xOJz788ENks1kZrdRqNVwuF/r6+mAymVAqlWCz2fDss8+isrIS\nAwMD+OCDDxCPxzEyMoL5+Xm88sorkhAJQA5NNpsVfh+39uwaaeRbWXnojt7U1CTxyOxqmF9ORgSx\nVFKgeBlRuscOl0WyqqpK/FJpYMNiTDmiWq0W+hHpXHTlV5K86czPza3SNZ0x3gCEq1xZWSkXh8/n\ng8fjwZ07d0RhRaiHnxt47GpEiKG+vh7pdBqDg4OCx6fTaZhMJoTDYTQ2NiKTycgykhcGL2i1Wo10\nOi2pErwImXnGS+T48eO4ceMGqqurxUycGL9KpYLb7Ra5KjPD1tfXZVJIJBKw2+0YHh5Ge3u7vC8m\nkwltbW0IBoNiXFIuHzpD6XQ6SehkdDZNwMkGYadPWAeALBE5yrNhUI7jSiyTRZGdqvKD3FDlwol/\nXpnTxEy1cDgsYgq9Xi/v15eaR/ree++JZPL48eOYnJyUG8BqtWJ1dRWtra3SmVRWVkrGu91ux+uv\nvy4kajoyAYcPeiAQwMWLF2X0SSaT6O/vF0yToHpjY6OE0zU0NEiOTzQaRUdHh5ihFItFweLoek8A\nfG1t7UhXoNw2JhIJNDU1IRQKSRHlOM5tM40oKHnloSNlixgex3JGa3AM8fl84gi0vr4uP9epU6ew\ntraGY8eOScdVWVmJ1dVVLCwsIBKJYGJiQihe165dkwtsYGAAPT09mJ+fR3d3N37wgx/gwoUL2N3d\nFdyLoxMVJsQZle725MrygVQWrt3dXSQSCSkUhAT4/5UbY+DxJpVYqMlkkgwtdkm8uEi6ZjGtrKyU\n1zKfz4uAg/ABWRfEyyg/ZYdKXJOKMxrXdHV1YXx8HE8++SQCgQBMJpPkLAEQcYLyUtTr9Ue2ysRr\nSS0ymUzwer3iNUC5MF8zUgZZ3EulElKpFPR6PQwGAwKBACKRCDweD7xeLy5fvoylpSU4HA7hag4O\nDmJjY0Mcr3p7e1FbWyvc6+7ubvT09IjrmNvtRjKZRCAQwPj4uODG2WxWLCN7e3sFf6azGQC5uDKZ\nDNra2iSrnj+rXq8XCIZdL5kwpH/xQuMzxMUl8Jiwz2dEqaD7X/0eu1SasWSzWfh8PmFVKK0cSTF7\n9tlnP1dNqyh/tpT/f/j4+c9/LtQUOox/73vfw29+8xtR7ly5ckUO8/z8vITSEd8knWR6ehoqlUpS\nHpkrw9Emm83iueeew+zsrHQcxWIRfX19GB0dFaMQUkg++eQTXL16FT6fTwx3DQaD8Fvz+byoPZaW\nlmT7z0OoVqvR0NAgSgoqo6ampiRwLx6Py4Pf398vGfINDQ0olw+dfEh/Ih+TGebKQqrX69Hc3CxW\ngKurq+jq6sLy8jKqqg4TV2tra2G1WlEoFBAKheB2u3Ht2jX85Cc/gd/vR0tLCwYGBuD3+3H79m0s\nLS0JgfvChQv44IMPpEPq7OyUore3tyc+B9xAA48loACkw+TGnRgxuwo+A+QDswPl2EVjFIoXiJvR\nfJhmGDx0nCT4kc1mRXXFUDh2zCxkPJwscKTLsciSSM/4C6VJBjHwixcvYnNzU+zv2C0pl5jb29sS\n48LOTqncIS5otVqFT+v3+9HW1iZ+ETs7O/JnOa4S6jAYDAiHw9DpdLKwWl9fF/Pk+vp63L59G08/\n/TQMBgPS6TRmZmYEaiGkEYvF0NraKuwDu92OoaEh4XaazWZRSlH5x8mJsA4XVYRTyPFNJpPI5XLi\nCMbkibq6OhgMBtHnE54iuZ7d5WeLJKcH5e8px3glHloqlaQZoRqOuW7lclkuTlKy2Az8yZ/8yeeq\naV9IR/qrX/1KRkOaCly/fl1st0ipaWxsxPvvv4/Tp08jk8ng8uXLQpb+4IMPJF98ZWUF7e3tsjyZ\nmZlBT0+PaHqbm5vFPJndATN++DXJGaWiiZ1ELBaD3W5HNpsVpQlwaIzAADbq5Gtra4U/GAqFZOsf\njUbFCGJjYwOJRAJ9fX24f/++4KZMoCQmxyVLJpNBZ2cnCoUCurq6EAqF5PtpamoSBQnHPG7OC4WC\nQBh7e3twOp342te+BpfLhXPnzmFsbAzBYBA2mw35fF58VC9evCj5UCRwDw4OwmKxiKadapVcLidd\nHvHSg4ODI2Yg/HP0UOBFxK6ouvowllj553hAiIWyKyc0wM6MHV8ulxMzCo75PETUbxPXJkeVS01i\nzfx7SpI2CeeUi/Lr1dbWoqOjQzxrKX0kb5lbZwBiz8ZLmJMWC40SR+UB1+l0mJiYkC5JyZclV5V2\ndeyoJycnYbFY0NTUhOXlZaHwARB1mMfjwYMHD+S9qq6uRm9vLzo7O3Hq1CmcPn0aTz31FM6fPy/s\ngHQ6jfv374tPxMzMDJaXlxGJRMTTgoo7xk77/X6R5ipZD6R2mUwmwcYdDge6u7vR0tKC2dlZBINB\neL1ehEIhwaVZHDk5EOsEHnu4KtVQ9Lkl5k44JRgMCk2voaFB/AnYBRPXBw4v4Uwmg6eeeupz1bQv\nzEYPAH74wx/i97//vThAKbmdvG0bGhrEU3RqakqSGTs7O/Hw4UOhnPCFqaysxPr6umjM/X6/+B8S\n66RdG9UWXCZwU89DcHBwIK5M/P5oisJEUGbwULZIByG+gbQcc7lconoql8uiYQcArVaL+vp6iXRg\nMmcwGBSaEPOIiDvR9Yd0HW4ZI5EInnjiCaEHMad+a2sLt27dQjAYxPXr11EsFvGVr3xFMGjSerjA\nsdlsaGpqEgVTOBzG+vq65FPRsQt47LFKWhEfekIe7CaBo1xSulotLi5ie3tbDhwPGS8E0p1Y6Eig\nJ6TAToQFh6bPrk/dlqgi4583mUzCPa6rqxP3LmKgPFCUgKpUKkQiEVlcHhwcYHR0FGtra3A6nWht\nbZUuix0ti2SxWBQoYXd3V+S/HFU3NjYwMjKChYUFUf6weyKkxDA28myJjxLT39vbg81mQ3NzM37z\nm9/AbDYLZZCGOYxYcTqdchGx204kEohEIohEIlhZWcH9+/cxMTGBqqpDT9crV64glUpheXlZ+MyN\njY0AcMSHwGg0ikHM2bNnhS9rt9uRz+fh9/vlouf7ViwWxe2LZjfEYAEgl8tJB67EPDmm83WkaIXv\nKy/LtbU1KZ6UE9MXl+9RPp+XML5kMines7u7uyLH/T99VP+/KIz/tx/19fV49tln8U//9E+yNafa\niRZyHo8H9+/fx+7uLvr6+rC6uirxt8lkEgMDA8hms3Iz3r59GxcuXJAulIoMFlOHw4Ht7W2Rd66v\nr4ucb2pqCmaz+fAF+ZTGw1vQbrfL16CxApVRHAcJ1ldXH8Yu82eg3yJdqIi9UsHD7piu7larFZlM\nRmhgbW1tiMfjODg4NMPlaMVxicoo8l+/9a1vIZvNIhgMQqvVirfqr3/9a9TW1mJwcBBWqxVnzpyB\nSqXC6Ogoenp6kE6ncenSJRwcHGBpaQmBQABarVY+t9PplGJPgQOBfyqseAHRC5RyU/IDOdpzSdPY\n2CjYJTXvXPiweyiVStJNkRXBYkXttHKzH4vFoFKp5OAGAgGRG1O+SRf0jo4OFAoF0ddzwVAul8WH\ngebLnZ2dQuvx+/0YHByUBefm5qYsf/L5vCxzWCyVLk8AxGCHlKtYLIaGhgYZZ1k4aaBC/iWxXb7+\nTU1NAnuVy4dRPD09PXjxxRfFtZ9qq0KhgPb2dgwMDIgjGcdlk8kk3TbpWWazGRUVFdBqtdjf38f1\n69cxMjKCkZERCWokB5tuY6lUCgAE42bcCsMXzWYzzpw5c0QLz1SK/f19UW1x2UObRVrwxWIxKb4s\nwEoNPhWAmUwGkUhEXl9elOvr64LZ00SnsbEROp1OKIW0Wkwmk8hms4LRf56PL6SQqlQqfPDBB8Lj\nq6ysFO6mkkpUKBTg8XgwPT0N4HBEefjwoTg7nTp1Cr/73e9w6dIl2V6GQiG0t7eLl2dXVxeuXbuG\n8+fPY2VlBbFYTA4RYwesVisqKw/D1EiJCAQC0Ov10Gg0ePDgAV544QUkk0moVCqk02kppsz7picA\nt/dcjsRiMbhcLoRCIaFfPXr0CFarFS0tLXJANBqN0EbY1QGH3pexWEyWJnQJ12q1whCIRqOYm5uT\nA2m1WvHgwQN89NFHwmLo7u7G0NAQfD4f3nrrLdjtdkmOnJubw8OHD8X42uFwSIfNTq2pqUn0z5WV\nh1Ei1FvT3IUHnq5KHOu2trbk9rdYLEIPymazyGazUpSVG/uGhgaxKqSKhpAPu0alIQwXgFwSUMnE\nWJSKigp5H2icQYyPrz9J84QvSMcplQ5D6TweD7q7u6UwUDrJDfn29vb/ZMtWU1MjRYcLT+K4arUa\nRqNRolGam5uxtbUFrVYrKazEmYlrWiwWYQ3MzMyI9r2jowOxWEy6dtpFks+cSqXEPIVjOul55XJZ\n/E4PDg7Q0dEh6a/82qlUCktLS+IXQek0IQRenoODg/KMsnPlBv7jjz9GR0cHtFqtSKwByIVK4xHm\ntZGjSqYImSN8zjj5cLJsb28XaEU5EfBrkA3AYuv3+4XiVldXJ8wFCgT0ev3nrmlfSCGtqqqC0WhE\ne3s7bt++jbW1NQHbueDhTWI0GrGxsYGXX34Zb775JiorK9He3o5yuYz79+8LFYnbVb5BtJ7b3NwU\nTIodCADR2QcCAbS2tgoO19bWJsWNuJrNZkMymRQCOrsWHkSDwSBbaZLG29rapDDQEi2TychWnx6n\nIyMj0iVw4cRDeHBwIJQQ5W3K8XF1dRWRSARGoxFf//rXBTd9/fXX4fF48Oyzz2JjYwM7OzsIhUIY\nHx+HSqXCuXPnZPH1z//8z9DpdGKxxuXRhQsXMDc3J4Fwd+/ehdFolPeHODKJ55Rc1tbWymtNuzJy\nc8ls4MPN7B6O1NyOJ5NJNDU1oVwuo7m5WdylAEiHxteWShQAApUQciGBvre3F//1X/8lz4rf74ff\n75eDQ+YA7RsjkQh8Pp8wGIrFIi5cuAAAWFtbg1qtli7JbrdjbW1Nir1SfkiIoL6+HoFA4IjbFQAh\nsCcSCYkq4WvDiYivYUVFBcLhsOCcGo0GPp8PxWIRbW1tCIfD8vowVI5Qx87OjizO+H2Rk8rvgxQ5\nMlj4HNLQm7zk3t5e6d7X1taO+D6Uy2VMTU0JbstnieoyOtQzuZeesuSckkZFFya32y0OVUqCvlL2\nyXPCEZ1TBXmtXCoqo2+am5thMplQLpfFRYoXENkc2WxWzGA+V037IjDS69evy8Hr6elBe3s7Pvzw\nQ/m9bDaLTz75BJcuXRLN871792AwGCTWluFr3L7xQOfzeTG/7evrk/acJr+hUAhOp1MMdbe2toTP\nSvWT1WrF66+/jhMnTiAej0unRp0+6RPEZbhVTaVSRzar5JnyIWTB2dzcFHihoaEBmUwGdrsdfr9f\nXOpXVlZgsVik8PMhp6kux0CXyyXSO+qCGerGrB+bzQaz2Yy+vj4AwKuvvoqWlhYsLCwIJmexWPDN\nb34TFRUVojPu6OhATU0NjEYjhoaGxGnH4XDI98TtNgsEBQPECakYouadXRp150yZJGG/qalJzI8J\nIfBQVFVVyQJPqXgiDmsymdDc3Izl5WW0tLTA4/EgkUiI1wEXcBaLRYoELdNof+jz+bC7u4vu7m50\ndnZib28PoVAId+7cQUVFBYaHh8WxjNSlzs5O0dYrzVp4+XFJQmqVUtNdWVkpE4jBYBAvAQAyygKH\nvMjjx4/j1q1bMBqNorqhMXqhUJDxnG5mhBzIk6U/p1J4wgUpL0nyLOkbQVNo+gPX1dVhZWVFQuto\nTM4FEE3A7Xa7TBXc8vNZUKvV0hlGo1HEYjExJdLr9fK9UTmlpICRKVJZWXkEbyc/mXRGJd+aDBpC\nYjRCITuEcdxM6CA23tDQgDNnznyumvaFFNJ79+6JHVyhUBDeJBVEvPEACE3iwYMH0Gq1MBgMmJ6e\nFlyN3W08HpdUwLq6OoRCISkSVFSYTCbZ8HNE5PIhHo/D4/HIFpw8TP65dDoNs9ksckZuD9kxs5uh\nNK6mpkZ8Lzk6cjnEDbHb7RYH//r6ejEvyeVygpfyYWeXzC02KSM+n0/knqFQSOSFp0+fRk9PD6qq\nqrC+vo5QKITJyUlcu3YNf/VXfyWRywMDA9L5rq6uCqZJH87V1VXMzs5Kl0jHH46x7Ar4UHILzqUC\nCxU7cy4aiNHRHZ4EeqUrf3V1tcACtNvLZDKilOFyga9JIBCQy5lyU3JvyQDgCAocHjJyOCm00Ov1\nIuNNJpNIpVLY3t6G1WpFd3c3stksZmdn4XA4sLe3J4tJPid8ZpXkcS5RA4GAqIWU479Go0E4HJaN\nMQs/4SqOrisrKyKtPX78OIBDXJjEcj6HtLLj98Ff82dWUobIB02lUlhdXQUAYR0w8SEUCiEej2Nr\nawter1fk1VVVVejt7RWpp81mk6mKpkLr6+uy1Nvc3EQymZQzywBFg8GA/f19PHr0SOKEotEoNjY2\n4HQ6ZcqpqKjA9PS0vCYs5vzZGJjp8/ng9/uRSqWEwQEc2mBS6caEWk4MJOgTt+VE83mVTV/IaE9c\niWM0uXezs7Nwu91yYzmdTqhUKoyNjeHll19GLpfD7du30d/fLxtMjrkVFRVigTc3Nwe3241AICBS\n0s3NTQnZ4zaeAD/dhfhGl8tlnDt3Duvr62JqQC9SLjtoMMJxiZ0FuyMW6GAwiIGBAQSDwSPjOSEI\n0q4AiOrp4cOHuHDhgixClpeX0dfXJ5ttnU6HSCQCAGJfRtVSMBiU5Q9wOCYxV71UKuGHP/wh/uEf\n/kGWfLxY2InT3GR1dRUvvfQSFhcX5ftisSdLgt0LCxopS1Q1HRwcur9TOqs0JMlmsyLnZPggu19e\nGvv7+4ILM8mVMEe5XBZeoNFolGiOsbEx3Lt3Dy+99BKWlpaO8C75Guv1enlNCoUCTp8+DZ/PJ7gk\nYR7KdOkk5fV6AQDd3d3SZVIy2tjYKCMyBQIAhLdI6IbPE78XWtcxnpg+DSx4HLlp3kJMdGZmBu3t\n7TI+066OC0KlcxhfR47blZWVgvezYJKITuXR6uoqxsfHodFocOHCBZnGuCwyGo2wWq1iTbi9vS2+\nDy6XCxsbG3L2mGfGjlaJJdP/gOwYPvP9/f2oq6tDMBjE+vo67HY76urqcOrUKSSTySPnjB0n2T7d\n3d0wm82COXNxmclkRH4OHEJA9fX1IgyhjJwNG5kDn+fjC9Pa0xCCbx4A9PX1YW1tDVtbW3A6naio\nqMDq6iosFgsKhQIymQxOnjwpjjGMIuE2c2tr64g7ObGejo4OPHz4EDabDeVyWbpH+lJyQ8kIiZGR\nEVFZcPHAQky1EQsAl0MNDQ1imcZDCBwqXBhuR4yMDjzc8JIyUiwWBYP0eDxHArxo6Lu6uore3l4p\nQrRe29nZQTgcxtmzZ0Uay4x1wiUejwfz8/Oy1LNarWhubhY3LJfLhWvXruHpp59GT08PJicn0d7e\nLiKJra0t6PV6HD9+XLJ3yB1kwSoUCmKaTTyZoz4Aca/icsFisQjVh+oWSmiTySSCwaBAN2trazCZ\nTGhqasLg4KAE1aVSKdy6dQsA0NPTI0kKbW1tcnBJkaLUkoWuVCphaGgIs7OzaGpqkkuTVnVUGX1W\ng08SOi/EiooKWZ7yYqbogBct2QuclCoqKmShdvLkSfn7tHojdEIjFPoLZDIZmbzoPqbVaoURwQuf\n7wF/D4AUV3at/FqkGfH9obClt7cXW1tbwh3lZeNyuZBKpRCNRrG/vy+xzuzwjEajwGr8+pyuKCeO\nRqNYXl5GPB6XhqKrq0sKNJkvxI8pTjGbzbJMI0uElwLfi1QqJVaQTU1NsNls8rwTKuKFzovabrej\nt7cX+/uHGXDxeBzPP//856ppX5hElOONchvH4CrewO+++648YMRI0um0EMpp/OB0OhGPx1FbWwut\nVitQAZcPbP1pYcfOgcsnpalEIBDAwMCAWLhxbCLlhgsWgveZTEbMghOJhFj/cYPPrtNsNovShFQZ\ndmC06SPpn4bHlBAytIwjIDtYBpJxHOFYvrq6irNnz+Jf/uVf0NbWhmQyiatXr6Kurg6nT5/GwMAA\nBgcHoVKp0NLSIpHBzc3NcLlcWFlZET6dyWRCsVgUeaPP58PY2Bjy+TwMBgNcLpcUGdJaLBaLYMIk\nR3Ok5vvIQsOOha8BJwSn0yleoJlMBqVSCRcuXIDH45EN9uTkJObn52EymQTDpd0blw8c3TlKk1Na\nWVmJxcVFPPnkk0Kz41IyHA5jeHgYBoMBy8vL0Gq1YinHgkOOJ5cb7Mg5cfDyol8DmQhcjBHqULrH\n+/1+NDY2ipMVPzdhBsIYer3+iBiD0AyXYMRriZdSYsz3gBc9+bnslMmF3dzclMtjeXlZFGJ87pqa\nmpBMJpFIJGRLzu6cU0ksFhNTE54z/lz8WnzeSK2jZ+/KygpyuZyEOba3t6Ojo0O+L06Y5G1/VsHE\n10yj0cjSMhaLwev1wu/3o6KiAq2trejr64PVapUzt7+/L7ACubxXrlz5XDXtCymkb7/9Nux2+xGC\nOgsVxx5uZJUEeW7EOepSpULDj42NDQwODuKDDz7AmTNnxBQ3m83CbrcjHA4fiXUlhkfpKf1MSTfi\nOEVSeKlUEgoKKTakiLAjpWeA3+9Hc3Mz6uvrEY/HhVDOWzmRSKC/vx/j4+OS5EnskAV5Z2dH1C31\n9fWIxWIoFAoSP0FLNcpOqVsmFejpp5+GyWSSqObR0VFsbm5idnYWwGGn4PV6kUql8Oqrr8Lv96O1\ntVWcfi5fvow33ngDjx49EuK0zWbD5cuXBdpIpVLQ6XTy0HIBx0PDDo1YMZcA5OuRhE8qDBeOwWAQ\nVqsVDQ0NCIfDokMfHR3FK6+8gkQiAafTiRdeeEGwu4ODA1FzkWfKZ4kdI/B4pF5bW8OJEycQjUZl\nO043LVoYrq+viz0joRke1P39faTTaZGeshNkoeImn9Jcjp+coGjy4ff7RRbMD0pRKysr4fF4MDU1\nJRcNjXiWl5ext7cnMSbsjlmkyfAghszRlXAacXx+3xsbG/JaEctW5iixY2Yhb2trk66/oqJC4mCK\nxaLEu7CL7ejoEEnm3NwcvF4vVldXpWju7+8LTc1isaC/vx8nTpyA0WjEvXv3kE6nBVMGIPg5VWdK\npTvfH9Io+axbLBa4XC4JFRwfH8fk5CT29/fR0dEhzUpdXZ2EUJ47d+5ztAVtEQAAIABJREFU1bQv\npJAuLCzIRpYuNxsbG6I2IkGW8q2ZmRkxVKZKIZ1Ow2q1CrF+f38fCwsL6OrqwtLSklAcOLbPzc2h\ntbVVHjSGi1VVVcHhcGB+fh5msxkmkwmjo6PCh8vn82KcTI4qKRLcJJP7yviF+vp6eL1euN1u4UGS\nB8rOiCYYqVQKDodDHkLKXnO5HEKhEIxGo6QrspCzGBH74uGi47yya62oqMClS5cE7KcxA7FPm82G\n1tZWXLp0CUajEf/6r/+KtrY25PN5eL1edHd34/Lly8Ia0Ov18Hq9KBQKaGtrkyXA7Ows1tfXhQ+s\nNH9gJs7Ozg6SyaRcgCReq1QqFAoFuVQJcVA263Q68fDhQ5w7dw6XL1/Giy++KBctrRD5ehSLRXHf\nIu2HsAMnH3Zl+Xwe/f39WFtbk8JXU1ODO3fuwGAwoL+/X1RqHR0dGB8fF/6wEh4gSZxdJA87YQeN\nRgOv1wuDwSDMDUIu9JCgCxkVPuxueSnv7+/DarUil8uht7dXoIyTJ09iZmZGQhL5TJtMJin8W1tb\nMtqTKghA6EJU+3CZycuen4uTDnHmra0tbG5uHqEbcaGqdJnK5/MwGo1iEBKJRFBVVYX29naMjIzA\n4XDg2LFjIjluamoSwcHS0hLu37+PmpoanDlzRgojX3PgsfELf5+UKF6USm767u4uksmkiCwoJuFF\nEIvFMDo6Cp/PB7VaLekCvb29n6umfWFRI1qtFh6PR8D0uro64cJRBkgso7OzU6hJxHh6e3vx6quv\n4syZM9BqtfD7/dBqtbLtrqioEOoS1UNc+KhUKjidTtHfh8NhFAoFOBwObGxsYGtrC21tbQKk82Hj\njU+xQHV1NSKRiHSoXDbRIJrjBvO86S3q8/nQ3NwsJsF0fcpms6itrUU6nZbNNw8nl1mtra3iTs8x\niSOcTqfD3bt3AQChUEjs0D755BM4nU5x+75x4wasVis8Hg9u374tphV+vx8//vGP5UHa3d3FwMCA\nKEZUKhW8Xi+qq6tx/PhxTE9Pw2KxYH19HQMDA+js7BR8mltyqmb4GvL75/vAYsdLiP8mdkcVzYsv\nvogHDx5gcXERN2/exLFjx7CxsYHZ2VkxwqBbFzs+pXsWxz++ZlShdXV1YW5uTpzeyQFeXl7G2toa\nFhYWsLCwINZ9xOSU0teVlRWcOXNGnl9SvDY3N1EsFnHp0iWRuxJjJTOhsrJSCPA7OztS5LgUoqE3\nHZ+i0Sg2Nzdhs9mgUqlw9+5dKYDpdFoilSlIAA5DBltaWlBTU3NEtcefgQWJ7xtNRxhOWC4f+sjS\nz4DS4WKxiJmZGelkM5mMQBpUTXH5RQyytrYW8/PzWFxcxObmJqLRqPCzgUPiPDFwl8uFdDqN9fV1\nsdxj56lkOHABzOaL4ppIJIJsNiu0Lxqi8++yqQEgsnF6ITx69AgTExP41re+9blq2hdSSLndm5yc\nRDgcFgDYYDAIb4/6XS6jVCqVuI17vV6cPn0a0WhURmBahxkMBhQKBZw/fx73799He3u7dD4HBwfw\n+XxwuVyi7qipOYx7bm5uRl1dHebm5nD+/HmEw2HpwEZHR6WwaLVa3LlzB263W2zTlNtQJVUnGo2K\nKTKJ07TNUy6yeDDpYE7yPkf73d1d6RoePHhwhPJD/1Sn04nV1VXh0rHY0hotl8vhlVdegclkwh/8\nwR+gUCjg7//+7/GXf/mX0gnl83m89dZb0om43W4Eg0Hcv38fGxsb2N7exvnz5xGPx+H1enHy5EmU\ny2U4nU5sbm4iEAgI3sctKbFQkq5DoRA2NjaELG80GpFMJrG6unpEc6/RaNDY2IiOjg4sLCxgYmIC\nZ86cQXt7O4rFIkKhEHQ6nWCF7GqZuUVmCBdbxGY5DQCQ36denVQaTkqk5rS2tkreEA8fDWL4eTna\nNzY2Cjas1WqRTqexsLAg8BBHf61WK+IM0m1o0MH3jWyBmzdv4oknnpBnkiM5Qx0JP/E14whPXvOp\nU6ckQoQFVemARTyeVEE6bil17UzibWpqQjwex/LyMmpqauB0OuF2u0UOS79UwiqUf7I75n97PB7o\n9XpZDrHLJ593YWFBuMU0B2cHTEyTXTB/3q2tLckPo4uT8uJkl68soGxS+GulP4Ldbsf58+c/V037\nwpZNdXV1cLlcWFtbw+nTp+X2pTRrYWFBttLA49uD2KpWq8WtW7ewv78Pn88nRiU3btwQTT3fDIbW\nsaCRNsJlARcdPEA0ceb4Tk9HPuzNzc2Saa+02CNJu6mpSW5BZhYBkIMNHB5iUlBKpZIsuujWlEwm\nRaJWUVGBQCCAtrY2+P1+nD59GqVSScZer9cLp9MpIzEd0NnZsxhHIhF8//vfxy9/+Us4HA6cPXsW\n8Xgc7777Lqqrq+FyuXDp0iUxmAiHw/D5fBJPotFo8Pvf/x5GoxGdnZ1YXV2VLoxGIxy1GafBpQcX\nb3RDJ9TAMLWhoSHYbDbpbMnkmJ6eRkVFBdxuN37/+9/LNDE2NoaWlhaYTCbodDp4vV6JXOYoV1tb\nK9Z6xD/p6E8oZmlpCefPn0cgEJCxUamWUXpeEqrglFBfXy/O9tS/c4QmAZ/LOhYh+gW0tLRgaWlJ\nYAg6KXHJQ4L5e++9h+7u7iMXNp8XsgLoms9CxO+dZ4buVFzUkBbW1tYGnU4nxHl2bWRRsFDxAmFX\nzbPL7i8ej4u/A3FwdrV+vx8HBwcScc5LZ2FhQdzDlKZDLLSUIVOybLPZRBZMA/dCoSDLOsq0qZAj\nFKAUNLBgApBLgv8oawwhnoqKClG0/Z8+vpBCeuPGDXR1deGNN97Aj370Izx48AC3bt1COByGxWIR\nMwEuJLhtJXHaYDDIOHHlyhU4nU7RYhuNRvT19aG1tRXHjh3D8ePHZcxm59Pd3Q2v1yuLobq6Ovh8\nPkm0ZFQyaRtcpGxvb8soT/Iu6UzcnpPG4ff75aHi9pLKCnYv1OzTuo+Li8rKSqTTadjtdin2/Lwc\n+ymhzeVy4l/Jh4h5VUajEY8ePRKsaGBgAA8fPkSpVMLp06fx85//HC+99BLq6+uF6BwOh5FMJnHy\n5EnodDqcO3cOTU1NeO2116DRaNDb2yuHzfWpBjqTySAcDmNrawvd3d2wWCxil8cOj+MdF09kGvDw\n5nI5rK+vY2VlBdPT01hYWEA+n5ciyJQEWh1++9vfxscff4xwOAytVou+vj7Mz89LigFHWGK7fF6A\nx1G9BwcHAqfw4qNdn5J7SjzVaDQilUpJ4QQg4/Tg4KB0Tiw8ra2tSCQSIjNOp9PixWCz2RCJROB2\nu2Wkpu6bbk3c4re0tMiyiNAWQ+Q4xZAdAUDoeVVVVSL1pFIMADweD8LhMGKxmATdkaNaV1eHxcVF\n2cCT1M7PyQmDcSFkJHR3dwtdK51Oi1nyyMgI6urqJHiRUyfjaTiOx+NxiSSvrKwUyhMjdNLptBQ4\nYqpcHCs39pwqeAHy87HbVHaf7KJpcMJFm/L/Xbx48XPVtC+kkI6NjeGDDz7A97//fdy4cUOMkqnD\njUQiEqlLKSatrVjgqqqqRGKWz+fh8/nEzFaj0WBpaQkNDQ2Yn5+XB9flcsHpdEo3pLzVqetmZja5\ngIlEQlx2jh07hkgkIhvJQCAgBh9cqDCRcXl5WfxPDw4O5Cb3+/2wWq2CoXEBQWd5jUaDlZUVucEB\nSJGkzJJkeB54g8GAg4NDG0Aa8xIPttvtSKfTqK2txdraGjwej/D7aC02NjaGJ598EsFgUB7C+fl5\naDSHGeivvfYaXnjhBZHfMeeJmmnyBonvhkIhWdTxNeaygg5JGo1GQsbodarVaqHVamG32490chxF\nqfbhuPtHf/RH2NjYwMTEBBwOBxwOhzjM833lRpruXCzKPIRarRaTk5MiR15fX5fxjweTiaM01N7d\n3ZX3gKYnWq0WiURCFi8s4qRg9fX1wev1Cs2HMcfclhMXJimdlyvzpti1MQr7e9/7HiorKxEIBKBW\nq4U+Rymox+MR5zCO56Ts7e7uyuUKQAo42Rnt7e3S3dGLgCbMvHSISbpcLvm+wuGwwAJMsFhdXRXf\nYZVKJdg9LxV+brVaLR0omyKLxQK1Wn1EfAM87hyVFyOAI1Q0nhsly4K/5p9XdqCf/bNc+H2pC+mv\nfvUr/OhHP8L8/Lw453CLSVpFOBzG3t4eOjo6BCdpbm4GAHEc4vjBAtTT0yN52Xa7HR9//LHI10i3\nCAQCaGhoEMf6bDaLXC4nOU/U3u7v78NisYgqguNGTU2NLLEYR8LPqQxRo0OP2+3G5OSk/Fyzs7MY\nHBxEPB5HLBaD0+kULiq/LnBIXE8mk9BqtQAeGzmQ+0evT46DFChsbGzIz7K7u4uOjg7cuHEDTz75\nJPb397G8vIyDgwP09vZiYmICOp1OlCJf+9rXMD8/j8HBQQwODmJ//zCimJk2165dg1qtRnt7O65f\nv47a2lr09PTgk08+keUcu3Sa9nKJQJNhOkU9evRIcNeFhQX5dTAYlEuH771GoxHHdmqlPR4P3njj\nDTz//PMol8t488030dXVhe7uboyOjkpxVnbCfP9YXDje6XQ6jI6Owmg0wvWpdwFTAihTdDgcWF9f\nFzksOxZ2VXQX4vtFXjJTCx49eiQ8Up1OJx0hAJhMJunUV1dXUSwWj6jguBQiW+THP/4xCoUCIpEI\nOjs7sbm5CaPRiFAohNraWoTDYfT392NiYgJ6vV4oV/zelQtAYqHkivb394vRiLKLZSKFsmsktptI\nJFBTUyNiCXbMBoNBpkoqkLLZrDwHarUa3d3dkntmNBrR29uLqqoqiQ0KhUJyJlk4eR6UeCd/rTwr\npFR+togq338A8jorf5/48eeViH4hhXR+fh5erxfRaBSnTp3C0tKSkIibm5sxOTmJZ555Bjdv3sTy\n8jJcLpc8uHRap4sNF0CZTAaLi4vY29vDwsICotGoZH3X19fDbrejv78fTqdTjE6IEwUCAfT29oqa\nwmQyYWJiQhREJNyzc+V2dXNzE+3t7dLx8cEkzYqUK5ovMw20VCqJLwBv5GQyKQeK8dEbGxtitccu\ngN1UJBJBV1eXUGQ4znK7y87A7/fjhRdewGuvvYaOjg4ZW7a2trCysoKvfvWrmJiYwOXLlzE5OYnu\n7m7cunULVqsVCwsLqKysxOTkJJ566imcPXtWlCxXrlwRRUtDQwO2trbgcrnERzMWi8kDTh4t8W6b\nzYbOzk5JcLTZbKiqqoLdbpesIP6dVCqFXC4nYyMP1fr6OhwOB373u9/h5MmTOH36NP7zP/8T7e3t\naG9vx9LSkmQ8kYu7vb0t9CJlh6NWq8UTllZ3GxsbAgf4/X48evRIiP0sdNwk7+7uoq2tTaSalZWV\n8Hq9aGpqgtFolKwrp9OJxcVFWK1WxONx9Pf3ywKMhHBKKZWG1cBjz4na2lq89957mJqakkPf29sL\nv98vLJdYLIaTJ0+KqTkvZ47/VPSxSLLbPjg4wOrqKnK5HNbW1uD1eoVpwmeKhY8TQktLixDqNzc3\npTHiboB4L1VHNpsNbrf7CPeWHf/6+jomJiYQiUQEmlGePeV7phzTP4uH8v/xolTipBTj8PUsFoti\naML/x89bVVX15e5I33vvPfT394sCiZvWtbU12ZTX1NSITRm1wDU1NQiFQmJEwY+xsTFks1lx4SHu\nwhad6YjJZBJerxfLy8tiLEwqDrPt+eBlMhlZODFxlJZwGxsbsgwqFovQarXY2NiA2WwWp6dbt27h\n/Pnzwgll1lIwGERHRweSyaR8j4xCaW5uljebdCeOjMDhA2I2m7G8vCyv0/j4uGBq7NIpUkgmk3A4\nHNDpdLh16xbOnj0r8sKlpSWcPHkS8XgcOp0Ov/nNb0SrTf4qO9mRkRHcu3cP+/v76O3txfvvv4/W\n1lbZkno8HulOuNyhcxSllxwpCdWQ08cDVltbC6PRCOCQBkbTCovFArvdfoSPywlCr9fDbrfj9u3b\nAIDvfOc7+Md//EcMDAxAr9fjo48+Ej4qsUuj0SiHrFQqHaH1kN2xtbWFZDIpPxOVMDzMSikl+a9M\nUaBVIjfVoVAIXV1dSCQScuGur6/D7XbD6/XCarWKkTOLCn1fyRcmT5YULhYqnp3NzU3paAGIfyz3\nC9xYKxVYyo6ajQHfm0KhgFOnTuHEiRPo7OyUyzeXy2F1dVW+ViaTkcuDGWJUnREH52vBJVE6ncbS\n0hKWlpbEvSmTyWBpaQlNTU04efKkEPfZnPAi4K/JiiBuzMLIf5T/n5c5Lytu8uk7yv8mC0CJMx8c\nHHy5O9K3335biLkrKyuorKxEc3OzYDfEj2ZmZvDcc8/hlVdeQW1tLXw+H4aHhyVeN5VKobKyEufP\nn4fJZBKSOx1oiC9x6bG0tITjx4/j/PnzsrQhvWpychJ2u13yg4aHh/HRRx/h2LFj4iXJ7rGjo0M6\nYZVKJXhoJpPB3t6eeJH6fD709vZKRAfHTI4pDFRTqVRIpVKyRKKumPxaBr4VCgXo9XrEYjHxSG1q\naoLb7cbi4iJsNhsqKirE35J5Qtvb2zhz5gwymQyWl5fhcDhk3LJYLEilUnC73bBYLIhGo3A4HHjm\nmWdQV1eH27dvo729HbFYDBaLRWhcVNJkMhkkk0l0dXXh4cOHcDqdgv2l02npQBgfQSWNyWRCf3+/\nXCI+n0/eJ3rVUtO+srIisAHHVNJ0jEajmGWHQiH8xV/8BX72s5+hr68PJ06cwOLiouDYpGARp6Xv\nAjvURCIhlDJeyDT85VJCqVAjx5JxJMlkUrpups2SmkOPXVoEEpKigQq5yKT6cQ9ATJe/5vfBMZaE\neXbKXGwVi0XJm2JBYVfP7qu+vl46ab4unLjC4TCWl5eRy+WwsrICr9eLbDYLl8slP1dTUxP0ej0y\nmQwymYwUWhZrLm45nZBH29raCten0Tu8XDs7O3FwcCCeErTE5M/If5S0JuW/mdlED1i+fiyiAKS4\nsvgrCy/wOBJcicF+qTObxsfHJcdocnISLpdLfDj1ej2CwSD6+vqwsrIiNyLHi2w2C5vNBp1OB5fL\nhXL50OCZ6gbeuqTwKDEmAsj3799HfX09otGoOCfZbDao1WpEo1EsLCxImJ7dbheZYF1dHR48eID9\n/X04HA5MTU0JlkTaCrf83DgajUYsLi6ip6cHa2traG5ulsULbcBWV1eFlM1IE5pdtLa2inCA9CgW\nFZKyM5mMjFJ09mGuVLl8GN+ytbWFO3fu4Ny5c1haWkJXV5eQ1kOhEHp6erC1tQWbzYbr16/L2Eoe\nZ09PD9599125RGZnZ3Hy5EloNBr4/X4MDAxgb2/vCH+RMSGhUAhzc3OyEFSr1cJPPTg4EHEATST4\nZ+hLyWVOV1eXHBySzYlh03v0gw8+wF//9V/jF7/4BXp6etDY2Ii7d+9KMJ2y+yAuRsyzpaVFliks\nWHT6YhFjt0OYpaqqSgIC2SFxqbOxsSEXMy8fLlTJ+iC+SCtEclrJraa9n9FoFErRZ5crLAT8vngh\nKs1RlK5TAES0oEy+BSDQCRc+8XgcFosFzz33nCSIJpNJSfwkzYxqNnrVcsnHaYQdptFolIuE57Wm\n5jBFQGm+TkaNcpTna7+3tydFWDma08uBZ4fvLbFP5XKJVC6aevP3+LX4ej799NOfq6Z9IYX0zTff\nFAlnT08P9Ho9EokEqqqqEIlEkM/nZYs5NzeHnZ0didLgAoQadr7gVNKo1WqR5bFD423NLpKO9gMD\nA+L2vra2JtneZrMZs7Oz6OnpwcbGhox+KpUKjx49wokTJxAIBGCz2ZDNZmX050PFUbu7uxubm5tC\nQWGsb0tLi2xblYbFlMfV19fDZDJJHLXP54PNZoNGoxFch10JjR7owkTuJnOiCClwUWUwGGSr/Pbb\nb+PKlSsIBoN4+PCheJT29fWJeUUsFoPZbMY777yDrq4u4RiySw4EAhgZGcHi4qJgyk6nUw5WOp0W\n7uOxY8eEAN7S0oKenh5RoLBz7ujokI6WaZI2m034prTyAx5LZIkP003q17/+NX7605/i7/7u72Cx\nWOB0OrGysiJKIkIExWLxiAsUJwaGo7EbZLonDz4lw8rtPzFrwgFsDihjJibJTm1kZAQ+nw8dHR1Y\nWVmRRFrgsR8pecfl8qGhdjwel26QyygA8rMAkIVsLBYTJQ/PgHJEpmyWPzsAuTiUHr6McUkmk/D5\nfEilUhLNXS4fmqlQgUaoipAN3fYJyylx5fX1dXi9XpnQKF3W6XQwGAxC81J61372Q7lAYodOXJlG\nOcqOlBgrIQVeIHy/6VvBc6TRaL7chPzbt28L1sjRkN0B32C62Oh0Ouj1evT09Mht9tZbbwlxn0Tc\nbDYrjvfMkaEZQmNjI8xmsyxuyEdlhDE7wXw+L/EisVhMeIaMkuWbQ8yWpsM2mw2PHj2CSqUScDzw\naWb92tqaEJLZrVZVVeHRo0cwmUzSMQSDQbS0tCAYDKK9vR3Ly8vY2dkR9yOllI+8SMoANzc3YTab\nxWSaYxCJ8RqNBqurq/J5+/r68Prrr+Py5ctCvRkeHhbxAjeov/rVr/Dd734XU1NT8Hg84n3K4kwe\na1dXF9566y0UCgVYLBbpPOlmxQydZDIp0j+tVitxE1arVQpvJpPB+vq68F85elqtVvT09AjuSxUQ\nuxvCHvF4HCdOnMC///u/48///M/x8ccfo62tTTpBdosc4ViAaFBDj0sAspiiAk5JdCd9jRdnMplE\nqVSS8EH+fWLc5AFrNBoEPjWgJhxgs9nEVpLTDaW2pLyRCqbsJPl9cuIihYeqvcrKSlnKsliyUCgN\nXfh3eZETH+T3yL9rMBhgtVoRi8UwPj6OeDwOq9UquCKFL/39/eJaFgqFAEBeZ4PBgEAgIOkObrcb\nNTU1kmK7s7PzP0WGfJbWRMyWhVH538r/z1+zuBJL5b+V3Ss7WyXHeH9//8u9bLp+/foR1RINbWlE\n0dzcDIfDIZZifOP5ANP0lURdbnqJh3HEoHUX1U90GyJmRfuvF154QSJD4vE4ampqYLPZZIwm75OU\nFXaqHN24YGB+PX82LhGi0aho+pnsaTAYYLPZMD09jd7eXkl95CHg5yBvknZg/HN0izIYDNja2pLX\ng9AAjSIoU1Qa/9Ls4/Tp08jn83jzzTflAujv7z+iOSe8EggEZFNbXV0t0Qx37tzBsWPHxFmebk5L\nS0vo7u4WPIqdQ6FQwN27d5HJZEQCGgwGZaznFruy8jDEj8u/ZDKJ6elpuTQnJibEyYhfM5VKiYv9\nyMgI3nzzTZw8eRLr6+vymtE0nK8rF3xUupGzazKZcObMGaTTacHVeClwM041EgMOU6mUyEnpO5BK\npdDZ2YmtrS04HA48ePAAbrdbRkwum/b29oRWd3BwIPEZlEa3tbVJwSNHl9Qwvh8A5HUlMZ5Lts+S\n0YnvUhLJ7qylpQWNjY1iqcczptFoxBPW4XCgq6sL8Xgc+XxeqGEc4WdnZ5FKpXDq1Cl0d3fL60rx\nCU3VKQdl98zJiVOCUn0EPB65gcebeuXYzr/D/8+OVNnNsshyKiG3WLnZZ4H90i+bPvzwQ6F71NbW\nysimTBzk4SEWRV4kb2renPw8VB+R9pJMJmWTPjk5Ca1WK6O2y+VCbW0t7HY7MpkMbt68Kdk1fIM5\ntrEQcInU1NQkpOLh4WG5PdmlplIpiQshaZ5bVCqgEomEbIczmQz6+vqQyWTk1qaShYmlLOjEnHZ3\nd8VEhGMYzX01Gg2mpqbQ2dkpZh65XE6ibnd3d9Ha2orp6WnhOT799NMip9zf38e9e/fQ2dmJlZUV\ndHd3Ix6P4/jx4+JqpVKpEA6H8f777+PP/uzP8Nvf/lb4oSR32+12bG9vC4Rhs9nE0erkyZOiFopE\nImhra0Nra6uwKCoqKmC1WkXQQIf1rq4u5HI55HI5vPTSS8jlcmI5SIwzHo+L5R4PJL+3zs5OjI2N\niXkGpwpiZdXV1cK8CIfDmJ2dlQJE9yB62hJbJ9meLBLGm2xsbAiMMjk5CaPRCJvNBp/Ph76+PoTD\nYTEKTyaTMoLzeWeXxM06l0HkOvP7YBcfDAbl86hUKjz11FM4efKkSJh5GSjHXsI9LLTEJ2mCQ2cz\nJo4Sgtrc3MTDhw8lB43ZXzQHGhwchNFoRDAYxNzcnAg2mDHP9FqO2ISsuFxi508lE5sK/rzs2oHH\nTAYlNUo53vO/AcjfByAdOf8f8FjxRr5xdXX1l7sjZSGlldVnsRAS4cmp5IjDN7hcLiOfzx+hdFCW\nxvC0lZUV2O12tLW1ydKDzvrkltJvkWR7mjgz4oC4K0enRCKB9vZ2TE1N4erVq3jw4AH6+/sxNTUl\n6iJKQunyZLfbEYlEoFKpYDKZZNThsoQjOjm0TGNUmpLw1xUVFcK97OrqQjQaFWNmRo+Uy2VRYykz\n5IlPUa3F/Bou3a5du4YnnngCd+/eRblcxrFjx6QT2t/fl8uopaUFDocDVqsVNpsN6+vrWFxchNFo\nFEuy2tpa8WYdGBgQmhttEpmdxdz1iYkJWaqsrq4Kf3B2dhb5fF6gjKmpKTQ3N6Onpwevv/466urq\n8PWvfx3T09NIJBLQ6/UolUrwer2oqKiAx+PBysqKGHlsb2/j7NmzuHHjBiwWy5Fiwe325uamXIzE\nP1nkOjo6kM/nhdJG0xGz2SzWjewiGbRIXwg+S3t7e2IBSY4lCze7UeDxoSbvkws2UsVYDImJtra2\nYnh4WJ6Fe/fuCS7c2tp6hAXAs8Sphl+PkwiXZsSFeQaoLuzo6JBwO8aC6/V6dHZ2CgYei8XEG5ab\nf06VW1tbmJ+fl8uH54tsBf689PPlGVDioexECY2x8AKPF1OfVTGxAH8WI1Ziqfz8/PeXupCOjY3J\nC7TwP5h709i4z+tq/Mxw5yyc4ewzHM5wGe4UKcnanMiSLMc2kiZ1ghRdkrYo0AAtUvRLi6Jb0E/9\nFCAt0KBL2iL9FCRIY8dN4ii2E1teZEs2KW7ivs6Qs5OzL1xm5v175qY2AAAgAElEQVRAn6uHTF5U\nf+DFXx5A0Dac5fd7nvvce+655ywtwW63o6WlRUYKl5aWsL6+LjYUpKfwtFX5YATd2YklfYOUFNrr\nEmSmPQjLTI7ycbaYN4Sn8NHRkYxxcq68t7dX5N38fj+Wl5fhdrvlZPZ6vZienobX65WJEZb5Gxsb\nCAQC2NragtFoRH9/v8itAcdTLoQIkskkbDYbNjc3JUjw5G9pObbIXV5ehtfrxebmJhwOh6gScdPS\n66i+vl46tIQd3n77bQQCAZhMJjz33HNyLa1WK7q7uxEKhfDWW2+JEldXVxdefvll0XxVxR78fr9o\nqpL9MDs7C7vdjs3NTRiNRvFef/3116VhB0Ayp5WVFRHg5sFarR5bL4+OjuLChQuIRCLY29uDw+GA\nw+HA66+/juHhYVy6dAnvv/++WKiQh3zp0iVMTEyIXxBtXH7+85/LQAMAccKkKDabnsxajUYjAIj7\nrNFoxOrqKhwOh/B82YBKJBIYHBxELBaTQ5rVBysp2lBnMhm0tbUJNzabzQpezy4zaXqqXzszVmLi\nwPH0GO2iSZqn7B4DJDmklNrjwAjvo4pFMvgeHBygvb0do6Oj0Gq1WFlZEZiMWC0lG0kB5FQTmzjq\n7DwbvT09PSeoR2pZXSqVhKdMDm4mk0EqlZLqVG1eqfxxQhPEw6kNoQ7NsL+gNhZbWlrk3zgOTZPB\n/+2hqXE3/P/4+MpXvgK3241EIiGBhHqgW1tbGBoaQmtrKyYnJ1EsFqXJxJQfONl5ZDbJr8LOKEt/\nAKJZ6nQ65SIzgGk0xzYQc3Nz8Hq9kiWwWcDRTWJs6XQaQ0NDMpLHzVZXd2ziNTQ0JIpRExMTGB4e\nFg8oNo4ojMxyhrYTVqsVOzs7YrzFf2fpQlM78vC2trbQ398vWDI7p/Ty4Yx5KpWSRUeaFrPFvb09\nfP/738dXv/pVAIBer8eHH34oyk8WiwWTk5Po7OwUmlY2m4XD4YDZbMbOzg6MRiPy+TwACL4XDocl\nS11cXMTIyAjefvttjI2NIZ1OIx6PS8DmWkin0/Ie5NtSrai/vx/ValWmq0qlkujF7uzs4Pnnn0cu\nl8Pk5CQGBgZQq9UQDAYxOjqKtbU10WylMeLa2hp6e3uFlcEpKE4VMfCQksQSlGr2pK8x4ObzeYyN\njeGDDz4QDzBmvdVqVXQQUqkUOjo6kEqlEIlEMDw8LBCD0Wg8gWvW1dVJE0plErCiYceeVCxCOBwh\nZjWnNqOYgdHhgfuHe4ulNO1rnE4notEoNjY2xBJdlUukBgYlISl0Qp3dw8NDRKNRUY0idky7coqt\n8/vwehFOULNO4OGUF++ROtGkhjMyFchLPc0TVX9GpUfxvWq1Gv7t3/7tkWLaY8lI33jjDdRqNfT2\n9gomShzw/v37EtjcbjcsFgvm5ubkxFDnalXaAx9cIEzzmX2RQG6xWLC4uCgq73a7XYKc0+nE/fv3\nodUeKxLRp4fye5FIRIjiDx48gMViQVNTE6anp9Hb2yuTGxTX4OlXV1cno4e0T7FYLAiHw2hvb5ey\npVKpyKgidSaz2ayM5+l0OiFF7+zsCCRAaCMcDsNkMonNCWfxd3Z2RI+VOPS7776LUCiE+vp6XL58\nWQR1mZ0MDg7ixo0bYn72xBNPwGaz4f79+1heXsbIyAimpqYwOTkJk8mErq4ufO9734NerxeXyP39\nfUxNTcFgMGBxcRGtra1ykDF712g08Pv9mJ6expUrV5DJZPDgwQOZR+c9am5uxsrKilBviLlyHJe8\n32KxiBs3bojgMCk4FosFer0ewWBQBi42NzfFooVNiGQyiWQyidnZWXzyk588obzE4YlsNotsNov6\n+npsb28L44AN01AohIGBARFZbmlpQTKZRDabRSAQOOHg6XA4sLy8LBDT5uYmfD4fotGorHEyCliy\nMphSJpHBPhQKiWoasc5fhfuR5kX+JAM2D+1YLCbC4zs7O4IHqyLPrOA4oUfmCSEUt9stlh7ZbBbj\n4+PSVKUCms1mO6HRys9EMzp+R/6u7n0Ge1arPCAYiFl1coqJGSjhAr1eD6PRCL1eL/9G+ImShwaD\nAdeuXXukmPZYAinFg1V7AM5Cnzt3Tpo9TU1NQjxnSUCchQtLnV7gKQ5ATjUuJpKGm5ubxTKExHiO\n4hH41+l0sFqtcsPX19fhcrnQ0tKCRCIBr9d7omvKEUF2dY+OjiTYcYPQY8ZgMECv12NlZQVOp1MW\nPbvr7LpvbW3BYrHAYrFIhkrfcmantVpNurWkxxDPoulYU1MTAMis//LyMvr6+oSYT1EJl8uF5uZm\nvPfee/B4PHj11Vexvr4umOnMzAwWFxelSXB4eGyId+HCBelA22w2jI6OQqfTIRQKob+/Xya7PB4P\nfvjDH8qUFKX/CMU8+eSTSCQSqFaPtTo9Hg+CwaB01Ts7O4VC9eDBAxQKBeEJh8NhsezgnPv58+dF\n1lCj0WBjYwMulwtmsxkLCwtIJBL47Gc/i6WlJcn4VIGO4eFhmQSj/iy5nbXasfBIrVZDd3e3aKfS\nII7rgNUQXQB6enpEIYlY8tbWlgQBv9+PzY/EsYkRki53dHQkjbBMJiPGc9w3HDYgfYz+7WxGVioV\nmSUHILxOOpuS+tfR0SEHBCEhAOIOYbVaAUD42F1dXdDpdAgGg+IOGggEUCgURB2MU4eEfpglMnCy\nqQY8FBA53VBSKUsApKrjPWNQVUdCgYcKT6rICeERPvh8BmC1OfWxxkhv3bol5O1CoYDh4WH89Kc/\nxdDQkKjGT09Pi9BDMpkUUjVJ9f+3lF6dK2YpxL8zq3A6ndBojkWiE4mEeEbZbDbUajXBHaPRqKg6\n+f1+zM/P4+LFi/if//kffPazn8Xc3BwaGhowMjKC+/fvi94iQWxuZAAiwLG8vIze3l5Z+Mwa7XY7\n9vf3hZvHDjx9vrXaY43S9vZ2kd+LRqMik0fLYTUTz2azcnJXKhV0d3dLuReLxcQl9MqVKwiHwycs\nM0qlEr74xS8KZs3MmWXjwMAA6uvr8eMf/xhPP/00Hjx4gM7OTkQiEeTzeRgMBszMzODf//3fceHC\nBYFhzp07h1wuhwsXLqCzsxNOpxM6nQ4//elPYbfbMT8/L5ueXWK6OhoMBnR2dqK5uVmyaZvNJl34\nlpYWhEIhMeXzer3o6enB9PQ07HY7Zmdn4XQ60dHRgf39fXz44Yd44YUXMDExAavVKhbgdrsd8Xgc\nWq0WNptNHGpVHYP9/X1hZLS2toqnWH19Pba2ttDU1CTNT8ICOp1OpsTIJR4dHZWRZ2J89IanopfB\nYBDbDLICrl69KsFE7ViTCkVMlLgvm1Wc3trf3xc+57lz52A2m7G4uCifma9BsnxbWxtMJpPoUfh8\nPiQSCdy5c0dGlQmpraysCEa7tbWFQqGAWCyGnZ0dGYAhjk9c/vQv4JepTPx+wEPNVeBh552OqQya\nrAZV2I/xQu3Wn1aVUh8f60D6ox/9SEoFm82Gd999V5oCZrNZBIJDoRBmZ2dhNpuFQhOLxYQyQzoH\nMR4AJ9J8EmwJ1pOMD0CmMaLRKM6fPy/6nR6PBzMzMxgaGkKtVhPlIXIOievNzc3hqaeeQigUEgM7\nq9UqPDpOSVGIhVQTj8cjmqTqho/H4/B6vdJwqVar2N7eFnbB7u6uKMCrXMGWlhbBsohLccOz2cHS\nMxqNShbe1taGJ554Auvr6+KXRWX/1tZWdHZ2YmVlBZFIBOfPnwcAIcibTCaREGRAoeBFMBiE2+3G\n6uoqLl++DKfTKY0qt9uN//7v/4bf75dBjPfeew+zs7Po6ekBANmk6iTX7OwsDg8PsbW1hZ2dHdjt\ndrhcLpTLZSwsLAh8s7i4iI6ODjz//PPC693Y2MCNGzckczEYDJiYmEBXVxcaGxtx9+5dvPDCC/jJ\nT36C/f19+P3+EyUqyfvMduhmyUyaa43iHyyzGazYuCIjg80q8jFJt+NmTiaTcDqdyGQycl8JTQDH\nB+T4+DjS6bRgkWoQVQWeWfGxkcmm0OZHOroXLlzA0dERZmZmUKlURCWfGSMxf4pXx+NxHB0dIRQK\nYXV1Vb4rYRbixN3d3dKgowmjw+GA3W6XRIOwHGETYp4s21XcEjjpr8TAyuxRnWpS8U01JjAL5XNO\nS+zxtdQgW61W8dRTTz1STHssgfSVV16RMvvw8BB37tzBjRs3sLKyAofDAavVKsIdPp8PKysrsijt\ndjvq6+uxtLSEjo4Omb/lheDF4wVRLzrLHOD4opN6RTsFkvGdTqfMXOfzebhcLqyvr6Onpwfz8/PS\nKKCzJbuTr732GkZGRgR31WiOLTJCoZA0Y5iZ1Go1sYnm0AB5kFS/2t7exsjICGKxmHT+iftxaktV\n/QFwogFDibpwOCz8P3ZTDQYD7ty5I/Sng4MDXLx4EfF4HKFQCPv7+yJhmEqlxFXA4XDILHSpVILL\n5cLMzAy6u7uxt7cHp9OJmZkZjI6OYmJiAi0tLdje3hahapbWXV1doo/6mc98Bu3t7VKhGI1GTE5O\nYmVlBbu7uwgEAvjMZz6Dp556Cm1tbZicnBQ1Lgp0EPNKJpN4+eWXsbW1hb6+PoyMjGB5eRkzMzN4\n9tlncf/+fXi9Xty9exdnzpxBT08Pbt++jc9//vNIJpMnsjBCGL+qUUOckuUmoR1m7STZk+ROsj6v\npUZzbFXCpmOxWESlcuwSe+nSJezu7krgItOEgZrKWHyvX5W5qRkYeb8U+NHr9VheXsbu7i6AhzAY\nExNCYpz5J1+UmroejwdWq1U6/4SmOOW1u7srNtqUKGRSo86xqxQlUp7YDCVWqjaK2KXn66hDBmqg\nVPcDA6fKSVWb1rxWp6EA/vljH0itViuam5uxurqKmzdvyhQN5cTy+bxQP8xmM8rlMiYnJ9Hd3Q2H\nwyHBlPxNdaSM2OnpBUZOnDrTzEV+9uxZwcPq6+vx8ssvi7gxO6avvvoqnn76ackSqZ06OjqK7e1t\ndHZ2IpvNigmdautKWIJdy82PNFA3NjYEk6VIMwcPKMxQLpcxMDCAvb096aRXq8c6mVRk4vdiRsGg\n3NraKnguRykfPHiA7u5uVCoVnD9/Xjrd5KQSd6MiD3HZ6elpKWdLpRLm5uYwMjKCubk5oQ0Bx4yC\n4eFhGAwGeDweKW954F27dg37+/swGAwimUbzO07AEIro6+tDXV0d3nzzTXznO9/B1tYW3G43rl27\nhtHRUeRyOTFj0+l0GB0dFcrK1taWCEXfuHEDkUhEGBgDAwN48OAB9vf34fF48ODBAzkAAQijQ1Vb\n4vVl1sTMn0Mb1H4gHcput2NtbQ1ut1t0dDltZDAYsLS0JCLKlPobGBjA9PS0QDK0l+GwBKXeuHYL\nhYKwDEjvKZfLJ/DSrq4ufPKTn8TOzo40btva2mR/kSqXy+WkX+F2u9Hd3S0VDx11qRpGKxkmIpy8\nq6+vP+HPpNFoBH4AHsJwKkbLz0DqE5MECtfQKYBZJpWm1MPiV83bMyCqTSpV8Jk/p/JH1ZJfo9F8\nvEv7W7duiVEY9STfeecdBAIB9PT0YHd3VziiBPqJKbGbOTIyIv4y7e3tJ+gb6snHC6ieYDyh+G+k\nB+l0OszPz2NwcFBOMGJWJKJvb28jGo3CbDbD5/OhsbERy8vLqFQq6OjoQDAYxPnz56HRaLC+vo7b\nt29jZ2dHOsDvvvuulM7hcBgul0tUkHp6eoSbl81m0d/fD+DYR5yuoH6/X5oLqVRKRmGNRiOCwSCc\nTif29vZkYTgcDuEC0hjvk5/8JPL5vDi2jo2NYWNjA5lMBsPDw3jrrbfQ0dGBX/ziF6Lgr9fr4fP5\nxJiup6dHusnBYBAXL17ExMQEPB4P7t69i3v37mF4eBjb29sIhUIol8twuVzQaDS4d+8eXnnlFTzx\nxBPY2tpCKBSC2+2Wcp44XrVaRTKZRDQaRTKZxLVr1+ByueByuZBIJHD79m0hnd+4cQNnz57F4uIi\n7t27h1gshu7ubqFipVIpUV26cuWKKGyZTCbEYjFhhJBWxMYdAyUxTHV2nRN3nZ2dsNlsIs7NLI2l\nIknqFMigRBztWbgWiYVznVIRyWq1IpFInNBz1Wq1ooSmZpKVSkXK8GvXrolRIGEiqjxx8q+1tVWm\nrqhFQX5qMBgU0j6F1wGIBxoz95aWFlFC02qPzfAIEbFCVNWVAAgXFsCJ7jwPBMIjrCI5gKPVHtvD\nuN1uwddpb53JZIROSOV/VagFeDgCymvM2KDSqxhQP/YZ6a1btyRTIhXlwoULiEajePnllwVrvHPn\nDvb29tDZ2Ylnn30Wzz77LOrq6rCzs4Mf/OAHcDgcGB0dxQcffCCKMWp2SqyFF4xgOE8kdRKC+Cm7\nt+fOncPmRxYi5NrlcjksLy/L5E4wGEQ8HkdfX58oI5lMJuTzeRlVvHbtGrxeL9544w1Uq1WMj4+j\nVjv2BgIAp9MJr9eL+fl54eMdHR2ht7cXt2/flgklrVaLubk5Oe1bW1tFA3Vvb082fC6XE6dVlp9H\nR0dIJBKw2WyCZ7FzPDExIYMPNLYjTUuv12N2dlbgjRdffBF2u13oVAsLC+jo6IDP5xN1LmKJ4+Pj\n2NnZwVtvvYUvf/nLuHXrFgYHB+U+jI6OAgAWFhZw9epVHB4eYn19HUNDQ3j//fclo1leXsbw8DAG\nBweh1+tl5Hdvbw9utxujo6Pw+XyYm5vDP//zP2N5eRmXL1/GV77yFTQ2NuL+/fsi+cbM7e7du5Ll\nc6yS0Ak75IVCQcaPiamRE8rykdgbu96sDiiUzOxdo9GIAy0nfoBjPJjEegZnHuyECqgoxUEKwjwM\nUKrq1/r6OjKZDH77t38b2WwWd+/elQGLcrmMZDIJrVaLzs5OgVZ4oHLN8juyrC4UCpLI6HQ6mfhi\nJknltc7OTsFggWMGA/eUys5Rs0gVi1QfzP7V/ayqNtVqNbE4SaVSonY2MDAgWTQPYAqCszfA7JPs\nFlUdiweniss+aiB9LIT8v/u7v4NGo4HT6ZQOJx1A2fiwWCxwOp2YmprC7OysYC00IGtra5PSy2g0\n4sMPP0Rvb+8vnTAMpCrpmJgMcSCN5tgrm1332dlZDA0NoVKpCBYFQKhOZ86cwfr6OpqamkQdX6PR\nYHFxUYy6WJ6Gw2F4PB4AkEkj4HgT1dUdCw17PB6Z5GAGXi6X4XA4EIvFROBkeXlZSiI2N2gYxuyU\nUn2RSAQ6nU5EVRobG6Vz2tfXJ5uTY5937txBNpvF888/L6Upid4M3BaLRUoq2jxTNi6TyYhm6A9/\n+EOMjY2hs7MTt27dwjPPPIOZmRmcPXsWU1NTJ7rWfr9fOJlsGlUqFYEVbt26hf7+fmSzWQm6wWBQ\nbEk4PcaStLm5+cQIYktLC77whS/g4OAAExMTWFxcxIULF7C9vS3jlWazWcpmZj1q04YbnsMU7A4z\nUDAr4vpSbZeNRqOUlnq9XoSLTSaTUJhIcaKEol6vF5vmra0t5HI5BINBUcZ3OByoVqtiuDgxMYGL\nFy/iueeew/e+9z0cHR3B5/MhFArJuujp6UGhUMD9+/eFSkUP+nQ6LRgsFaZomcJmbbVaFTqU2o9Q\nJ+c4fAFAMOzTXG+W+GqQVAOsWkmebv4AJzFMwgHUxKBUIQN8e3s72tvbRa8gHA4jkUgIFVLVQ2Xc\nYPJBHYu/+Zu/eaSY9lgC6Z/8yZ9gfn4eAwMDctqNjY0J75HYSKFQQLValfE9blg2pJgp0rOJOqQq\n6A5ALhLxU+AhN41z/mxIcU763r17uH79ujg/coFHo9ETYiBcfMQoGSDr6+sFdC8UChgbG8OHH34o\ni5cKQgTZgWMea6FQECB/ZWVFsgOS8jnm+NRTT+G73/0url69Ktn37OwshoeH0dLSgr29PczPz+PK\nlSuiuk4PqMPDQ8G7gsEghoeHpUPLzz85OSmuniqn1+/3Y29vDzMzM7h58ybu3r2Lq1ev4u2334bR\naBT+p1arRSAQwM7Ojrwn7U3ee+89ZLNZPPXUU9DpdNjY2EBjYyM6OjqEJE8C+9NPPy3EfVJ4yHlM\nJBLQah9aspDeRpM5ZkoPHjwQ1SxOLnEt0SP9NM+SJS4A2WisWJiNMTNi95pYHzFBZjuqpTSHKPhv\nJMWToZDP56WTzck0n88Hk8kEi8WCarWKzc1NOJ1O/Ou//iuefPJJfPGLX8S//Mu/oFgsYmhoSHoH\nFy5cQCqVwr1794SUznUPQBpiFotFCPvqAc2qTe2y86ChQSEzONr1UBuB6lHMnH8Vh/M0n1NtGP3f\nwhLXOvezWlUy66TGKdXfOHlGJ+H6+mMxdboy0LZFxXH5Xl/72tceKaY9lkD653/+5+jt7ZWsS6PR\nYGFhQYj4pPA0NjbC5XJhd3cXKysrkrG2tLRgYWEBo6OjODw8xPb2tgD2zDZPc8dOd+NYwrFDSFFm\nZg7snhuNRmxuborwB7vQ9fX1MsJIcQcqCHETkqLExcbGgfrgolCpHMxMGGzPnDmD5eVlNDY2SnOs\nWCwiEAjIPDKJ67VaDZFIRJpNbrcb8/PzOHv2LHQ6neBRwWAQTU1NwkDQ6XR44403MDAwcELEJRKJ\nYGhoCDs7O8hmszJEUF9/rBy/sLCAixcvYnt7W+4NpfK+8IUv4PDwEFNTU7h8+bKQvJPJJMbHx7G9\nvS3Ut0qlgieeeAL19fXicMrMb3JyUlS2mClwsbPMZFMIOOkwyYOZJTfpb8Tg1eeS2QGcnJBTyz1O\nmHHKifeOs98ajeYEk0Kr1YqeKJudDPKc1uEhrGZT/DlWB/X19dDpdKhUKtLUougMJezW1tYwNjaG\nkZER/OhHPxLvLI5Yc40T16cNOtWvWHmQ5sd1qAY3/lKzdnWsk1UgK7/TI5lqBnq6U67ilGqQ5Xuq\nUB1pX/w7eaXq52O5ztc+ODgQCUU2Qgl7LC8vC2uHY+EajQZ/+Zd/+Ugx7bEE0q9+9au4fv06lpaW\nUCqVMDg4KJtlYGBABHJ5shgMBvj9fvGDyeVyyGQyoj7OkpNUknw+L1gKN9hpQBmAEKVJludi5zgq\nxUEYPB0OhwReNnTUOWEKRtMSmlklZ81/67d+Cy+99BJcLpdsNuKt/CykfxAjIgGemQyxJ71ej/n5\neVy/fh2ZTAaNjY1SKra0tGB+fl7Ur4rFItbW1pBIJNDb2ysHgMPhEIthv9+PxcVFuFwurK2t4erV\nq3jllVdgNBpx8eJFpFIpEYXe29uDXq8X+k4kEkFdXZ1Q1Xw+HzY3NzE6OoqpqSnxMz84OMCzzz4r\nTQ1mCouLi/jwww9FYtBsNovrKFkDXV1dACCQRLFYFBqWyiOmohKxTQYnZkisIlKp1AmeIYATf2cA\n5SbkJuXvFE6m/kI4HJb5c2b/vb29cj2KxaI4PDAI8z5TepCwBDFTEuGpjZDP5yU7ZJBnRed0OiWQ\nMZitrq6iVCqhvr4e7e3tYojIRqbNZpPBDDbeuEc4pUTDPgYoNQiS0cKgqTZzeT1VPFntmqvcWbXc\nJ2RwurRX3+P04/TPM4sGfhl/5eHJQ5PDOHa7Hb29veIhtrS0hHQ6jW9/+9uPFNMeS7NpdXUV6+vr\nsNvt0Gg0+OCDD9DV1YUbN25Ix5XSZm1tbcjlcpiYmBBMklJzFIhlQ6W9vR2zs7PY3d1FKpWCVquV\nzuFp7IX0EmKAOp1OOGtcrCx/ib0RN+JG0mg0MvOezWZlJK5QKOCll16C0WgUMVuOqu7t7Umpxkw4\nEAjA7XZL0K9UKvD5fEJLIZnf7/dL+aXRaNDX1yf4bCaTEcdObpxa7Vi8pFqtyphtZ2enBF2TyYT1\n9XUZGGhtbYXL5cLCwgKGh4cRi8Ukg6X1CW0/iP+aTCbMzMwIbUqj0WB6ehovvfQSPvGJT8Bms+HM\nmTPCsnjvvfdEVo3cQ3aFh4eHYbVa4Xa74ff7ZQqor69PJPV6e3uxtraGDz/8UIRjCJc4nU7UajWh\nPLFM9X80rvvqq6/KYT00NAS/3w+9Xg+bzQan0wmz2YyOjg4YjUaYzWa4XC7YbDZxaaCFsE6nE2Ux\nl8sl2U0gEBDZOq7fQqEAl8uFhoYGNDY2yjXidA+HTzjuSdNC3pNUKoX19XWsra1Jl/rw8FAmAMnm\noEdSNBpFLpdDa2srrFariHnz/202G2w2m+CGR0dH8rkYoLmfmPWp2ejpzJEB7jR38zQ2qv5ZDaB8\nLv9dxU1VSpL63ur7qawc9TOeDqBqY4scVuLMNpsNzc3NorFAxscTTzyBoaGhR4ppjyUj/drXviYg\nO9VqCOTX1dUhFArBbreLWAUxI44uEgvT6XTSfGEzRC0nKLl1uuRgtsILSXCZmQgbQlSSr1ar0q1u\nbW0FAAnCra2tGBwcxJ07d6QpRPWeSCSCcDgsXFBmzOx0Op1OwchIaWKJvr+/j2g0ikAgIOr8LB8p\ntpvL5bC5uSnixiMjI9jZ2UFDQwNyuZyMvVarVWEXLC4uypw8ABiNRlitVsHQHjx4INMzr776KnQ6\nHcLhMJ599lkhyPv9fnR2duKtt96Cy+VCOByG2+2G3W5HJpNBIBAQj3hSshYXF3H9+nVotVrMzMzg\nzJkzMlzw3e9+F7/3e7+HfD4P/0ejkaRHNTQ0YGJiAt3d3UL3UV0zw+EwAoEAyuUyEomECHnwnpZK\nJalwfu3Xfg1GoxFLS0t49913odfr0dvbK4GDQYM4GwApw7lBmeGSncGqqaWlBblcDo2NjeJwymYW\nNzGnweLxuPBnrVYrVldXpaTnyOnh4aGoIzmdThweHmJ2dhblchn9/f3Q6XS4f/++CO4QF+ZEFZt3\ner0e7e3tiEQiSKVSwgphc437i7Quslo4VHB64kjtwBND5n5QqWKn+Zjqn3mN1fJfDZanB2z4XDWo\nMhNWqwSVkK8G/9NBls9XPxfvtapXmsvl8Pd///ePFNMeSyD9xje+gWq1KiRjzrJTwZ1ZZqFQwNzc\nnGQsJpMJDodDSuBK5diJkacMu+tWq1Umk+jLpGInqmhvqSv/QHAAACAASURBVFRCNpsVagVPKwpZ\nmEwmoSWpPj0Uofjggw+kI80gryrSNDY2ipdTU1MTZmZmEI1GodVqYbVa4XA4JJgdHR1ha2sL8Xgc\nmUwGAwMDwkzQao99rABIwGJ2o+pcut3uE5+jru5Ytd/tdsNgMKBYLCKZTKKtrU0aSTy87t69K02/\ns2fPYnp6Gp/73OfwzW9+Ezdu3IDT6cQ//dM/4cknn5RrdebMGRgMBgSDQekwkybjcrnQ1NQEn8+H\nYDAIv9+PRCKBSCSCM2fO4L333kNHRwdeffVVUQJLp9Po7++Xe8OpHJfLJULW+/v7ePfdd3Hz5k3s\n7e1hYWEBIyMjCIfD8Hq9kl1RycrhcCCXy2F3d1ccZPv6+jAwMCCmetzc2WxWcEEAgrczYLJK4Mgt\ngyizf/9HflShUAjFYlG0a4nfMhCz+tjb24PL5RLlJW5iVjyFQgF7e3vQ6XTo7u4WvybaNzscDhgM\nBqFxkU2RzWYFCuCUHO2QifNubm4KZ5NTWeR2RiIRaf6aTCZRHjuNIRsMhhNUQgbK01kk8BD3VIOj\n+lAzVMJsfKgsHEIE6nupnF9mq3wfACcCsfpg8OS+P02R+ou/+ItHimmPJZD+wz/8A7a3t2GxWOQG\nVCoVzM3NwW63yygXABlLIxeSYh+nGw4coysUCjL3y+ytWCwil8uJzBltTZgBM6gyCyGuxBl76ieS\nUE5cSa/X4/Lly6irq8OHH34o2Jaq86hy33jDiWnNzs4iHo/L+CibEWNjY4LDEt+LRqNS8nHKIx6P\nIxaL4ejoSBTLWfpz2ob0LIPBgFu3buH5558XjNRoNIpfeblcRm9vrwRZekCxwQQcq7C73W4YjUbc\nvn1bspj79+/j2rVr0Ov1ePHFF/HlL38ZP//5z/GFL3wBd+7cwU9+8hN87nOfQ7FYRFdXF1588UX8\n8R//MV588UWYzWYRHllbW0N/fz9mZ2fhdruxsrKCs2fPipNpOp2Gx+PBxMQEBgcHRSzZZDLJ//H+\nsgG4t7eHxcVF2Gw2zM7OYnBwEIFAQChcxNOJU6r8Ra4vtStPdfxarYZQKITh4WEsLi5ifHwc+Xwe\n2WxWRkGPjo7k+qkupKRKabVaod9VKhVhbRBDZFJBkRWOLJPjyvvNZhKJ+IlEAi6XC7VaTWyc7Xa7\nsCeq1aqQ6nU6nYh+p9NpWRfMipncRCIRmZTz+XwizL67uytQE5t5DClqpx44Wd6fpkSd7ujz59W/\n8/qxY8+EhVUH/4+vqXb/1YxUzYJV7JWNYjXgfqzpT9/4xjeQSCTQ0tICr9crpxq5nevr6xJAKADL\nE5AZAtN4qt5vbm4iGo2ivr4eBoMBBoMBAGTxGQwGoU1RhoxlNcsgBj3Vv4ifq1wuC+4Vi8Xg8/mE\nl8YTHYBkyqrcF0sVTolw4a+vrwv5msEqHA4LA4EHAAB0dnYKoZoBlpqWFAPme5HuxKDHYE0jN5ZD\nOzs78Pv9aG9vl2uxsbEh3MiWlhYxE0wmk/jggw9gMBhkbnxoaAivvfYann/+eRSLRdRqNSwuLp6Y\nTmtubsabb76J3/iN38Cbb76J3/zN38R3vvMdPPvss4KtUiqRWcj09DRqtRoGBwfFFmZiYgKf+MQn\nsLq6KrKEtDixWCyiAk/dAqvVKvYd9fX1gnnSTfSVV17B1NQUxsbGMD4+LlkVsxoeeswcaSFDwWxq\nFni9XuRyOTEIjEQiEoTPnz+Pe/fuSTbKhhkzbVLnaPlN1wcGUr6/agvS2toKm812QiYynU6jVqth\nfHxcRq3pK0ZlMZobkgmi1WpF9JtBpaWlRbi8e3t7kozs7u6ipaUFbrdbBHbm5+eFSdDU1CTqT5lM\nRpIjVgRkNpzGWRnQGPS4Z9QH/0/leDLIqVoTrL6Ah3RH9efURhYfat+E73W6AfnXf/3XjxTTHksg\n/frXvy7ldiwWk85gpVKRMpd/5xdigFLJslQgZ0PIbDZLN5gjepzIYLZK0VreeOpLctGynCCWSswI\nAEKhEAKBAACIKAlvNDNXLkS1LCGuxNdlI4sZQaFQwMLCAgDIiCGdG2u1mnDiGADNZrNk3dFoFJ2d\nnTg8PEQ6nQYAyW5ZmrHz29raikwmI0wHg8GAQqEg4tFer1d4lhy3S6VSSCaTGBoaEg8oSsY1NTUh\nEokgmUzi85//PILBIBYWFtDU1IQrV66goaEBr732mlgp/+IXv8DNmzfxrW99Cy6XC+fPn5fpn6mp\nKcTjcTzzzDPo6OjAa6+9JsLesVgMTqdTRFMaGxulcqGEYHt7u8jrUUGJGHq5XJaJolAohHg8jkAg\ngM7OTlHL5yHDcVq1yUKe4YMHD+BwOCSLZdZP1SO6YPp8PjgcDnzwwQeSEVLPk2wPteQl3s9siFAD\nFaPIj2Q1Q3rO4eGxrQknmlwuF27evCnZ2fT0NDY2NlAqlcRbiRStarUqHX9V/IR8WjZ02Izi3Dwh\nN6vVKknJ1tYW6urqhC7IvUC/NQCSTKhBDXhIRVSD3unM9TT1CoBMnakNKRV2UF9bzWpViO/0z6q8\nVD7+9m//9pFi2mPLSHl6eL1eKSNJIeFCUC8as1DVpyWfz4sAhMor400hXYivxeyPP8eph9OqUOSQ\nMXgR+Kd2JEuu0/SYg4MDAfuJ0ak3e39/H4lEQpR4rFYrkskkVldX8elPf1pKa9onDw4OolwuI5vN\nyly7Ko3HzxoKhSRoHB4eSikYj8dlUoW6AZubm1LicWrK6XQil8shEokIHg1A8ORMJiObmE2jjY0N\nyUjK5TJ8Ph82NjZkWGFmZkZEultaWrCzsyPi0bu7u8hms+ju7sby8jLS6TSeeeYZxONx3Lp1C7/7\nu7+LSCSCBw8eoKurC1NTU7h69aocLMlkEsViEfl8Xg66fD4Pq9WK9vZ25HI56PV6bGxsoFKpYGRk\nRKCScrmMQCCAuro6xONxbG5uwuPxiEYBs0kGUx7W77//vlwrrl21KlL9i7h5DQaD/J1KXwxa9FpS\nMToAIoZC+IDXj4GDOL0qQs1Jp/X1deTzecRiMaE4tbW14fz58zCbzdja2sL09LRMBtrtdmmCnj7o\nCTMRH+bnIizBRlRdXZ1c93g8jvX1deGfut1umdqijiorIr4XAOk5qBgqDxUGNjUAqnAB/4+vxwRG\nLenV55H2xOuu4q2nqVzVavXjHUi/+c1vYm5uDg6HA8FgUDqLPHl58Xhq8MEv3NbWhr29PWxvb0tJ\nrNFoRJWcJSWDGUth4PhiUlxBJZGrky21Wk34ZlwAgUAAwWAQwMNynSc4O6HESNWbQfxtf39f5uqB\nhyK0LD2DwSBef/110Q8wGo0oFArY3d0VTQIGeBrX9fb2Qq/Xy9gbqTlcBM3Nzdjb25NmRUtLC8xm\nsxi5cXOtra2hVCqhr69P1KUY9Nvb2+F0OsUV1Gq1iqpQf38/bt26hRdeeAGhUEj8kV588UV88pOf\nRLlcFsGN5uZmtLe3Y2lpSQRO2traMDAwgHv37uHs2bNIpVJYWFhAe3u7BLxqtYpyuYxcLieLnpgl\nS/aVlRXZRIODgwiFQtja2sLly5dxcHCApaUlUXfnvXn99deFN8h7aLfbf4lf6vF48OKLL+JP//RP\n8c4778hMPl+HODyHQRgcaWrH57JCohlcuVwWPJfNQRUj5DqidxLv+/7+PiwWi1QphUIBzc3NcLlc\nIl1XqVQEfqmvP3Zm2N7eRrFYhNfrFReDt956C4VCAV1dXQIJce0DkKDHARnitPx8aiOOByhhtcPD\nwxOqVYTqKJrCRIfDCBStZjOO/QkGWE6NAZAEhdQ8Vo/cvyr7grGBQZRJGbNQHkhqlaByYT/WhPyv\nf/3rACDmcuwWqqePGkBVPIWqUZFIRERi+RWYKXCRstHEEUu+NoMMBYozmYz4hKtcUr7WhQsX8ODB\ng18i9asjp+qNY9OCTZ9arXaiu0keYCaTgcFgwPj4uJR97KpSSqytrU1OdN5c+kutrq5icXERFy9e\nlGDLTRqPx8VIkFNk6XRaXEnpjUXnSpPJJPJq7E6rGDXpPT6fD0tLS+jp6UEqlZLOMTOt/f19oZxx\n4R4cHMDhcCCZTApfksGVLAL6Jo2Pj4uyOjm0zA7JNKCgTWdnp2wuj8cjOqehUAgajQYul0vm+Vne\nMhvhMMTh4aH4d/X29kpQJP/0/v37MkBBUj2rAx7epKWdJu2ruL/qU9/X14dCoYBIJHLCHoOTR8RQ\nuR45tlsqlYT2xiBKbLux8djumx12PqrVKnK5HJLJpEAR6XRaMtYLFy4gn8/j/v37qNVqsg44acX+\ngZqZkhVB7Faj0cgYr5rhcm8zcBWLRcGyiTtzPJr7jqOa+XxeGnZU+GdjTh0LZeLDz0XeOAdluH6I\nJ/N68ZqxN6L2XVSI4GPdbPrHf/xHWSzEXgD8ynEyZqXM7jQajaiL88JwM3ExM03nyKbBYDjhGMoT\nijeJxmEc69Rqj50Qqc9JX3a+LrEj/r1SqZzAnmjBTGV6LiK1uUXOaSwWw0svvSQKUgym1WpVvNbZ\nLVWhC85IW61WvP322/D7/ZiZmZFF8/TTT8NqtWLzIw8gv9+PyclJhMNh3Lx5U0Y8meGxkVUulxEK\nhSTDaG9vFz6mwWDA8vKyXCMqKL388sv4/d//fXz/+9/Hc889JwZyHR0dggn6P1LFn5ycxIULF/D6\n66/jzJkz8Hg8sFgsoh7P5hrvv8PhQFtbmxDNNzc3ceHCBcnmma01NzdjamoKV65cwdbWFjKZDMbH\nx/H222+L8wGl/BYXF8UPixkclY5oqaLRaHDu3Dl897vfxXPPPYfJyUmhHHEtqmpBzGpZNtOj6PDw\nEB6PRzZvLpdDIBAQShSnsziyur+/LyIurKKIMxqNRmxvb6Ovrw8+nw/vvPMONjY2hHTPSSgAwn8m\ndssss77+2J6FjJmFhQUsLS1hfHxcbGYWFxeFpM8AR9iKWSg9rJhlUreAWTYNIBlouVfUGXyOzqoT\njDyEaOut0+lQLBYRiUSwv78vCmPMZJm5Aw+7/0zK+LkZJNlg0+l0sNvtMgFHZSxmwypO+1d/9VeP\nFNMem/oTKTwsH05TE9TymYGytbVVDNiAhxwwFTdR0/PTNAz+ztOJi58XuFqtYnd3F7FYDF1dXXC5\nXNjc3JSxTJaPxDvV6SiWWBrNsSo+g/H6+jqAY+4ncV1OmVSrVVgsFnR1dWF5eVm+O5sPzNbOnDmD\nTCYDAALk83saDAYp08bGxtDT04NkMimybdRYDYVCuHnzpvjm8PpzMZtMJhwdHYllMI3TSLrm3DY3\nGTVQOQpKF9HPfe5zePDgARKJBJ577jn8x3/8B7xeL/x+v8AyzBZSqZRUDMzWuru70dbWhnK5jKWl\nJQQCAbzzzjvo6uqCxWJBPB6HyWQSU0K3243NzU0EAgEsLi6KlJ1Wq5UshoMV/J6cI69UKrBYLDCb\nzVL6stHJaoPNHgCyFpmdqRxGZjOcfgMgBxUbdFRVopA4GQYcl+TBT6iJVUGtVsPm5ibC4TDq6upw\n9epVTE5OSpn+5ptvwu12Q6fTIRKJ4PDwUASgWQbz86lNW9KG3G63zN/TapweaRQhYfnM/aR2w8lh\n1uv1Aj9lMhlpypFiVavVpFrhSCwPQdUcr1KpCM0PgDAamKVnMhnEYjHJ0JnFnm5WMVPln9X+SaVS\nkaZ0pVKB2WwW6xeaMGo0mkcWLXksI6LvvvvuCck09aEGQnXyoaWlBWtra3C5XCKswJPpNLDMYKle\nPHYNAcjiUJXb2RRgeexyuWTiRH1tvgYzP246qg8RcKeL4vDwMIaHh7G5uYnFxUU5rfl7Op3GzMwM\nurq6xLLBbrcjm83CaDTCYrFgdnYWHR0dghUyyFWrVWly+Hw+AMDGxobIh926dQtbW1twOp0n+KW0\nXiZvkDgh8WVm3Xq9HtlsFgCQzWZhsViQTCZl83GGnM0/MgB+8IMfwO/3w+l0YmxsDH6/XzI+qnTR\nSZQz+t3d3dDr9bhz5w7efPNN2Gw27O/vi3CwxWLBxsYGnE4n3nvvPXR1dUmmr1r6WiwWLC8vw+fz\nia0JMxtuSDZwqMFZrVYlU6KOqNlsxtzcnARmHtRqCcgAyqDHjctOPoMkD3W32y20qebmZrn+KguF\nJTwD/dHRsVJ8d3c3Pv3pT4uGKpkLsVhMvLF4yLCyo2202rAiJgic1CVg0Ovo6EBzczMmJiaQzWYx\nODiITCYjDBOW6Wz6UsuUrBnyvWm9zcOMuqekEDIZoVgKg6TBYBAr8b29PYRCIWFO0FCQFMJAIACP\nx4N8Po/NzU2pTjmJpk4/qRQn/s6qkVKUmUwG29vbJ97vypUrjxTTHktG+md/9mew2WyyKFXhCZWW\noAY/PpcnrFrSqfgcS1U2rvj6POUorcWSgP8HHJ98LI/oV87XU3lolHPb2NhAQ0MD3G43crmcZBLU\nF11cXJT3GRgYgNFoxPz8vJTN7Lq3tbVhfX0dFotFshqqKLG82tjYwJNPPonV1VUJuMziiDnp9Xop\n74PBID7zmc/IomZw5EZvbm6WkUE26RwOh3wHjlwCQCqVQrVaRW9vr3ByOW9P+tr58+fh9/vhdrul\nQ05bCuAhBkbXA87Fb29vy4QT5/gDgQC2t7clKLDRwammbDYrJezBwQHm5+fR09MjFCiOEp89exbf\n/va3MTw8DJfLJRkYmQ82m03m5qvVquDlh4eHOHv2LH74wx/i8uXLcpgww+MBxmDC9cNGZlNTk+CX\nTAqam5uxsrKCc+fOYWpqCsPDw9BqtTInz9ev1WqSkXN0U6PRYHJyUqhFpVIJly5dgsViQblcRjAY\nxMrKCp566inMzs5iZWUFTz75JACcUJJSmy5s6qr0I7X7XalUpPLQ6/XCO6agDDNUNVlhtqlqtLL8\nZgVEPiyvGxMRdbKICQ0/Awcr6LbKwRQ2g6ktQUHnRCKBYrGIlpYWeZ4aS1T6Ffc275/KwNnf33/k\nEdHHkpG+9tprcmqoNAsGNp74fLBkIc2J3Deepix3mRkwG2C2yfJjd3f3BP+UZSuBc41GA7PZLLJk\n3CwEplUF9f39fTgcDvk83KTk2u3s7IiBmlarxb179+SEByABNBaLIRqNorW1FcFgEGazWSZeiN9Y\nLBbBCDs6OmSkVV38tVpNJqra29vxh3/4h3jllVcE4+TzyC0lGRyAZNPJZFJsOXhvSG5nBrm2tobd\n3V309PRgbGwMZ8+eRU9Pj0AZOzs72N7eRjKZBAC4XC50d3eLsAcHId59911UKhU4nU4UCgVxcu3q\n6pIM02KxIJFIiBMAhWHa2tpQrVbhdruxvr6OtrY29Pf3Y3p6WuhgxGeZ6ZZKJcRiMXg8HsneDw4O\nkE6nEYlEpNQ7OjpCKpXCwMAA5ubm4PF4pPqgPTa1OA8ODgTrZ5OIAYJ4PNczOa80XGSwZ3OLmCFZ\nAzzgM5kMkskkPvWpTwlU0N/fj6OjI7FxMZvN+NKXvoQf//jHqNVquH79ujSuuK+Ak8R4BikAAoVw\nHTGYEcrg5xofH0d9fT3m5+dxdHQksBIPEjam+KCdCzNVZsfMOrmnGLQYCwBIF59ZPXAMldC5gYc1\nG5GERggxUCm/VCohHo9L1cTnMgHh39XDRKW1feytRojh8LTgFyDmyBvOjhqzTpUXysVG9SZmC8x8\nGNjIv7PZbDg6OjZaY+AhY6BWq6Gjo0OaAOxE8qISx1OzEDanyL1kgI/H47JBGEg7OzslkLe0tCCb\nzYoivs1mk4MjHA7D4XDI4iR+ZDQaEYvFpCmhikzwO7LznM/n8V//9V/4oz/6IxGpJpwAHHtAcbM0\nNDSIlJ7D4UA2mxXsiJkorVe6u7vFJbVUKiEajSIej8sggM1mg8fjwfnz50U3dWFhARsbGwCOA1c4\nHEZnZye8Xi82NjbE12l3d1cESeiakEwmReGfQZ9ZIUW8SdG6f/8+rl69KgIqGo0G2WxWTO5oB5zJ\nZKQBwukxMjgGBwdF0NhkMolIDXFLri11lt/r9WJvb08wPAZXjkpyLTKD43ppa2tDe3v7ieDS1NQE\nt9stk0t6vR5nzpyB1+sVFa/R0VHJ9EnKr6urw+uvvw6z2YxPf/rTkrlR+Z4ZGH8R62dFowZctZfA\nh1arlYmwfD6Pvr4+mcyKRqOyzlkd8j3UhhVxe71eD41Gg3A4LI05iq4waDKo0ruLhxeAE4GQamV1\ndXVIp9PyWfgcwiJut1voYhwwIYylZqZ8qKyLj3UgpR2zShdhZgmctCGgIAZxEzXz5KnBC0vcihkE\ns1NVjMRgMKC3txetra2C99Vqx+OIm5ubJ7qALOVptkVZNgZz+gax00wiMgMsyymdTod8Pg+9Xo+t\nrS2hAJFLp27Q5uZm5PN5kUfj5yGORgO8XC4n0yMAZDJlb28PgUAAJpMJb731FsLhML70pS/B4/Fg\nc3NTFhU39N7eHkqlEtbX16Vz7/P50NvbK3JwOp0OqVQKsVhMVITYuOnu7haR5qmpKfziF7/A/Pw8\notGo6MjyEPJ6vZienobP5xMcUaPRIBAIiHTf/Py8cF150FDyjwFob29P1PQDgQCam5uxtbWF9vZ2\nABD91mw2C4PBIAMNy8vLArsUi0VpxhWLRUSjUSwtLYmiV2PjsXstpQSJW7LsAyBMDG46HrIWi0Xw\nQJbmKi80lUqJYSMDENdcJpMRpsXBwQHi8Tjm5uZEqGR+fl56B5ubmzIia7PZ0NXVhWAwiGw2K4Lg\nDNTqnLpa6nLv8KHiiWowVfmVZJYAx1kuBXd2d3dllNpoNJ7AKHU6HVwulwRLWpKrjSnS75hglctl\nFItFAJDeBQ+q07BfXd2x0DW926LRKEKhkECFBoMBRqMRJpMJHo9HLH04Rku8mEkJr8HHOpDS/E7t\ngqudenU+nTdOJetzQao0KS5YdixZcnCjAA8Fe0l14Jik1WrF1taWLBQ1wJOHF4/H0dvbi+3tbcEX\nA4GAKOJUKsfqPSaTSVSKWP6RcsIm0O7uLsxms5TvzLyZHRQKBQmMVJvSarWyoZmRnx5Y4LXY3d3F\n2NgYYrEY/B9xIe/evYu6ujrcunULu7u7WFpagkajEd3F4eFhcUXNZrPIZDKIRqOCKet0OnR0dODy\n5csYHx+HTqfD1NQUfvaznwkntaenR7BKmqsBEFz28PBQbLiDwSDS6TR0Oh3W1tZQX18vOCZwrD7E\nLjBL0ObmZmSzWalAYrGY4KcsKZkJ8pChWHKlUhGvLXXtkUPb1taGtrY2EVCemZnBpUuX8MYbb6Cj\nowNPPPEElpaWYDabZaPzAOR35JCFqpDPdaoyUOijlM/nT8AudE+gSSBdAegrT+yP02r0reKBHQqF\nhMM8ODgo1Kjm5mbR+AVONmUZ5LnuuaaYlfI5/DvFQti0stlsSKfTkjxw7DgUCglljgdFsViUIKXV\namGz2cSehE3FfD4va57lP6+fatqo0hTL5bKsFdrIGI1GcaUtFotYXV1FIpGQ71T7aNCgs7NTGCVr\na2uIRCIS+MmQeJTHY2k2/c7v/A6GhoZOdOYZTLgpqtVjFZpkMimZGyW/uNlJp6nVatIB5gKmxmSx\nWJQGBwMeG09U5iGGwlJJxbb4+fL5vHQht7a2sLe3hyeffBLhcFiEHUjFWF9fh81mkwyFJOSmpiY4\nHA4AwPr6Orq7uwVL5G3gRsjlcnA4HCe64g0NDYhGo7Db7XItGTRUqxQu1pGREfznf/4nuru70dnZ\niY6ODumuc0yWTSDixWyYeDwedHR0oFI5tiWZnp5GKBTC0dGxgDIFkJmNqyRmACemfgBgfn4ePp9P\nFnA0GsXQ0BBKpRKCwSBcLpdYyDAj5SZR1YhYjns8HszPz2NkZASpVEqyRxL/3W43gsEgWltbkcvl\n4Ha7sb29jc7OzhOdbNKV2FjZ399HsViExWLB0NAQJicnATzEtKmbWy6X4Xa7ZeMxGDGIqiwPdVqv\nvr4eq6uruHnzJlZXV2U9khnA0pbvx9dRMXEmHpXKsQX4ysqKaJk6nU5ZU9RsoDA1lcJYqakBVR0R\n5b+pz2Fio4YLPpeHgapFSpZAOp2WYRE2fpiVnh7JpCRmc3Oz4KBs4hJOYQOO+1udeuKh39zcfGKQ\nhc8jlBeLxbC7uwudTid7lo1rDmmEw2FEIhF861vfeqSY9lgyUo70nRZvUHmfxBIJppPszAtotVrF\n/TKZTArOqHb+yN2kYRqzIjZR2H2kPQg3hHpqMYgRc+vs7MTa2hr8fj+q1apkj6SAtLa2CmZGOk0w\nGITb7UZdXZ2Q3QlncBKD700iMjFQbpj6+nqZ4Ve90Ummt9vtJzQASP6mwSCDczqdPqFf2th4bBD3\n5JNPoru7G/v7+wgGg/jZz36G27dvIxgMCr7c0dEhSkJc0MSlAUiwV7vNxDM7OjpQX18v+C/Fu2mz\nQik8l8slgXRraws+nw92ux0rKyvo6urCzs6OCIG0traKqhVFqXt7e+X7NTQ0CF2G1iC0lqDmAtcK\ngwxZGwsLC5icnMS1a9ewtLQk+gPE79gJZ1AiLEVuJINDqVSSSR8mAGxgUVyGB70KKfC6kucMQK4p\nAx99mjwej7BZGMgYEDo6OuQ7c9STn0fdfyzBgYciO2plpgrvqJUbf1b9OVaGpEcZjUbZI7u7u9Bo\nNDIhpvI8CcOxJ0FuNrFtToJxSlAdwGHywKGBUqmERCIhAtu8f1SS83q9so4SiQRisZjATcBxA9bv\n92N8fPyRYlr9//6U//ePQqEgGAkDKsfS1JOXgDJvCGelk8mklHfPPPMMarUa3n77bXR1dYmwAom1\nWq1WNg7pIyz1DAYD1tfXRbGek1LEttRJCZWDmsvlYLPZEAqFRKSE2JlKnK/VajLZomp7EugnmV1t\nRqgBtlwuS9Dk6zc3N+ONN97A9evXRW+UUzucOuH7U07PbrcjHo/D4/GgqakJVqsVtdqxnuby8jLe\neecdHB0diUyay+WCy+US/Pbw8FAOGwDCbuC4K+8XwvB5iQAAIABJREFUlbRYFvE7sZRmNpdKpYSf\nSMUmj8eDWCyGSuVYzd5qtYrKFR0AGFz0ej2mpqZk7p+d8L6+PoTDYbS2tqJQKAhLgGOj7NY7HA4U\nCgUAD2EHBnDetytXruDg4ADLy8u4fPkyFhYWJFCouCjvJR+EXviczs5O6b5rNBokEgkMDAxga2tL\nBFcol8hrSgaA2khkds9ONNeETqdDMBiE0WiUCScepA0NDeKBlclkJGng9WK1pgZD4JctP1T6n5rs\nqKU/s2Q1Y+VBzQDf1tYmB2kikRCJRBL2mXHyuhJnJU7NdUvxGbWZRaiGfRSOVzc0NAinm0wflUZH\neh2NNdPptFD7uN4f5fFYMtJ33nlHAG8Ve1EnJzgNQlGPuro64fMRqFenIcbGxrCxsYHt7W24XC6h\nFkUiEcFKqBB+cHAAj8cjm46ZC5WOVCFmdrb5eZuamhAOh+H/yI+9sbFRNCo5KsdMl5vOaDQKJqtO\nErW2tkpHmngpN1Fzc7M4mdI1UqPRiPyf1+uVyRsGKtJYiCETsOccPzPMdDotmpRWqxW9vb2i1cn7\nwYYdIQ9Ve4Dfk/qYrAKoCUkqCiuNurpjpaWmpibo9XrRESC1iR7rDGhsrpHdQBGM1tZWGThgU4fl\n/O7uLoxGo2CeVOyiiAvxT2aCPOQ0muOZ/FgsBgBIJBJIp9PCFU6lUtjc3MSZM2cwNzcHk8kk65WH\nHst3Zm56vR5dXV0CxbC0XV1dxaVLl4Sjy/KVjRhi+WtraxLgCCvRU4wVE4MOP0s6nZY5fJXXSq4l\nD6G6ujp5HzX48b1Ow21qN5uBkw+VA859y59T4TFeG+oV8JpZLBapwmiEaDKZTvQ/uKbZMFb7A6TJ\n8UHmjvpdeJ/JZQUgcINWq4XRaJRJO0JwpFkZDAZcvnz5kWLaYwmkt2/fPnHBefO4KNgppzAvyzR+\nYWaAPMEp4NDX1weDwYBQKITbt29jZGREVNMPDg5EUIFTLqoIAktxyoGxVGOA54KgxQepV+S+sSyj\niDLwcBFotVoJJCxfcrkc6urqsLe3B6/Xe6KRRnyR5Q4PFgCCJR0cPPRvj0ajMpfPEocZPTPF/v5+\nEf4lrYfQAbMYFSsjrsRgQYgBgJzWKkbKz8bPrzZj1DltABL8OOVDMeB4PC76AF1dXUin00KzYcbN\nDj6zuXg8Lo07cnE5ocN7QXcEBmtey46ODsHbiHWSE0qhD51OB6/XK5xSKoBRFFnthjO4FotFMULk\nIReJRPCJT3wCBwfHlsD8vMxIGbRaWlpgt9vlwCTfU8U3GRy4/kqlErq6ukTDltdbLdXVwKZCZ9xv\nwC9L1amBkT/Lygx4iIerAU79ef6uZrhc56xAubZ5CMfjcckU1Ubc6c/CIEpMu1qtijwjqVNsPp1u\nVBPDZQVHhTXO4avB/dq1a48U0x5LIKUtB8sFlRfJTdjQcGzgxgZTqVQSnUmWU8SomN5zIQ0ODopF\nM4Mny3NmPVtbW0Ls5kI4OjqCx+NBKBSSLOx0sCSOx8XPIMOSkxkmszQGJk7dEDTnAqY4MqXj2ATh\nRAkN4pghkiLCw4ULTfUUUrMGBmJmKul0GtevX0epVBLJOgZUFW8ib/L0ZiSGxesKQLIFABI4iY8y\nuLDMp0EhJd8Y3HjAcahAo9FI00jVsGQlwGGHQqEAh8OBWCwmDQ1mPezYt7e3i34B1w4lBFkVuVwu\nYXjw/tCOhliny+VCf38/2tvbRcaRbgv8vsyQeEDkcjm4XC709fVhZWUFTU1NSKVSomLGa00YhZCS\nKqBB9klTUxOCwaBwX3n/qaTEYHNaFF0twxkIeR3U/gQDFf+uBlPgIetFxUf5XK41HqB8Pg9jNUs8\n/bNq1qvuEaq4qWuIwZVrk7xi0vSYENF2BYDQCrlf+eDeJ3ZcrR7rP6RSKYkrH+uM9JVXXpEOuxrI\nGASY+QEPG08AxIKDJQ5PJVXP8eDgQKwRKCnG8qmpqQmdnZ1CulfBdgLkbOpwAICZKRd5JpORoMey\nn5kWbXDVk5ev19bWhrfffvtEBsaNv7a2hnPnzgmxnZ9Dp9MhnU7DarWKQyX5pHQI3d/fFzoKs0gu\n5NP8Wm6U2dlZuFwuXLx4EbOzs9jb2xNfLK1WK+N9DLDqpuJGZ2MJgJz0vC8mkwnAw83ITW2z2cQS\nRavVyjhoKBSS7GxhYQFWq1UyNR6W9fX10hzixFNd3bGxH2EAKv8T2mhqahL8lZm52iF3u90S1DmG\nWK0+9HwirshAtb29Lc60/J4+nw9nz56Fx+OR19XpdOjv70d/fz9qtZo0PkqlEiwWizQouf55eLDx\npDIouK55vUmjI6ZPLHBnZ0f2kFrdqYc214RaovNwZnDinuNDvfcMatyTDEpqGX36Z3nv1fdTO/Xq\nHlcPIj64tzj+zYOCa45x5DRG29jYKOsoEokIRctsNkuiw+Ys9yqTEbIL0uk0nn766UeKaY+l2cQO\nGvDwJqgK9QaDAfPz83C73dLBJgZH2S3g4UiaOp7Jf2PZd3BwIHxK4pSc1VbxQE4mlUolOBwOUbHn\nZ+Ji4Pw3bx5LdNJnWGIzQyE2RGdNr9cri5qdc2bIqlNjQ8OxBTMAaTwAEJIys2uesmywENzna3Aj\ncNG3tLTA4XAgGo0inU7jiSeeQLFYxCuvvAKj0SinPBtbpC+p02LMSpiJ87MxSKVSKWg0GunuE7Q3\nm81obW2VYO3z+WR08Ny5c4hEIhgdHRWIxGq1yr0hf5DZ6urqKgKBgGCuDocDer0eer0eoVBIDhk2\nYBoaGpDNZuH3+0UjgaO529vbJ8RcuKE4gkz8rqmpSTA4Zkf5fB7r6+sifs2BAdok8zm8HnzUajVZ\nzyq+qg6bqEGPpTwDP2EHAMI3JYMjl8uhv79fMt/Dw8MT3E+18lBLbVZgamBVG0z8f+4J3ncGMX5m\nrrvTzByVWqX+H/+NuLrKP1YDMxuRbGKR3cAZf35GHj4k2nNCipg7vd3IU1WrY65hXudHfTyWQKri\nKZxEYsrOG0c/bwpnqF14dvK5APizzAhYyrMz7/f7EQ6HYbPZsLa2Jj+vlqNcpFSWIeWFZYx6uvJG\ncjqGN4IZKEszLgh2R3mTGJh5mppMJrz//vv49V//dbH12N/fh8/nQ11dHYLBINrb25HJZKSEYRnC\niR9u1EgkAp/PJ11pvhezycPDY0/7zc1NGI1GBINBOBwOfPGLX4TZbJbZfhUH5unNE/+0eLBK9Ukk\nEshmsyLim8/nUSwWhbtJpXt6vNfV1eH69etoa2tDMpkUgjk3GlkW6XRaOLjlchnt7e3ivsrNs7q6\nKsGUfEGLxXKCtUGII5vNymFksVgEs6P1Mw93Umm4qTiSqTbTDg4OYLPZxMKYQatWq2FjYwMazbG2\n6cLCgkAfNpsN0WhU1hcPC0rpqTg5gwSbMCx5yav1+XyiUs9KhgLbvN7sKagHATNhZsbUlWBGzApR\nzWCZXHAfn+7w8xpx7Z0OjGp2y3vMhwoN8BchNPpmccSX6llkMxDb5rXhQcU9R+YEecmceKP6F9eH\nWrlwgu1RHo8lkJ4Gs1XMhRkPOXfk15ELGI1GZSKEJR/hAQa+cDiMVCoFp9Mps9sUhGXXmY0FdsqZ\nDXAhM+tST8xarSZZikpV4lQLT39+P2bGKv7Iv3MRMVDRyZNldX19vcil0auci44mdoVCAXa7XbQC\niJ/SUplwgErlYkBtaGjA5uYmBgcHEQ6HRchld3cXs7OzsFqtsiEYUFUIhAceDw9+N2LL7F7z0OIm\nojByuVzG9vY2VlZWZNSR5XWpVEJ3dzc0mmOZPKfTia2tLfF8SqfTUkHYbDY5QOnFxM145swZrKys\nCC5IvJk0OgBybThYQXsQNj8KhYLQsFpbW4Uio3oMsZlBqIkHLQ/JfD6PcDgs95H+9LVa7YQtBwCZ\nssrlckilUrKG1Pdi5cHnkzZGVkRj47G9Dgc6+P3pOMrvQyUnBhu1smH5zHundvFVpo2aMaoBn/tF\nxTKZbavTYKchBQZlBncV1iGMQ8yb15ufiSIpbEbyfQjjEX89PDx2r2DM4Pj5zs4ONJqHHNf/L4/H\nEkjVrjJTcwZKBhDKxFFpZ2FhAY2Nx3YK6gnLrrFOpxOxkKamJgwNDQnOxYu1srIipR7Ferlp1LKF\n+AvTfpa6LP9YEnGxcLLJ5XKdwCr5eiRpM+ifnpqq1Wro7e3F9PQ0Ll++jNXVVdk0lUpFGi5ccCTY\nh0IhuFwuADjxXtlsVk5xBk0A0gEvlUrweDwoFot48OABBgcHsbu7K9+vsbERP/3pT2U0UcVZ1YOF\nhGie3Mze2BwgJsVrVqs9dESlmIRWq0VLS4v4TtHyheU4syKn04lMJiO+8QyoXD9kRJB7GwqFRAWe\nlDS6x9IbnustHo/D7XYLzlutVk9k9DzYeA+IUzP4GI1GLCwsSFDiz/He6vV6lMtleL1eaDQazM/P\nw2QywW63n3h9NseSySTy+Tw8Ho9gpqlUCo2NjcIvZmOsvb1drnmtVpP1xzFKBhomBnQ9iEajsk4J\n4TQ0NMBsNqOhoUEoUgzCagDlQ4Ul1GRBpVTxWp1mBvDPp6+VupaZZJG+xMozk8mITQ+/IysZQnbx\neFxkKKnly33Bpinl+CKRiNwD2qqr5PxHeTy20p4PYpgjIyPI5XKwWq3Y2NiQTIbBjBkLyy0KX8Ri\nMSSTSTgcDmlkEB/jBePrcEOpTS3+TrBbba4AOJF98aZy4ZBZwAXOjO20qozaZee/qRk5sxhmRSpB\nn80uZr7AQ+OxS5cuCdzAxUdaFBsi6qJk44aUj/HxcbzzzjsIBoMIBALY3NyUzOoP/uAPMD09LT5N\n3DSsFviZ1GqiVCqhvb39BO7Gzc1DIZfLyTAGACFWM5BUq8e6oA0NDaJ4RUsVSt7ZbDYp+ywWi2Ci\nzLTYuGG1oeJ05A6TemYwGMTLiXJuzEY1Go1M15By5nQ6UalUxOWgVnvoMlBfXy82M/y+avbGz0Xm\nQqFQQDgcRldXF9ra2uSzk8fI71itVqVJoqobkfqkNpjIP6ZqFoOZCu/QcZUcYAqyHBwce2V5vV7s\n7+/D6/Xi8PBQEh1m2mrj6ldlpGqnnxm/SonjemTQVX9XoTQ+l+tepdZRpatUKskY7MDAgLguGAwG\n4SSHQiFZK2RI5HI5afzW1dWJfoEaY9j1f5THY+nav/HGG1IukFZC4QXKdVF0pK2tTbrsKjl+eXlZ\nplUo/+Z0OuVEInZJfhi5lqTLJJNJWeBqZ54lEQU1eGpzkop4DzNKblieZOqDmQQnSdjEUOkk6oJh\nRkO/Gy5Ybhh2kzUajXzPYDAIq9V6wg2ReBfLUp6uLP9YKuZyOZw5cwahUAjZbBZ9fX2Ix+MSQChH\nt7CwAJfLdQL2UPFitdHHP/Ne8XqpvFRCKKfLYeJTlLDL5/MYGRlBLBYTs7xqtSrcYFKVdnd3ZWJH\no9GIqIwqvcdgnkqlZL5avfZUFWppaZHPyjVHJamWlhaEw2GYTCahfjU0NAhxn+rq/L4kwvO1iMHz\ngGNDK5FIIBqNSqeZHWQGXh5cHHFmlkk+NDNsHqBtbW2SLasTg1wXDICk2xFjVOlEAGSPMTmhGDer\nMxWaU4MnA6GaeaoBVy3h+X/8s/qLr6023Yi5qrxWavgGg0EJihrNMeWP8CC/H7+z3W5HR0eHcIxZ\nzZC5QXjkU5/61CPFNO3//pT/9w+aZJE/CkAaLyz7uMB54p7uQNtsNnHHrFQqMr2UTqdRq9VE8o7z\n2MRJiXOqpQQAWZhkCbCkVYnNaqpPkQiNRiM0CmaR/MXNY7FYkE6nBetl8AFO+k45HA7Mzc3J5I5K\nGeH3ZsOBjQpSv9TFrC42Zq8MogwYzKLi8Ti8Xi/q6upw7949dHV1Cf92d3cXbrcbly5dkpluBjz1\n2jGoqfADy0kGC94/loDMhhhoSaCmcIjZbEZ3dzdmZ2eh0+kwPDwsuqHpdFoOllgshuHhYXFcoNZk\nKBRCtXo8YkxJPw51UHuB1Q7vCwWueZAAD4NXR0cHHA4Huru7hXdIqMJoNKKnpwcvvPACnn32WZTL\nZYTDYdHn5MAID3i1ZGVjtaurC9VqVXyTXC4XOjo6hMLDe89AzLV5dHQkuCv3FFks9EVqaWmRzJx8\nZDYtGUBI+ePBq9PpYDabMTY2hubmZszPz+P111/H1NQUqtVjt4SOjg45LNWgqTIM+FBZHuq6Uf9f\nbcCqGav6ULv/ak+lUjmWoSRWSjsXk8kkMYLXn/zsiYkJ1NfXo6+vT+4LcX1ev0d9PJaMlIo6avlV\nqVQE22KmwsYL8JDbRtoFT6SNjQ10dnZiY2NDQGa1w8hUnuU88dD6+uOZb2ZELEGpMgU8LEsYOLgY\nCeBzo2azWckWVaI9KTd0ImW5xrJRPYW5KOLxOAYHB0WlngC9SlRnJszFpmZ6wEklqUwmIxNgaoeV\n1BsA0mgymUxyPXltOLvs8Xjw5ptvwuFwyEYGINkV74maTah4FLvYKmbG60A8jvYQXNQMHEdHR9jc\n3ERnZ6c0Zf4Pc2cSG3ee3fdvLdxZC1nFnRQXSS1RUkutkdTdY/cybttjN2JMkAEcw4YvBnzMMZcg\nF599yCHXHHJIfHE8WeAE8IxnOjNpT8+0e3qTRElUcyeLZBWrWBv3YlXlQH8eX/1b9miAAMwfECSR\ntfz/v9/7veX7vu8934eA0SewPKanp7W5uanJyUl1dXVpd3fXiiVYNzxCoBpgn1qtZjQrWvQhj2tr\nay0e8JUrV1QsFnV8fKxyuaxcLqfnz59rZmbGWi6SwEAut7e3FQ6HNTw8bHtOBFKr1Uzh7+zsaGdn\nR+vr65JkcAYQEYabcLRSqVjoC25Mk+5Go9HS8ch3awJKks7H+XCvOAkkQ4eHh60t3crKipaXl9Vs\nnjVEJ0KiIQo4uTe6wcSthxxe5DhwhoMKGXze86aROf7AswWSou0eDW1IWm1ubmp3d1fRaLSFv0zP\n2wcPHryUTrsQj9R7U21tbdbHkXB0dHTULLhXWv5wRqNR7ezs6PLly+bK0+kdBVgoFCyZQPVTJHJW\ns0+YjyARwoEH9fX1WbkZuJnP5BM6Bb1WqTXLDfZHO0AOsTcM3jseHx/X06dPbeN9ppR1CkIDHgdF\noLzS39zctG5AHFQ/iZRKoZOTE42MjOjhw4caHh620IhEzh/8wR9ocXHRDjNYrz+Y3BteCl3UI5GI\nJd18HbkP76Wzw8xYEXognJ6e2rpAb+rq6rKqJcJ4mrTQMxb6Dz1giUhYFzxCKq7q9bqSyaQlrwib\naXAxMTFhUwro6gXezD4zCqZSqWhmZkbf+c53dP/+fVOC165d09DQkFZWVjQ/P2+UJww1yoxk3M2b\nN/XKK69od3dXW1tbNuMJXvLx8bFWVlbMswcymZ6e1r1793TlyhX19vZqbW3NQnRPw+M8kcyRzrL7\n29vbhuVidOHDDgwMKJ1OWyewzc1NffTRR3ry5Ik6Ozs1PT2tdDpt++mVIvtO8s4beM6DT3D5UN/r\ngSCmynu8QsbgNxpnDXN2d3c1OTmpsbEx1etn/U1HRkbMQKytrenZs2eSpKtXr+rRo0cvrdMuxCNd\nXV01DIhSRElKpVJ6/PixLl26ZLQfT72AtMwBQ6DI4A0MDBgnFa5ZPB7X1taWgflQS4aHh/X8+XNj\nAUhqSewg7BzUoaEhgxm84kcZeEIyP4N/iCKF/4ki8R4kz9nd3a2nT5/q7t27KhaL5m3iKfskFYkE\nj3t53G9/f99CG4QNriGQAvfgO9HTFevKlSs2m/3w8FD5fF43btzQkydPbCBa0Hvw/2YtKHFlxIk3\nJFJrksIbBcoej46OjLIEBghPEtI/JaPsQXd3d0sHrYWFBd24ccMURFdXl3F2UeaFQsE8czBXDENv\nb68+//xzzc7OmuKBgxkOnzV/2d3dNVZApVKxGm56yF6+fFmlUkmff/651tbW7HnX19fNeNArlvWj\na1itVtPly5dtei70wEajYSE6yclcLqdqtWpNe7q6uvTqq6/q2rVrWlxc1MrKinFK/dliH+glCkSC\nh0cSlftLJpPmENFV6fT0VAsLC1pZWVF3d7emp6dtNA3Qj/dU+bdXhMgCSTT+jzzxb86fdJ7p5/PY\nd+4J/mi1WrUmQx4nB88GB37y5Inu3r2re/fuvZROu5Cs/dzcnGUEpfOHr1ar1vJtcnJSpVKpxYoR\nypBtQ9B5TbFYlCTzvvr6+lpq1b2iQZFI5zjl6elZj1I6SjEvBmgAt7+np8c85kqlor6+vhYck6tW\nqymRSGh/f988TDxmHwpzoFAy3FcwGeUVKJ4oWWKUAaGVL1RoNpsWvvvGDZ5jurOzo6tXr+rLL7/U\n7du3FYlE9Nlnn+kb3/hGSyFEoVDQ7/zO7+hHP/qRKSSfvfUHgTAeDxYFDmUK4ff3SejYbDa1uLho\nLAsMJEkcjzf6zllgdOwjVB5gAQ4nySvCd0lGC0JZ8T2EiZOTkyZ76XTa9pRkJnX+W1tbun37trq6\nurS0tKRQKGShf7PZ1GuvvWZjjzEYe3t7qtfPOpplMhnt7OyoWCzqypUrVl1Fo2vCWs9TlmSc6+Pj\nY+XzeYVCIZtI8OTJEytOSafT5gnjzOCp01OXevOpf+i7WygUrDdAKHRW/AHMkk6nDZ6A20wENzc3\nZzDRK6+8otHRURUKBVWrVZspjzyjC1CUnkqGbPmsv38vf5ATCmbgk0Mjw+jVajWb+0VDHZ8EvXXr\nljWoeZnrwubaQ44nrOOQ0rgV+gXlXAD7YJk0yMVTw1vkqtfrNn2T2lkPVOOtcLDB7KjsIDTe2tpS\nOp02JVir1TQ8PGxhP5bOj+dFQZbLZY2MjGhjY6PFegZDE2+lAblRBlhyLxwoHlgN1Oj7JJ10LpS1\nWk2VSsWUIQbMY8fgusyP7+vrU0dHh3mmYEuxWExbW1t68803NT8/b4oAZYrQ+8SCV/78jPp41oI1\nwAiEQiHLjmMQE4mEJSPBb/G6o9Go1tfXNTMzY+WkvAeKGk1vfKvCUqlkho2qL5QaiTraL8JTRGYj\nkYiePXumVCplkRHd3UulkvL5vJLJpMEjPtu/uLioDz/8UF988YU++eQTLSws6PHjx+rp6TEHIZ1O\nK5fLmYeIAqMxOIfeM0GI0mZmZlqy0jRHX1hY0KVLlwwbRGaLxaKq1arW1ta0uLhojZSBlHp6ejQ4\nOKjZ2VkbJT08PKxLly4ZCwYeZigUsn4Xp6enRuHa2NjQRx99pPn5eUlnhotheIToJGy9o+PzCXCZ\nPTaKzFEQ4jF4Gq3zOeQXMNqc4Wq1ahDh0dGRyuWyenp6XnrUyIXxSHHdJZmnubu7q0uXLunk5MRG\n5I6MjKhUKlmtbCaT0eHhoU0ExeNhPgxKwY8NIdlxcHBglTAkGTi0eH8+sQO9ZHJy0gbDHR0dWUYY\n4ZbOky5eWZKwKBQKmpycbMGLvAJFKFiTZDKpubk5/fZv/7Y1BMa7814k30Niy19eOWNxt7e3df36\ndTMC3puRpEKhoEuXLtlnQR/69NNP9dZbb+nJkyfG1X3+/LneeOMNffrpp3bAPejPuuIpQMHh2WFu\nYOR4LxU/vvUeCQ+8TqpXtra2LHlCog/lgMyUSiWbUNnX12djfGEaUKyxu7tr5bZEIsjbzMyMcrmc\nYeyRSERbW1uamJjQ2NhYS9IG2QYSajQaVsKJcYxEIpqdndXVq1dNZsbGxrSxsaGf/vSnGhoasuGI\nGAAMPIoEw9xsNm1SAnvgO+Cn02nNz8+b8hwaGlImk1FPT4/1MqjValbkgBKKRqNaW1vTtWvXtLKy\nokajYcUC5BaItjBseJH0jyB/cP36dZNfPx58c3PT7p/oLRqNWgtBZAHs2PeW8Hg8Z7xWO5vMgEKE\n+4ty54zxuZ57CzUOBwyn5WWvC0k2EQL5JqzcON7L0NCQNTQGF/3yyy91dHSk+/fvW6mXdLaQeKso\nV0JESv7C4XBL+Oc5mmyAJ8rDmQRv9Y0MwKhQxhwSrCDKElwJjqy3pNI5VcRbVa9sCd0IbUlCeGwO\nBYNlJVsK5uSVz9jYmObm5jQ5OWnr4RNGZKYnJyf18OFDSecliz/72c908+ZNS75Eo1EtLy/rzTff\nVCaT0eLiot2f1IqRoly958mwORIOodBZ93i8X8ozw+GwZdI9l5biDRTtwcGBJiYmTIb6+vo0PT1t\n0QZVXbwepYkxAdOWZI274S/v7++r2WxqYGDAwmtKhcFYs9ms1fd3dXUZrWx9fd0y+xsbG/Yd+Xze\nSkC3trb0N3/zN9rY2NCDBw9sbA7YNDgojAaUP5glDAdgqEgkYjLLQEaUgpdRJtFiuCg7xotkL/Hw\nOzo6rIMaDJlEImEDAb3Hl81mrXqqWCwaLFCv1zU/P6/PPvtMuVxO6+vrxq9mtDcd8CWZZ0yyEBZF\nMpnU6OioLl++rBs3bmh4eFgjIyNKp9M6ODjQxsaGTTygrSJyyUWCjfvq7Oy0JLQkTUxMvLROuxCP\n9OTkxLwKsEssCQeNUbzValWXLl3SX//1X+v+/ftKp9M2hA33nEXiwBImZLNZjY+PW7YRrAtPCSuJ\nR/yijLynJ9EcGmyOBhF4pyhkYAs6QbF5WETPR/X4jv/+wcFBq3Ticz3tC4HlefASfO8BPo9/Y0Ry\nuZz1ePVcOagyJycnljzp7+/X6OiolpeX9bOf/Uyvv/665ufnra772bNn+s3f/E2FQmdTLBk4R/LH\nQybcm+8NwGtCobOyvpGREW1vbyudTn+NrcH9e6oZioBnPjw8NFrSw4cPNTg4qFrtbFQKRROsNSNI\n+PzDw0ONjo6qp6dH29vbisfjFhFUq1VrbrK+vm5yODMzo1KppIGBAR0cHGh8fNw86eXlZc3Ozlri\naWhoyBKi7C11+8y0AnvHG0UR7O3tmUffaDRswB1eJLIhybpvoQCJBnzF3YvCZhQyigVZJLGFN0w3\nLMJ+WgtKsp4QPonMcxQKBWUyGUUiEWugjDOO4L2dAAAgAElEQVRBRRfVZaenZ6NvyK6HQmfThHt6\neswow4QBI4fzG4/HrRKOXhSwOKjiAiLk7HGe8caPj4+1tLT00jrtQhQpiR28qq6uLhsV4VtaETos\nLi7qu9/9rpaXl42HJ7WSf6XzcJZ/wzFkgemKQxjAweb/eHIA6SQ0PO0JrmEkErGeoHhOKAf6KhKe\ngANJsrA3qPx9oqnROOvUv7i4qAcPHmh9fd0Ucjab/VqGkwNOqMv9eUyy2TwrUrhx44Z+8IMf6P33\n31e1WrWOUsw+glY0OzurL774wqqbpqentbKyos8//1w3btwwT8KT3w8ODqyd3fPnzw1iYS+DHjn7\nxmFvNps2CbKj42wCJpnl09NTq61vNBpWZMHAPvoPvPXWW3r8+LH29/fNs2tvb7cyz1AoZIeKxieS\nbN93dnY0Pj5uTVJQPqlUSp9++qmmpqbU19enw8NDaxADjxgMF8+Zw0/H/r29PW1sbLS0wINZEomc\n9VZlLdPptE0RRZZwEqiS8+NbUGqUK4NBVyoV8/gwClQz8Xk4CT5cJhorl8stLBOcC8a1QOwHMmMt\nUVTIdbVatQIBois+D3nt7++3M5jL5QyC6OvrkyRLZvmELNMyPIsA56Ber2tra0uNRsMYEaOjo5YM\n4zkoSPDVWhQnvLROe+lX/j+8fINmcEk6FmGVCc8g2n/11VeGhSEk0CnAqADffUklB4zkFbgVvD68\nWqw2WVEoR/yuo6NDmUzGhnf5en3CT4QMZTAwMGCUIs8a8P/2FCKElcNDthPlA1aEJ+1r6TOZjG28\np4qg4OkY1dbWprGxMX311VeamZkxjqk3YngBqVRKP/3pT/Wtb31LxWJR09PTevTokYrFosbGxqwW\nGegB3LpcLuvy5cuampqykL+trU1LS0vWj5Wf4UUSJjIRAWzz8PDQ8DfPaezu7rbS22g0qjt37qir\nq0vf+973dOXKFQ0PDxtEALWFw4O3BAmfZAjtDjG6GFLKhe/evWtt+Ogi9fTpU127dk2ZTMZauBF1\nAMtEo2cjmCcnJ9Xb26upqSnVajXNzc2ZbOHl3rp1yxQ+igjMz7Mtksmkrl27pmQyqd3dXT158sRG\nhuMx+g785XLZns9HYkQ2UOOoCKIfgVcu/EFe8FCRQTjYkmyd8XA9X9QnfH3onc/njc8N7s97PdxF\nQon98U4DZeE+wUnHNxrTbGxsGGOA9/b19RkU4NkxL3tdiCJdXl5WKpUypULJFv0mj4+PNTg4qN3d\nXetiQ3KCDQcvIdzhsJBU2NzctCF0HHRCSqwZw9Nw73HpAaDBWD3lw5OEsaooRJSrx5gWFxfV39/f\nkk3n8uG89xxRftCsUDKEs3S6wpNOJpP2nGBhnjICTgh5/Pr16/pf/+t/aXh42LBHaGU0Jy6VShob\nG9Pu7q4+/fRTXblyRbVaTffu3dPHH3+sa9euKZ1O2zrTwAWPOxKJ6IsvvjCjJkk3b97UxsaGjXjx\n6x4Khaysd2hoyKYDUGXmKWp4LMx3wjstl8tWKulLjWGBMNKF5KMk8wxJpjSbTSszhTqHBwtOubq6\nqtHRUe3s7Oj27dtWYCKdlT8PDQ0ZtahWq+no6EiXL19WPB5XoVCwkPTKlSvmwdJ7dn9/3+QafrCv\n7qOdXyQS0fb2tnZ3dzU9Pa133nlHKysrWlxc1JUrV+y7mWcFYwNZIPIJhULKZrP2/SSraC7DOuHJ\n1utnfT0Z08J+oJwxAF5xolDBWWFCUKZLw2y+h32uVqtmlHBWuDjTPlp8kRIMh8MGseEVx2Ix62uB\nrJ6cnLQwOCiR/tM//dOX0mkXokh9p3Eqm1BuTPHs6urS4uKiRkZGVCgUTBkxFdMvHAqUyaHhcNhC\nN6m1FRg4CAkbMsL7+/uW1MKSQXvBI8RLJWNKNhCB95QLEj+MCsGiehwXax7ETPG+hoaGtLGxoYGB\nAcsooqwPDg4M5CeJgrL0uLF0ziDAKBweHuoP//APtbi4qNHRUS0sLFhHIJKA1OSDAeIZVqtVvf32\n2/r+97+vN99807BUOihRzPDBBx/o5s2b1lc0l8tpYGBAH3/8sQH7YGd4R+wFyrG/v9/ul4QZe3F8\nfKzl5WVdvXpVS0tL1sIQalOtVrNKKg54f3+/JVgGBweN8oNhgkbFAUU+gBqodBocHDRP5v/8n/+j\n6elpu6/JyUkrJKGaCwUGhYzPRgapqGN+Fp/FOoEl9vb2anZ2VgcHB1peXrYKL5q6vPHGG6YM4MDi\nbYNp+iQrvVV/+7d/W4uLizaxFnhIOi/JRvZwGPDYPW0Pb1VqnYeEwsbbpz/A4eGhKW2cKhJkwGiU\nAXd3d9t++qYyXsEjR8gUa8l9+mkbJAnxoqGQodC7urpsfPfLXBeiSFFGCNL+/r5SqZT9juFijNUl\n7MRr47BDR2JhGFtL0wsWE6ULqI0y8nPaCb+hyqCksdwoVRQdwsn3e0GiaUQikWip4sHz9PxKT8NA\ngfP6jo4OLS4uGv3K08UA5jn4JGD4vfeAUXB4uD09PVpeXtZnn32mVCql/v5+A/RpRyidlfJOTEwY\nAZ3SyZ2dHX3729/W97//fb333nsWMcRiMe3t7Smbzeo3fuM3dHR0pI8++ki5XE5DQ0M2mBBjyWFt\nNs9qp/ESSIxwGHkmujARwo6NjWlxcdHGgxDFSGoh/ROS4rkDP8Azbm9vt4YX7AWeFOuHkub/3Nu1\na9cs4RGPx83jxpsKh8OG7XJYgRj8Z0UiEcPl8XzxklgruJmVSsVkFz51JHI2SQFivF9XKvHwRil5\nhmO6tramhYUF66LEc3qHgjPDzwm3UdAoaRgOKCpGHPsqJZ8IRSFGo1Er4fUermfBEO1Bd/S8Y6/M\nKdclf4JylWR6x+dWwKIpIvDR5steF0J/8vwvxmP40RZgYzwU2B3KzQu0JPMM8VzAUz3BHg8BK4V3\nsLe3J+ncU/R4DKRvNoHPRGjwFILVTPxNYoTv9rSkYNLFK1AOPlYczBb8GOYAlTsoc0afeMHz5aBk\ne5lQSkUK2eydnR3t7u6agYvFYioWixoZGdHm5qZVcJH0+uY3v6mPP/7Y2teVSiXrR0r1yt27d/X+\n++8rl8vp448/1vT0tIWuKCsOD94bhsk36IBLGQ6H9c4776izs1NPnz41ehdZbf7PQaCElnElRDvw\nF0dGRlSr1Vq6V4HfHh8fG1UKOILwFC+LA0kv1PHxcZXL5ZaZYPBCvSzCZcYYwl+mwQx7gfJFBr74\n4gutra3ZlAjwVLxQ9g455fPhVJIABOpiiivTJFhDH335VoB4pRgE/u+dAw8l+agDGef9PHfQQQHn\nPDk5G4lMtt1Xw1GBxbA6vFd6yRI9UGKby+WsVylwQiwWUyqVsufycMyvokSlC1KkeEjgV/DpyC7S\nqASrxUZKZxsFbxNsD+wDTMjjQCSdPBZGqMC4XawnBwPrhgIiC4iiY6O818pmAITDRPAd5nlmPguF\nyef4sB+Qvb+/X/l8vqXLviRrBecrXlAANCTB4+Vz9/f3rZbYD3orFArWyxWBxNumPyieEN4Ra3P1\n6lX96Ec/0qVLlwxv871Zs9mslpeX9Yd/+IeamJjQhx9+qLfffltffPGF0dF4JrKn7LF0Pmaa3gjX\nrl3T+vq6VldXrfqKZNDu7q6RzNkrDCOKEBmCB1woFFoMoyQLM+HFHh0dqVQq2fpitOnfAC4IbknX\nsmQyaQYwnU5bcwxPifP4Pf0MwPLBdvEKh4aGNDY2plQqZZMQUNgYOM4XiRhYMUQrPgQGYuP7vHyj\n8E5OTmzyKQqGzwci8w1Q+GzOGsbJY5esCd4/+8TlX4fM7+3t2eRYjAvfybnifmDpJBIJDQ0NaWRk\nRDMzM5qamjJmCnBFuVzW7u6uSqWSJaA4k7/KdSGKFMuD647XVqlUNDg4aGA8Hh0LBQUGDl13d7fN\nAEL5Uj6HZUXheevvweh6vd6CB0lqwV9QroxQlmR8Rh9qc/gqlYpKpZKGh4ctW8jz+swnFi/II+Vn\nfHcikdD8/LxisVgLgZyDj8LlvYR2ZPv9hfASHnHw+/r6tLOzYw2TKY3kUBQKBatw8WEZzV+6u7v1\nwx/+UJOTk0Z7AY8Nh8/qtx8+fKje3l4NDg6q0WhoZmZG+/v7prQ9LYwogLJYMN533nlHn3zyiR4+\nfKixsbGWqhqfQPFMB8+K4HtgeeC54RXBQiAhwvwiPNFarWZjfePxuHZ2dsyTZISLj5zw7o+OjrS2\ntqbNzU3jieLxJ5NJoyv5Z/fQF4YS+lKwuIGIhAt58oYJz56IiEgF+ed7/DngDFBqi6FhHXkNXr9n\nKvi8hGeieIXnnRX2zFMb/Z/+/n7r0BWsTOJz2WN//iVZxEH7Q6IPDGpfX591s4JChbP3steFKFI8\nPKpGCAc9HhOseiIRQcNbLHaxWNTExIT29/cVj8e1ublpNCpJ9l4/HoMFp4EtigHryKbg2cGZw0vi\nc3wGH0vW1tamVCqlfD6vcrncAmP4zfc/9wLEvfiLul8vwGTrDw4ODEMGoyQ04+K7vbKm+Qqk7c3N\nTcukElYPDw/bVIC9vT3duHHD8D6eN5vN6sGDB+rt7TXeKb0Q8JI56HgvP/zhD/XgwQN9/vnnyuVy\nLXOGuru7DUI4PT3VycmJ9SrI5XK6deuWNbTxBoGRJfwfZQmHkUw9Bs17HxiogYEBozf5aISSy3g8\nbpEBLBKaQpN85AATSWHEY7GYFSpI517v1taWDfwbGhrSq6++qnD4rMcD8BAwiMc7wfS85+YNko+U\n6J7P7/GKMTy+vNefg3A4rDt37igUCimfz9uQveA5gQyP0uT5OOtwXQm78Sp90xUMg0+IsT94tsgy\n3x08K7yXtYJaB6yBzvEGlrN8fHxs40e8R/+y14UoUkLv7u5u5XI5JRIJq7Lxw9O80kDJ4rZHIhHD\nBHHL4QQSLmGZoI8gYOA7hP2U4Xll68O49vZ2TU1NGQWDjDDfgZKiTI/EB8LqlbekFkH0Ib+33N4y\n03iBJhTSeUd/xgrjhXJoOMzcm6QWAL9eP6t7xsLfunVLz549UzKZNEFaWVmxZieeuE9fA3iT+Xxe\n9+7dU6lU0s7Ojvr7+01RSeeKvL+/XxMTE9ZW8Ld+67daMuXFYtGqrvb29vTFF1+oXC7r3r171oGK\nkTGMckaJgRciK75kFwMnyTiLhL0YbAwlY5HptgTVjuoiXouypssUSojvxDOr1WoaGxszY04yhj2M\nx+NWBVYul/X48WNJ0m/+5m/q4OBAi4uLhpcWi0Xz8vFgkZvj47MJodVqVYVCQYODgyqVShodHTXl\nABEfBZPNZg1fBGuVzpvqHBwc6Mc//rHtyfXr15VIJGyNvMGgwTQeP84Q0R/jUPCAcUR8EQAOCd6z\nzyMQbuOE4PX793kPFMUOKyKoS/Bq2QuvHzy+/LLXhShSlAc9IH31kF8sFA3UHXimWAuyypDfPUwQ\niUSs3yAYDgLCQTg+PjawHaXnLRXYU6VS0c7OjllAqEfcH5ffdEI7X5bnq7l84on3eKXsr4mJCW1t\nbalarRqZvNlsmgdG/ThQhp/f7r0MBI6CCKw3iiWfz2twcNAOaWdnpwYHB40atr+/r+npae3s7LTQ\ni0KhszZxd+7c0dOnT9VoNDQ4OGiKiYO2sLCgn/3sZ3r77bf18OFDG+2B5wnNa2lpSTMzM/q3//bf\n6tvf/raePHliSlKSZa193wSScpC5wcS9QoNTyDyezz77TPPz8y1Nt9mjaDSqWCzW4uV6NgU0t1Kp\nZGWhGGgMjHSmuLPZrCk69h/ljqecyWSUzWYlneHCT58+1YMHDzQ4OKhEIqHx8XFNTk6a9wj2iFI5\nODjQ/fv31dnZqdnZWf3iF79QW1ubtre3rYxTkg3YGxgY0BtvvGEGY2hoyEJkIi+6gTG2mf6mnAWy\n3d4BQB6IRPCgeX2Q8obc+zPhf0fCVVJLMhBowE9AxXFiOigVX0FojaYp3BfGyHvYKOGXvS6kjd4H\nH3xgIfDW1paB6j4k8eR2lBujIlB4hPEemwI3C4fPKkKePXtm0IGnBIVCIcMwqeE9ODiwQ+K9KRJG\nbACNbDmcKG9wWHCXra2tr5WHSq34Dz/3wDv/J+zs6urS1taWLl++3DIaGEwYPE8683IGBgaMKM/3\ncZE4IbxC0UJ7WV1d1dTUlGXBT07OJmfCR0ylUtY9yVdDcb9jY2P65JNPjOBNI2kUT39/v773ve/p\n/v37SqVSqlQqOjg40J07d7SwsKB3331Xr732mhYXF/VXf/VXWlhY0MDAgDE1IHbTywDZ4dngiXL5\nloN0GNve3tZ7772nf/Ev/oWF+Xg4eFgkkDzthwMMmwAPj36zNHRhRDLfiXxwQfDn8HZ2durOnTu6\nfv26otGoMQyy2awGBwfNEyZy8jLkIxk69ZfLZZ2cnOjSpUt6/vy5vvGNb5hDwrmo1Wp6/vy5Ojo6\nLJnjG1mzBpwBSebdpdNpWx8Sezgm3rABj7CO8HO5vCPiQ/eg8uNCEeII8ZmsI6/32K+H0vzvvMcb\njBT9d77zzjv/hCY7vy7EI+VgIYhe8Lk8BYGkE95dNBo1Wg6WqKenR/l83rhweAVQOrxlZCGPj4/N\nG8aqged5pUuj4UbjfGpoMPQgBOdzoU4Fk0oe4+H9Qevnv9snUYAVODh46ig56FCU2gFVeCUxNjam\nqakpS+5FIhHr+IOH+PDhQxsSVqlUWrpnHR8f68aNGyao/oBy7/fv39dPf/pT9ff3S5J5RHg7f/AH\nf6CFhQX99Kc/1eTkpDo7O7WxsaGrV6/q008/1fe+9z2Fw2HdvXtXV69etTCMqhOwVkL9Wu1sDEYy\nmdTm5qbee+89gwKQg1qtZuHxn/zJn+jx48f6sz/7Mwtv2X8iGCIkn6zB4yEByQE+OTkx43JycmIe\nG2R6cDlYHaenp9Yfob29XXt7e/r888/1gx/8wGZ1xeNxq18nsvIwBfdL5h0MkrN169YtNRoN/d7v\n/Z41HeF9zHNiyCLK/NmzZ+axbmxsaGNjQ9vb21aB1NZ2NjzQZ7jxFn0Rgo8qoVB5g8SZpoG2TzoD\nV7woYcU58pdXet6z9bqDffVQj4/S/Gd6GCD4Xf/UdWH9SGmIAADNwnuFQ/kinaB8OFOtVjUzM2OZ\nU9pw+c3EO4SuhGLB00U5oMzA5uioxIZQ2dJsNo1KgmDwLFg2QmKSAT5E8dbQK3T/cy4sLJBDKpVS\nJpOxSg8woL6+Pq2srBiJm88F6/SeLhn4ZrNpBRB4cTT5oAsXjZHj8biKxaKtKwRrcC9Cd69su7u7\ndfPmTf34xz/Wu+++a5EDzzM3N6d79+4ZLjo8PCxJevLkiU3OBDMPhUKKx+NW+spYmfb2dq2trSke\njyuZTCqXy1lSDuwSA4RxOTw81He/+1397d/+rer1uu7du2eekC819B4MhhMDLp2zHzzNDgXnoQQM\nAAqPqAV5gsIUiUQsK81YGCIZMD08Oe4vmBylZr9cLlthQLVa1cLCghlSDBHNZSYmJrSysmJngh6i\noVBIo6OjhkHX63UzhMgjCotm3z7rzjoGIzFgCQwh54yzxLnx2f2g4guFQi2QjvcuWSefzAXv99CZ\nd1T4br7TN3v/VUL7C1GkhMnMk0F4sIw8PNQRDmqtVrOa8Hg8bgkCMBcflqNA8AxZTDZPUounQKh4\nenpqIRWCTHMFPFhJ1vcS4J7Qk2oYKi+8wPvLH1p+/6LX8ix9fX1aXFzUa6+9ZiEcF2vguZdAHlxk\ntgldyQonk0kTTEnWk/Hp06d65ZVXjAhfr9cNO93b27NyS/iUNIrwXfpHRkasr8L6+roGBwcNZllZ\nWdHjx481MzOjV155Rf/xP/5H/dEf/ZEODw+VTqeNGwxXdmBgQKVSyRIq0WjUqtGWlpbU09Ojqakp\nNZtNS+jgAVM+/P777+v73/++4vG48U99Awx/0NgXvFCfzAhW+SBzZPfB7vBokW8Os1eS9JnY2dmx\niAt4AqYK3iYUK58kA+pIJpPa3t42ZUfPBN97FgI+DXh+9KMfaWBgwDxynsVffpoACs0rdSAHDCiO\nCR65zyEgn5w51pfIhiSVh4u42A+exZ8jb1BYf+4N54bEsIcsULweSvRRq6/t/2XXhSjSSCRiCZLe\n3l5TlsHFA1NJJBIWcnd2dmpnZ8fqwvE8PJ4FNuWbmnhPQzr3ivEgDw4OjNoDrkaigQMApODbrwVx\nG09TQUHxfvBentNji57+wRo0Gg3zQPkZ1DHq3ru7u1toRmRP29vbrfMUPDo8fElWAYUxQUEyqMzX\nW0PC59l8Qo+sP/1NWVvq3bPZrCYmJnT58mWbMpDL5ZRKpfRrv/ZrVgr8L//lv9TOzo41aB4cHNTj\nx481OjqqfD6v9vZ2K1Mtl8umRPHmTk5OtLq6avOSSEA+f/5cr7/+ukZHR/U3f/M3Bv2wP14uOJC+\nuofDxbN6OIffIwd4cKenp9a5q1ar2b8ZI9LV1aVUKqVkMmkd/oETgKl8spXf4f17lgAsl1KppL6+\nPiPOx+Nxa/zin4/Ean9/v9555x2bT8YIYqq5MKDspS+3hVblk0KcO0atNBqNlgq6vb29lh4byAmZ\ncX4GXOATSyhlH7lhmDxG7P/49otEp3wGkarUOi/M7ydR5steF+aRcvGAUutwKzbf0xzwHMFPIDej\nNAj/8Z68h4CV8UIFhpZMJq3/JAvPooLx4PFms1kNDAy0CIF0nrwCkmDaJd4jUIJPEhAiclA9+M79\nggmenp5qYGBA+Xxevb29VnjAz0lexGIxlctlw4h4DsJdDoen/OC1o3wYOpfJZDQxMWFNfQmlWJPh\n4WFlMhmjq8Aa6Ozs1NWrVyWddfr6b//tv+m9994zZeSHEobDYX344Ye6c+eOHfK5uTm9/vrreuWV\nV4xOBc46ODioqakpffrppy1d48EjNzY2LByem5vT3bt31d7erv/+3/+77t69a0oCw8gaeSPm5RPj\ngUxy0KjXJ9Slrd/U1JR5bxgnvjOfzyuTybQoqWg0ak2O2Wt+7jvg851gtMgISnB6eto63BO+g31T\nVOCjDjrcew4ouQIGwmGQR0dHNTAwYIocrBWl6JsDwRvFuTk9PTVY5ejoyJQ130k5aNBo8Nkobf9d\nVDZyVlGm3qvGmyerT9GEz2/4ZBV4blA/vOx1IYoUuszY2Jiy2azi8XgLtuKVDp2UyBjSPR1FIcms\nC1QSlByHgAUFJ0WgUJSJREJSqycinXkZZF0B/emdiafKghNGNhpnBOdMJmN0D16DQvfZyKAC9WsE\nzxALGo/H9ejRI7399tsWShNar6+va3R01NaC3qMcoLa2NsvEY9m5vJX2/Es8cn9vePvlclmRSETJ\nZFLPnj1TOBzWtWvXFIvFlM/n9ezZM3V1damzs1O///u/rw8//FDf/OY3tbq6arX5rD1GACXx+uuv\n69mzZxobG1N/f7+y2azVoKPArly5ouXlZbtvwkaUbyqV0ttvv62+vj791V/9lW7dumV8ShSVh1GC\nnqk/WCTzms2mNTE+ODjQrVu3VK/XlcvlVCgUbICdn0wJ3BQOnzVNicfjGh0dbQmP2QMP9XAfyIbP\nnHMvGM7JyUmtr68rEokY4R/FjlFAwaBAgAlQloS3yCnv4XuBHzgzYJywGPh5s3nWLBk5ApKDloYs\nci5QdL29vRoYGDD6XSKR0MDAgLEhqJ2nypDxJfC2G42GGRF62nJPUAFRyj4xy5qitL1T86vwSC9E\nkZLAGB4ets2VzpUHmXw23JefHR4efg1XRPFBKub/PgHEa4MJLf6gaLDyHDbCf/4tnU/rJCQOhVob\nAEciEWvP5jEfj9vgsfgkFPfM34Qb3lOCm4on5Glj0KUkGVeQ+ngfJgUVoySr8PIHmmcaHh5WsVhs\nSZIxsrezs1PXrl3T7du39fDhQz1+/NgOAJ4BXecfPXqk69evG5Xr6dOn1iSYtdvc3NSrr75q/WpL\npZIuX75sCp1JCicnJ3r11Ve1vr6ubDbbUlywsbGhyclJZTIZ/fVf/7Vu3rzZ0nMVD5qDxHr5PaCj\nVjqdttnohUJBq6urZlgpjkAxjI6OtihClDaOAZ6Px/iCmLhPdHEFIxrPuw2FQkZ1Q7Y8junlHYOP\njPjRK74Mm9AYmeEeiW44Lx42Q6aCURXK60X3Q1TmceadnR3zVA8ODgwvBjP2HNdYLGZ7FI/HNTIy\nYl32pTMmwe7uriVTUerkTrwx9YkqPH+M0stcF+aR0qQBriO4By4/1BamioZCoZbkANaDUDYWi9kC\nULaHIjo5ObFkELga9wGHjsQGfS1JgvF6EmGh0BkhH84pryWTTmHA3t6eKR7u1eNw3kP1P/e0KE8p\nQrnBUaSxNeE0CbH9/f0WMj7YsT/IPtHFmpDMwABw4Do7O23ekfdimWgwOjqqTCaj//Af/oOmp6d1\n6dIlFYtFy57z/vHxcW1ublpImM1mNTQ0ZJ196vWz6Y0kpoBF8Hp/8IMfaGxszIzC4OCgCoWCxsfH\nNTQ0pJ2dHfX29urx48f65je/qbfeekt//ud/rldffbXl+dlHPE1CWjwyGqHUajXl83njWoKLDw8P\nmxdMaOgxU5RI0ONkr/kZCslnl9l3H0mwX/51HR0dmpyc1OrqagvWz+d6fBcjLrVmqFHWvmyWSIR7\n8fuN8eA7fDZdOjcAnBXvOZP8C8o6soeX7NeG9fWken9eJLUkwCRpdXVVc3NzKhQKVoEXDodtXMnw\n8LAuX76sVCpl0S1/gK+gpcG3ftnrwhRps3nWiZxMOaEeAr2/v28jjAkzPT4JXtfW1qZsNqtUKmUC\nVCqVWkJnLHSwOTAbTQhGsgTlyOsRjO3tbVOKKG3oULyf6ZbcM5QTaBUIEgoOJemTUUEPgt9Xq1Vr\naQe7ge9AKTUaDcOKWUeGCkrn5XR8JkbFewzQwPA4aAtXKBQMwrh+/br29/c1Nzen6elpXb161Q4q\nLeUoR4zH49ra2tJrr72mjz76SA8ePK5bG+kAACAASURBVNDOzo76+vpUKpWsi1K1WtXY2JgePXqk\nu3fvant7W8PDw5qfnzfvC8PGvHdoUT09Pfr5z3+uX//1X9ft27f1r//1v9b9+/fN6FHSyj0hG3gm\nePOFQkGSDKNMJpMtXqIP93zFnPeyfOThExnSuaH0yhT5Yn88/xjZRVkkk0nt7+9rfn7eeMv+NUG8\n3XuLnhpEQQc9QPHU2HtJLdgkz+YjlmCk540Gig9F5jPp/vyizF+0FsgsZ82vEYY+CIN0dHRodHRU\nY2Nj5sR47/7Zs2cql8uqVqumPNPptGZmZnTlyhW1tbWpUChYRdjLXheiSBOJhCqVSkvzWy7CAM/H\n8zxFH+ZiFff39zU2NmYLgwDgFQZDLY9T+sMJnMCGY9EkGecvnU633CdANooTb9QrOcJIFKVvoya1\nJjE4QEEvlZlLTO78rd/6LW1ubtp9t7e3a3l52drh5XK5Fk+Vg+MvwsXgAaDai2RHLBbT8+fPbU7Q\nwcGB5ubm1N3dbZU3lJ2Wy2XLokNzAxc7OjpSKpVSqVRSd3e3MpmMxsfHbYbO0dGRlVvWajW9++67\n+vnPf66RkRElEgmtrKwY9kVWNhwOW0Rx7do13b9/X//+3/97vf3227aPQTjHh86NRsPgonA4bJ2k\nWJ+gImK/pHNvk5/5tQQCwZCj7DxZnDX3ipX78rCDlwMGAsIZDkJcnA1vpLm8l4mSB/rh/1R5+Yy9\nNwqetcAzesPMvcMvbTabNpTRQw68Hzx0eHhYtVpNS0tLpuA3NzetMxaQSDAR6M8Oz+g9bJ9cQm7o\n9sSeAhn+5Cc/0dbWluVUxsfH9bLXhShSiOVBjh0Lg4LCMobDYe3s7CgWi9mCek8Rb5asIUIAcd4v\nrF90L7h+pAM/81n1WCymX/ziF/rGN77RYqk8LQjsFAvKfQC2Ex4Fs4EvCvcltXjd3Dv/l2RNShAm\nhKa9/Ww4GiNawBe9ciZDzPcQltH8g3BrYWFBPT09ev3119XW1qbPP//cGgH75x8cHNTa2pop7YGB\nAW1sbFj3fJJ909PT+vLLL3X//n1LWDWbTQvVr1+/rmazqe3tbb3yyisKhUImB7dv39aXX35pB5JK\nK2rn33jjDX3wwQe6f/++lQqz5ihz1sEfQm/Mg96VXx8fFr8Ia/aKy+PJ/D8YLiNj0nkjH74DhcF9\neUXA64PYJZ8Nw8Ird5Q63+NhCDBJHAFk1+OjyGXw/0Rt/ndgkEQLk5OT2traMkMVzE/s7e1pbm5O\njUZDExMT6u7u1qNHjzQwMKB0Oq35+XkzDr5rlD9HyIRvlenPqN9n1gCslz1NJpMtjtL/9zxS6Ryg\n5sB674jQ2ltAlJUfk8CCepef2m6vQH2GHS/Rv8cfELzSaDRqCkWSZeOl80PBPfN7DgWejOepolz9\npvrwLijotLnjM/E6m82mzX7ndxgNxqtUKhWVy2XrJUAFmQ9FfecqD/aTbaWg4Dd+4zeUTCb14Ycf\namVlxZRU0LPZ3d1VKpVq6ZhE021e093drWw2q0Qioc3NTXV1ddls+Pn5eaN5ofgrlYrxEfnd7/7u\n7+p//I//oWQyqfb2dg0MDGhvb083b97U559/bt4FWCgeFZc3pl7ReGPE5bFAvEmvgIIJPCId9tN/\nr3+dl2vuhe/1is7zh5E7nsFjkP41fFYQavARkX9mz+I4OTlrMD0+Pm7RmL9Hvsc3/fC19jyDNx6R\nSMQobOQ9fGNmFDfPRklqf3+/hoaGlMlkFI/H1dfXp3K5bAknD3dI5+OLuGcvn3w2XGo8cOh23iCh\nB34VJSpdUK29TwT5Ch3pvHs5Bxycj0qmZrNpyhPaD6NJWEg2KBqNGiAtnXsbLwp5yMqTWKG+ntcd\nHh7azB/e472M09NT4wPi6eEReWI3RsMfQu9RNBpnxPpEImGNhUOhkCl4wvzNzU1T7HiRDBTDg+vq\n6rJMtU+wcXGwffaS5M+NGzd0//59zc/P6y/+4i9s3hKv8/xejx16Y0jJo8/uStK1a9esobT30oF8\n+vr6NDAwoKWlJYXDYV25ckW3b99WR0eH/vIv/1IPHjxQZ2enlYUmk0ktLy8bFNHX16d4PK5cLmfr\nFcQcudegMvK4mo9I8FyIODy85A0jn+GTL0Gj6S+Us1dwQU/Wy8+LPsN7WsHcQBDb9VxgHzFJsvND\nxhxcMui94vX5GnrOszdK0jksRa/bmZkZnZ6etrSY9GeKaEo64yBDO6TbWH9/v8Fx/tlRzh4a8d3f\n0um0vv3tb+vq1avWXevx48daWFiwfrBAgni2vjLwl10X0v3p448/bml04cNuT4ng94VCwXiEUKII\nL9fW1owHimB7vIeep2yOz0b7DfRZUp+QIKFE1ROv57N4D+3rwEghwH/55ZdWNVIoFFSpVLS/v29j\neD35nyRDcAQwSp2D1t7erqWlJd26dUuVSkXNZtMGCAKB0FEfWITae+4/GHpK54RqFNoHH3xgs3x6\ne3uVSCRssiveOocGjyeZTJonKcmqxjg0UNuAEUKhkCWZmADb2dmpzs5OZTIZfetb39LOzo6Ojo60\nvr6u2dlZra2t6fbt2yoUClpbW9Pv/M7v6IMPPjCeL4lFFAHrQIjO/vkD740te4tS8Jls/1ofLgY9\nTW9k/Pd4Rcnvgh4me+FlM+gE8DeKzOP+/nX+/ryS9feOofBnhwiAn/vvQjlhaNhbr7i9IvVKtlKp\nKJlMWk9amDAe2/TGh2RuPp+3aJQ5S0CDfk941lqtZpEJsvnzn/9cT58+1aVLl3Tv3j1NTk7q2rVr\nmpqaskmy6+vrymQyOj09VTwe17vvvvtSOu3CQnsOlQ+Rg14iCQr4iCQv4BxiUfEgvUfK5pFND4ax\n3rJ7/NAD5pKs8mlhYUFT/1DL7cM27p/QFj4qJON/9a/+ldVB7+zsmEKmVrzRaGh7e1sbGxs6PDzU\n6OioJFmjFgB/rKt0doAJ1fGePG1MOhNgiPN9fX22rh5L497Bs05OTjQxMaF8Pq+Ojg4rtSSzS0ED\niTd/ANhDlBbryT2QHIlGo9rd3dXw8LC2traMYYBh4xkoF11ZWVGpVLKa8OPjY01MTCiTyejjjz/W\nv/t3/07/5t/8G33rW9+yKq+TkxOjyvmGMsAZhLN8H/8OZtY9Xu7Xz3uYUit1ySf0vJLE80L2iMR8\nkYZXwEEIIhh+cobYAx9W4wyQR3jRffI3jBP2LhqNanV1VVevXjUKEaR5aIdEEJRto2x5BpShZwnw\nXhyESCSiqakpbWxsqF6vW4NvX3mHwWk0zlo2NhpnRHqae4+Ojurk5ES5XM6gMFgywBk8J700rl27\npsPDQ/3lX/6lYrGYvvWtb6lUKml5eVnRaFSzs7NKpVLq7u42BsfLXBeWtSf89N4YwDUL2tZ2Nv2R\nCg0fvuDp4Kn6pIz3GKTzRAACycayUR7bRGF5DBZFw/1xEMCHfCNh2qQRUv/n//yf1dfXp2Qy2WL9\nG42GlpeXrcIkkUhoenraKnfS6bSOj4+Vy+Va6Eu8P51OK5fLWSlsJBKx2mY4razfxMSEMSSkM8NB\nMiaRSBj5nHHHUGCGh4e1s7NjY45prr22tmaNRfzB5v6oVsLjJqMPY4HmFjAb6HMwNDRkEAVNpim/\npDDg9PRU29vb2t3d1R//8R/rhz/8oW7evKlMJqPZ2dmWpsM+0iAB4g9qkJAdpOig4Fgz70X+Y4aY\nn3sl7LHFF2Wag5/hlbL3PpFRDwXwM3+WOE98Hp+BAfE/8wrQP2MsFjOKGaE4bfq4SDT6UT58vud6\n+58BmYTDYVUqFYtudnZ2TAb9evNc0nkkBeT1/PlzpVIpzczM6PDwUNvb21/Lf/j9i0QiRuG7e/eu\nwuGw/vf//t86ODjQO++8o0QioY2NDS0tLdl6vex1YRgpgkFyA2wGq8XvPTmeTWMxGVcrnY8H8R6E\nx8KwuCScJH3N+rMB9Xq9pVcjHdk90O25o5SRgj2hxNra2jQ2NmZjSaDZ4P3xrOl0WqlUStVq1Swr\nRGEqpXyoBCl7ZWXFlAFeO3X4PtlGP0rw5kajYc2SaXLBQWJvMEx0x/eelIcKOIzUvPN+uIHcAwk8\nYBsUJrX+pVLJRhajCBKJhDKZjBU8NBoNbW1taXx8XJFIxBoRn5ycKJ1O68svv7REwvb2tra2towt\nwdwt70HTGwEZAVf3ITeXVz5eCfqkTlA58nt+5zPhXpmSZX/R5RWzV/J8llfuvm6cyyt4b4w9+wOM\nlD2m8Y1XvpwD78HiibJWeN/st0+geiUPNBAKnc9Du337tk0R8Gvv2SrcNxzsVCqlWq2mR48eaXt7\n2/jM9IT1BH6fN8H5KJVKunnzpt588009fPhQf/EXf6HT01PduXNHAwMDX0vi/VPXhSjSiYmJFqWH\ncOMxUPboK5bA1BAYlCHCQxLBC0ywTyjUC/AfvBKE0ws8lg0yOYkRKlxQ/D7ZhHCRCdzf35ekFsgB\nQT89PbUZ2z09PapWq0omk8bhjMViGhwcbFk3v7Fw7VBYeOiePwtOi5dbr9etlV2lUmnpSs4+wFFE\n2AiVGckbCoVslAlNRxqNhgmmdDYKJB6P2+RNDoL35o+OjsyzwFPFIIBhx2IxbW9vW6iGInzy5Ile\nf/11/eQnP7GGHZVKRaOjo1pYWFB7e7veeOMNG0cTjUZ16dIlo/fACPHJDuhU1JFz8DyejEHhmaUX\n80c9HurxQX7msUtf0RN0BLxH7WEvr1RRlCgIj/H67DX34rH/YKILJYdnSBSBUwCcxFBHihlQol6Z\n+mcKYrecSS8bm5ubmpiY0PT0tM2mCuLJ/n7BQaPRs6GF0WhUc3Nzmp+f19TUlL7zne+0OAp+TzAQ\nnZ2d2t3d1c7Oji5fvqx//s//ucrlsv7Tf/pPevLkiVH8Xua6EEX6ySefWEjhMUlGYJBQYcqnb5GH\n0vCHUpLNX5JaR3mQ6Ah+l3SOEfrMLILBgaJtH16RxwAJXev1uh1OPg/h8wA/wooVhrPW3t6uwcFB\nbW1tWTclGkIwFsIfJv7NOvgQhHvmu+v1upaWljT1DzO9Dw8Ptb6+3uKtS61VJJVKRZ2dneYlAsMg\nvP39/UZjQRkDgfgGGNQ24+WxzqyBJJVKJWNW+AGGo6Oj2traMsXN2u3v72t2dla5XM5a/rH3zWZT\nly9f1sbGhv7n//yfGh8ft8O/srJicJHPzvr9CSaOuF+uIH7nE1RegfjLh+ZeKQe9Wp8Q8mGx/wze\nw2v542VeOp+q4JkAKG1vEHgfz4ZDEo1GVSgUWtgW/lnD4bA1DcHwYoRxhDibfKdPOgVDbu5jZ2dH\nlUpFt27dMq/SJ9c8HYznwbsNh8M2FPHx48f6L//lv6ivr89KhPf29ozuJKkFlgMCe/r0qUZGRvTd\n735XqVRKv/jFL762n//YdWHD79gkFBwhPHPOSTJ5jimb5DuL+85PCLp0zgHEcyNE8BiS1KpMUT5H\nR0c2B4lDjmXm0BQKBftOqCBwFvnjO1H50DCZTCoWiykajZoCffbsmdra2tTf399SaUK4zgHj0AFv\nUMrJOoIbVyoVW7epqSn19vbq6dOnOj4+Vk9Pj5UXevwNL8wnjsDIGo2Gket7enqswsaviacNEVWw\nt57bG41GNTQ0ZIKMl8ice6KL4+Njm31FZ6p0Om2sgnK5rKGhIfNgaaM3ODiokZERra2tWRRDCfHh\n4aF5PME68yDmGVT+HuvzSkxqJcEjf/w+SG/j8nIYZK0EX8tZCZ6jYNjO5WWO9/rKLL7PP7M/N2Di\nwYQcipbGMRRbQDHzvFQcANaPyM0rU38fQENra2saGxvTlStXrO0ez8e6eG+bc8x39Pf3a3p6Wtls\nVr/4xS8Ui8X06quvWtTmCwg4N+FwWOl0WoVCQR999JFSqZTefPPNX67M+P6XfuX/w4tpoCwIoTSC\nG41GDZcMCgpdWUqlUgvGw4A6b8F80gqaBIcegeew8zMwIGZcZ7NZ8zabzaaFyrTIo40XNCkOx+np\nqZVnoogIlSAF53I5azdHswSPCWEoisWiotGozWfyuCiKXFLLjHXGblBaeXJyot7eXiux9B4Bf7xx\nAYcF4vC8PTxwwnMOLfxDlCm8znq9br0BCJ/p0wlLgM/DyDLGJJFIaG1tTbVazZJiJydnM5KGhobM\noIFd37x50xpdEDVQXovXGovFlEgklEqlWoyThzg4/D454kN97wFKX/cq/c9RHhgqDwsEeaisl4cW\nuCd/b97D80rde9g+QvK/QxY9hsnF2YHtAabu8U9/TkOhkBVhUCTB3jebTXOIgnX7NK/BEQIWwDDn\n83kdHBzotddeM2+V5wo+I7Lr7xFW0PDwsAqFgh4+fKh4PK7Z2VmDllgfDw1Sq18oFGw09stcF6JI\nyTITCtAcAsXAHzAOj+dwWPv7+630kgSPF3ZPL8GrQuA85oZFAk/1PTiHhoasTrjROKuwQanx3VRs\ncFh8RRKHDUU7Pj6uWCymTCZjSRSaYvg/HDYMAEkgChO4OGxUdUiyRNfU1JQkaXd3V4ODg9byjQPg\nPVGvBBBO8F6SQt7DoWZ+Y2PDyvbwVHhfOBxuwbq5X76TkJv56tyTZ1EMDw8rHo9baSkjMZaWlkwh\nd3V1GczQ29ur58+fm2FaW1tTNpu1ipZKpaJUKqVyuaxsNttSuhtUiv7yYX7Qy/Phv/c6eVaPF7K/\nQUVA5OUhJ4/pBb1Gr6i5j+C//fd42Ma/znupfDYKDY90b2+vxaP0Hjfvgxq1ubmpUChkTUrAIX0S\nDOULTEZEgHLH8eF9KysrmpmZ0d27d7WysmKwmPdm/X55o4FXDPc0l8vpk08+UTwe1507d+xZpfOE\nG5/b3t5uc81e5roQRcrNe+zIVwNBp/AtwDzeBrcRqxqskff17LXa2VwcFLLUmkllscPhsIUpQYyx\nu7vbLCoCHwqFlMlkLLFDswuUOgpLkpUxPnnyxAjzeIYcNjyLYIiHQcFT8J4hB5EmzlR+SGdVIXBr\nqdianp42vinKGgUaDGExMHgU7IOv86eMkLCOtaL9II2doVgh8BgJPoeGFnAMgWiy2axCofMxxLu7\nuzbFYGRkRNls1gzUzs6OTk5OND09rU8++UShUEjvvfeerl271sKxLZVKSqfTNnbFe6RBTNRjjt7o\nIL94Zx4iQe54Ha/FkAeVEQcXj9srYu8x+UjL36+Xey7Pn8SwgQVyeUfDf46nMflEL9BMkO6G0ucM\nFItF5fN5xWKxlmKMer1ulUJ4ppxxZJ3P4plxjNbX15XP5/W7v/u7isVitu/sCfflE4EeaiJa6unp\n0cTEhLa3t/V3f/d3SiQSVq1HJOVl4B9jUrzouhBFKrWC8CgyhIcO5ywCBxOvh00hIeXxQ5QYi4HX\nQSURhxJv189fgtjP50H98TgqCjcUOuMqJpNJlUolw/sajUbLWNx6va5yuWxdZ8CAOYBSaxcb3uPX\nwx9ooAWfmJBkHlooFDIyv2cQeA+E9wW9AK8w+U6fgOO93CPrSps6xkkwCuLg4MA4tb7LkFc8jcZZ\ntymwV7xYqru80gJv5VmTyaR2d3cNFyNB+P7772tpaUkPHz5ULpdrGY19cHCgSqViXhPzkfgO9uNF\nl98z/zq8xiBk4jPNvN8nqvDQgpAByioIE/AdQcUZ9KC9MeZ34PXBZ2QP+JlX9NFo1BKq/vu5Nwy5\nV4zkFJ4/f27dvNhvohDyG/4zcCp8ko3zxr7Pzc1pYGBAd+/eVTabbRm3g3xihHFCPLWLyG1sbEzT\n09PK5/P627/9W8ViMd2+fbuF2/yixOE/dV2IIuWGoTF5isbp6al5hPV63eaOw1vs6emxskjpfFgW\nzXp9/S+fQTIGzA3LDBbHRvOzcDhsI36BHLC4JLt4D0oNpb6/v28Hl+YevrQ0iFv5yx846eu9Kz0G\nBJ8Ob5kKFDy/RCKharVqmfX+/n4tLS1ZV3QfJvK9ng5FMobnQgnRS6DZPJu9DsEZD5bQjgIFYA6a\nKHsIg73p7u62ueuEYnS1Ojo60vT0tL744gv19PTo6dOnevPNN7W4uGgHmP6z7e3tVubHXs7OzrbI\nFywIPGaiGq90fDju2RbBxBx/e0XgE1DBkNj/DtkN5gCCn8seIW/IchA24Pu81xrEXL2xDlKfvAx6\nmAePkc/3/wYW8HAC54HpDMvLyzYyG3mimQ39I7yMI0feK8QjDofDWl1dVT6f14MHD9TT06ONjY2v\neaDeGUEmua/Dw0OVy2WFQiGlUinduHFD5XLZklI3b97U/v6+VldXrXvVy1wXokhHR0dNONhorMDh\n4aFisZj29/eVyWR0/fp1y/oy7oJwAwGhtpsD7nESlBHCguVCGfLZhD+lUsmywB4O4LB5L5AN9Eq4\n0TgrZ/PP5KkmfAb/95f/XN/8xB9Cf/CazWZLf879/X0ru5Vk3p0kGw0yODjYQkliD6BRIbQ+lK9U\nKhoaGmrB2HyCikmutEYkuZRIJJTNZltI3P5Z8BowOnjrKFj2anR0VDs7OxoaGtL29rZBQc1m0xrF\n5HI5SbLM6/T0tMLhsBYXF80YYhBoCA3kg+FDZrh8GB9MygT3znt2fIb3IL1ifJER9a99Ee7HnnuI\nwHuPQe/V45FeboKy5PeSy0NN3jP2HrNPjvGZXkljULu7u7W6uqpisWgTXJvNpkUcBwcHpry9k8Bn\n+zPGGT04ONDTp081NDSke/fuWWbfn0VvXLxB4vc098GZGxsb097enn784x8rFArp3Xff/f+fR0rl\nEhsdDp+3raLRCFlDDhSHi/G1HiNKJBLm4rOA3lr6jZZk4Szv4QqHw0ZG3t/fbyk/5bN8hQ74ExVL\n3rNB2LGwXoB55hclODh04L5cYKXgaFSfoBSpZvIHzmcwa7WaeZAoWI/FEb7RcMUfZtbddyRH0MFH\nGcZHRJDJZFqalUxNTZknzn2iiIkePF7uPS4yrFSxlctlm1IKY4M9C4fPyof39vY0OTlpz3Hp0iXV\najWDa1gf1gIj6GXBKw/vVXoD5PfPe45ecQXDbH8FcdOg1+oVF2vko4mgN+zxU7+P/nk4T54uKLWW\nmOJ9BpVxEG5CeXt4gjXifczTymQyqtfPBzqenp5a+TP7QGTB+z1my/mGr7y6uqrt7W3dv39f/f39\nVhvvFbD3sFlLf8/cIxxTqHNPnjyxgpqXuS5EkS4sLLQoRzDLcPis/pZWaslkUplMxnpqQuXp7++3\nVnN0+yEEpdqCBI30dWoFiQ2y+dVq1QSd+dvZbLYlDOZg40EhCCggqBy+wYgPpYKhnQ/b/cEIgt18\nvldqeFc09fDzqhqNc+YB5HYOBI1eBgcHrTl1MBkCrAKTAQEETwZnQtnB6WX9IeJTCYbhy2azks6b\n7PoDjiEkSQEfl4Neq9U0MTGhcrmsVCpl1CcaQ/Os9XrdIIKenh4bUcIEzCtXrigWi2lxcVHDw8MG\nh7AWPmphzYPJHf/HK5RgeB0M0VFInkPpfx9UzN4b5Dt85Z733Pi3LzB4EczA+16ktFE8KHUfFfik\nWdAYeKch+Pxejjs7OxWPx1Uul7W6uqr+/n6NjY1ZQQUy62EC7+F7o8a5ozPUwsKCYrGYXnvtNRWL\nRetB4Uc+c/nEHffLuvb391uDop6eHisaeZnrQhQpCgwMBo/k4ODAMLLx8XEtLCyYJwJnEc+svb1d\nsVjMXHofevnqCpROR0eH8vm8KRw8u97eXvX29lrSCiVAcoTwnAX3eIwvQUVZBRsJU0teLBZbkmpe\nieKh/WNXtVq1eU0oe7LxPkmEQHDoE4mEdnZ2TOikc+/Oj1Xh3qVWwjMeHA1Y4vG44b7emtMajWdF\neEOhUAtODOsBBcChhZe7uLhoCpGWePQg6O/v1/r6ulKplIrFoiYmJrS2tmaH7eTkxGAOqF59fX3K\n5/MaHx9XpVLR+vq6+vv79eqrr+rx48eWmPSeGBeHzWeqfWgY3K9/TLmy18gNe+Q9Jf9e/u/xcm9c\nvSIMKkUfxQQxUenrzT+CiSfvuQF7ITdesQchHu8kBJM0/hklWTvGhYUFLSwsaHx8XOPj4y1cW8L4\nYEWcTzyyXkA7a2trWltb05tvvqlLly5paWmppStVcD/8c9N1rVKpaG9vz4o3aM/5MteFKFIwPTJ0\nhITr6+u6c+eOuru7NTc3p97eXrNaYHB7e3vK5XJ2UKHgeCH03gAHNxaLKRQ6629I8xGPSeEtoNDx\nLk9Ozud2o2zwdvm5rynne/k9vE8+31NpgA2CFSAe7sjn80qlUlYWydrhhcA1bWtraymB5MBCFSPs\nwYrzPMEEmF877hn8Gc4rFwJOb0kwR6qJuFdJ5kF77FeSheKMZfbhJiNEJJlx6+npMRaH70cpnXOG\nMTZUytGVH+85Go3q13/917W8vGwRhmcT8Px+j5AtsDxkwb/WGxf2x4fdKC88Pe8lcnkMlGcKnh2v\nSPw++Gy9lzP/8yBs43FFPhsjzTnwipLn994ma+ATUF6OPezA9/b19am9vV2PHj3S1taWhoeHLWI6\nPT1rKOOhOp9w4rsjkfPWiOQlHj58qEgkorfeeksHBwfK5XItLRqD0VCj0VA6ndbW1laLXPvveZnr\nQhSp53mGQmcdzcFIAJ+r1apmZmZULBatsQUYJiE6SSFwQA6ptziE4z4zLMmKAaBsQN3p7u7Wzs6O\nhZtkGaHZ+LHOVDP5Ljgee6RTlRcu793AEPBeKhtIG7rp6Wlr3kHY7mvvMUaMM0EhIrA8B1c4fFYC\ni0EhHPT3EBQ6ng3upU/iSWdeBv0IqN7ivWR9w+Ez1gNlh+xho9GwmT1eWe7t7SkUChnd6+TkRMVi\n0Z4pk8no937v91SpVFqUEonEer1u2XyMI6yL5eVlra6u6p/9s3+m/f39FpK3l0vWy/+ffeT1L/p5\n8PI4ZhCz5Pf+O4Jwj8+wB/FJXos3yjnx3imv8x5p8P69cgS2YrwNRsGvxYsoXf7eg2vpE1X++clD\nPHnyREdHRxobGzM4qNFomKxK+CWUdgAAIABJREFU54lino9/kwOAvbO9va3FxUW9+uqrmpiY0NbW\nVktPCp6dseYe+8dA+ijgZa4LUaRgomBTjUbDRirjNQSHZEky8Le3t9eULrXZCI0XHm81UUCSDFfj\ndf4Ps2E4jChxOjERqiJcGxsbJrRgNyg06XzciPcAoNxw+XCDap9EIqHLly+rXq/rq6++sk3GCAFD\n0BhZkmFNQCW0+IPPOTQ0ZJUqdNAnhEJJI1AIMomAaDSqarVqeCyevk+ENJtNI+p7fBlWxOnpqYrF\nYsv8KIzZ1NSU9vf3rczQt0/k/hgzQZa/WCzq2rVryufzRmsD34N+VSgULGuPvFBC+vjxY73zzjvq\n6urS5uZmS4LCyyp/B3HSF3lnXlm+CKf04bh/j6cyBcP4oKzwmV4ZvkgJewWM0ebefMKUPfTJX+9F\n++qnIBbs5RrZ8c/m18s7GXw2zgr9befn59VsNm3UDnIcjAR8u0fWinWMx+MKhUKan5837zQUOis7\n5f2np6cmI0RKHrYIPssvuy4stEewWaBisahEIqFoNKr19XWNjo4a2MvBxGNE0PA0XxSm+3DdJ2Ck\nrxcD7O7umiD50JLFhsQfiUTU19dnoT2VRGzi7u6uent7W7yBtrY280y9APmQCEuLBzU1NWUbv7Gx\nYc1TuDc+x2eePW+OkIimHwgQdBMahAQPAcrNC773VBmjDM7KfeCpU5cdxFt5Po8lIwcYBKqNHj16\npHg8buNV6E8JJzaoNKrVqiYnJ7W8vGzRCcqHAoBsNmsGgB4OrNWjR4809Q+jJorFokEDQW/zZa7g\nvQUTJl7+/fP77wMO8coWSCgIMXgP1J8JnzTyHqxPVgVlyXvZRAx4fF55ehqgV8w8YxAn9vLllW0Q\nTgiFQtYbolQqaXV11RKkyC3nmO8O0gr9Gkiyz/rkk080NTWlyclJra+vG+7f2dmpYrHYArX46OxX\nGYB3YR5pqVSyDDsUFgaaJRIJ82y8t8RBxqODPoF18gLhLTzhHjX0WGcsUSwWszJFOnVHIhGjaSEc\nzIqKRCKWmd/e3jaLzwbhgaE0fCgrnY9R4b4JpYaHh61HZ7FYtHntfngbh8p7E96LRKHiUbe1tVnv\nUEpJm82mzYPy3gaXJzSz9mTjU6lUy3qzNlSI8dy8T2qd0V6v183wSbJ1rdfrlvwBPolGo+rr61Mq\nlVImk9Hw8HALbNPV1aWFhQVNTk5aCEcCjkMRj8eNjkXHqUKhYAY5EolobW1Nd+7c0aVLlzQ3N9dy\nrz4E5/JKJHh5zygYvvvX8zu+wxt+4BHWNugl+73ySjMIzwCreBzeyyCfHTTwKHMcGP8e/zzeW/ee\nbvD84fESVZHA4/f+/Y3GWaVbT0+Ptra2tLW1pWQyqb6+PkWjZ2NqarVai7HxuQXOBknm3t5eDQ8P\n67PPPlOj0dB7771nrRaLxaIpZp+oRi48Dv7LrgtRpHgKUG22t7dNyDc3NzU1NWUK7fj42BSrJOND\n+sNOwsGHQF5wAaSDQgPGinJE8AgnwFtREL4qAy+VTvpU7/gNRuH75hhsGBawWq0qHD5r4YXCL5fL\nZiTAfjxH1R9knwVG2fH8nuJEFRf3y/rDveRQeRhCOjdEKH+UnT+wvA4aFDxdz2uVWrmGGBjukaom\nJkZCbfNTXQ8PD+07QqGQ4Wdzc3MaHR01r75YLJqnDpOgvb1dmUxGIyMjtsa0MgyFQlpcXFRnZ6fe\neustPX/+vCXEDSogv0beG3uRR8bze3wwiCEGIwOplbTvlbb/bo+re3iIf2NUMLo8KwriRZ5dKHTe\noxMFHvxO/zdy55uRsM9eWfL6ev28wXfwOTmfGPd4PG4JqUqlonQ6rcnJSZtHxfNSku0jNRQ4DdOn\npqa0uLioL774QkdHR5qdndX29rbBX7zHQ2wvMpT/2HUhipTWcxDMPf8QjxMBZKYRXh5NQcD38Ow4\n3D5bKZ1bPD8egbCPhWIOO+R2lBVeMVZ/b29P1WrVBBSvGN5qrVazOnMunwzyCRYs38jIiFKplGX3\n19bWrKwSxesxseA9Suc8PehXvqdnZ2enksmk9vb2rPsR3ajowhWJnI3t6Ovra/FsWD9wMrxH36NU\nOlcu7B1NsD0dis8jMecPYKPR0FdffaVEIqF4PK61tTVLMjHGBZgH2aC94NTUlKrVqr766iu9+eab\nNs3Vlxnj5bS3txsPORqNKpfLtfA7t7e3tbe3p/fff1/z8/NGkePy4aMPJ4MwQBASCCorr1z5fO+l\nvUhx+e/w72f/vSflIRX6DyDDPjzn9R7T5wwNDAxYo/Wg0fb3yN++vNjfj4faggY4aLR98tXjzP39\n/Wo0Gvrss8+0ubmpwcHBls5MXnl6CAFj9eTJE3V0dGh2dlbValXPnz9XvV7Xu+++a0bU885ZQ0/z\n+mXXhWGkeKUkA7q7u7W2tqZLly5Z6zgWgjJFPCNCWITQZ549YO6tHQLFBrPxKCHIwN77kFo7p/tG\nxpC5UeRBfqVPSPDaarWq4+Njw4bxQlEkEMtRMPBcPVzBc5KpBBpgXXm2er1uaxqLxcyzA29EwYEx\nb29v28HxkARYEeE7LQz9iGheF4vFVCgUrLLIN3zxeB17wVrTn3V2dlaHh4eqVqtWLhoKhaxW2/Nl\ngSwYjHhycqLNzU3dvHlTKysrLQeJ2nqw0eXlZY2OjrYUMBB17O7uKpfL6fd///e1vr5uddlSa+9W\nZCKYCfaeqFci3tv3/N1gP04+1xtKnsMfdK90uTfuwWf3uQeUlA+9gdX4DL5/b29PIyMj2t3dVWdn\np6RzJecvL4veu/b3jeLmCnrs3sgEebZEgNzr8PCwGo2GPv74Y9MbtFn0XrAPyaPRqE3xzWazunHj\nhsbGxvT48WM9ffpUV69e1dtvv61MJqOVlRWtrKxoaWlJ+Xz+V5prfyGKlPHAoVDIOrqDkRGSEdoh\nFOVyWYODg6ZAPK5EOBLEW6TzDvgIEIIsyUrVSDSAewK083neOqEEUARktKFS8Hq+g8bHYJZHR0dK\np9Pq7u5We3u7qtWq8vl8SxINwcOT5vvxosF3PRWLQwQGiheMAqQjFEoUDIl1oRuSJ/WzhkQD0Ijg\ni3Z2drYcgnq9rmKxqCtXrpiyOzg4MOYCn+3bp+HBpFIp9ff3m7Hx4WClUlEsFjOIAtnh/dTyM5qE\nUShg8BgHIINoNKr5+XlNTExYt3yUFUmzhw8f6tvf/rby+bzy+fzXvHSPx/vrRV6Yxwx5DWvG83tP\nzBty//neS+UPn4uR8RCE/zv4WT7hyWdy7e/va2BgwBrNBB0M/yz+foLfg+L2EAnP7+lTKEDuqVqt\nanV1Vc+ePVMmk2nJ2sdiMcPDf/KTnyiTySiVShn1DoeHCBTvtLe3Vx0dHXry5IlCoZC+853vqLOz\nU19++aX+7u/+TkNDQ7p//75+7dd+Te+8847eeust3bhxQy97Xcg4ZvANL5gkP6Szxa1Wq+YVJRIJ\nLS0taXh42LAxwl9vFSV9LST2wufDMaxxvX7Wgm1xcVF9fX1WNcTn9PT0qFQqmZfYbDZNMfD/jo4O\n8/g47M1m05oiILC1Ws3qv2u1mlZXV83qcpA9Xw8FQcUXvwcGwVrj2TAeGQPU0dFhdCf4soxx2N7e\ntufAGHg8ONgLFkVOUg4owx/Yo6MjxWIxG6xXr9eNr4pBxHv0STgoUH//939vn0+FGMUEGFsONN+V\ny+WsljsWi+nZs2e6c+eOnjx5YrX+eKXgsclkUkdHR1pcXNT4+LgymYx9hvd4V1dX9f777+vhw4fK\nZrMaHBy0/fF4nNSK9QWVrGdS8FrWzXtz/jP8FYyugmG+/5mXeY9RYhwxGhh8r5S5Zyp8qtWqYejB\nZ/Khun8mXuuhAo8P453DU8W5oMlNOp02mAsI0FMOOW/T/zAx9OjoSPl83hwg+ODg6D6KkWT9bD/7\n7DOjNfKaQqFgZ8zj1S9zXYgiDYVC1g4vFotZLXYqlbIegx5D6unpsRCrVqtZnbUkC2uDIYbUimkB\nsiNQ/lD610tnyhiF4AWULkF4UyiptrY2lctla6rsP8cnxQYGBkxwSHb4ZIykFoH3eBeKi/DahzAe\ncyKJxkymUCjUkiQ7Pj5WKpXS8vKyYZnBxhSeu+mTFQgx2XG/NuzX2NiY/ut//a96++23LTSqVqua\nmJhoKYjwa0S7slwup5GREZurFA6HjclBfwAf+kUiERtxweSCjo4OPX36VFeuXNGXX35pvFEqolBo\n0Jx2d3c1Ojqq7e1to65x0Ov1uhYWFjQ7O6ulpSUtLy/r6tWrLVnyoGeH/HmKF+F6EHduNs9H22C4\niJg8/uwVnU+IkCfwylA6j2h8tMDfQSpVED6QznIGU1NTev3115XP51sSqNwfEQ0cZV8B6J0HDHhv\nb6/i8bj6+vqMB07v2uPjY1UqFR0dHWl1ddWSjrSsJBHsG4jjMCCj3Ht7e7txmD0O7P/PWQ72MvZe\nclA3/LLrQhQpnsr8/LwmJyctkTM4OGike7wIvB4qYjxw7h/WCwZCSLggtfaG9CRqFA9ZdYR6c3PT\nqh5QwGSRCSX4PkLt4eFh87a5N48VSmejPxqNRsvEUz6fZ4hGo8YBxSPwuNn+/r7VpHtcyGdtOYx4\ntIxQBlMCcwQjJjFFVh4FS+8DX8xwcHCgwcFBZTIZJZNJ21c8ADxXGAmjo6Pa3d01TJJ9wYsOh8PW\nZq2vr8/6EqTTaXV0dFiSjLVincje0lMARV+vn3UaunPnjp4+fWoyg4Fij+AWl0olTUxMaGdnp4X9\nwL4sLS1pcnJSXV1dev78uS5dutSCW3vjEKwsY81YH08r83Lpr6ADwPN67Bp8lvVAQWBgPDzE93nP\nOMhi8XueTCbVaDT093//97p+/boqlYp5hzgZAwMDxoDwuDoFJURwBwcH2tzc1MHBgXm4GG4iMUlG\nOfTJWUmWXGWvi8WijRZnr9lLfx9B75ezzs/ZXwyVT355A/Oy14UoUha4o6PDyOFkzal48haGblBY\nbQQ3+LCED2CiUqsn6ofY8br+/n5tbGxoaGjIQj8aIfu6cTZ8+P+2dy4/bV5bG39sysUUgzHGxtxk\nCFHakCZp1UGlVuqs6j/QP6Lj/i8ddtLJGXTSYWfpoJWiRKmqpklUpbkQLsaAMQZMAga+gb/f5vFb\nzvlyxADp017S0SngvH733muv/axnXfbERMgcoNm0dFZpwQFAEIHTsa+vT9VqtasnI8rtbhbfs7u7\nq4mJCTUaja5yViLhjI2N6y4mhgqE/ubNG+Xzea2trWlhYUFra2tdARACYijweRvZo8v8PolI33mn\ncw0MyJvTfmxsTHfv3tXnn3+ura2tMHbfcM5TEviD4/VrZ7wW3deRbADG3Gq1tLe3pxs3bujhw4eh\ntJhMEXI18XbW19dVKBT08uVLzczMhLxluOFXr15penpauVxOv/76q+bn58O8sHaUKKKLoFrn2Vkb\nvCuMHHQK4q40HDVBSr8SnHXCACS9G4yDGxHnUVlD5rjVaunWrVu6c+eORkdHlclkQsoRnkKz2dT+\n/n643951j1QzvJF0Oq3r16+HtorOrzpHfHBwEIKCrInvDaisvr4+lUqlrnxUaKXDw8Ow7t6dzD0A\ngJTfvuCgLBkfeFu5NEMKx4XhIUcRRccVy2azIRjjromfGklU6a6OByQGBwdDBF1SCD48efJEs7Oz\nIQ+UUz5Zh55KnTUq6enpCUaO6LqjEdCXB8a8UYsbq2SK0+npaWiy4souKdwrhTjq5n3ZQJzauL1w\nUtvb28rlcqFi5Pj4OJSacumZv0syCMYa+O0GjPvw8FDz8/N69epV8CJarVao+XfEwLtiJIvFYnC3\nmE/+m43khw8IZmtrKzStYJ5GR0e1tLSk6elpTU5OhsbPIDk/aIaHh1Wv11WtVjUzM6OVlRVls9nQ\n9o3D8NmzZyqXy/rkk0909+5dzczMhLnHoKMDvinZ8Kw/KX2koTnPyKHJM3lfjOx5LeEYD3yzpKDz\n6DJ7B8N8dHQUkCYVfOVyOVx4t7u7q8r/5nM7B+k343LounFkHqDBqKNn7XyNPJ4hqaum3pvbDAwM\nhMR5jC173tG01EG22Ww2oHUHTvC/BIfx5hCe5d7I28qlGFLnRFutlvb39zUyMtKFQlmQoaGhkFco\nKfBicHl+qrsbQxI+rsHJyUmo3QbpwJOAHqUzV8i7y7vbjXJLncICmlD7M3CdWEzfXNIZEmCDYUgw\n2txfBILhu7ybuAcV/KRl/pycB8mB6r1jPAdYPp8PmQvMA/PNu+EWEwDyLALQZyrVafa8vLys8fFx\nvXnzRltbW6HtHRcB8t6ghr29Pb1+/VrNZjPUWDNPHFyOthl7X1+f9vb2NDU1pb/++isYVNa5Wq1q\ncXFRqVRK1Wq1q5KFIFpvb28Y/+bmpiqVipaWlgLf5s1xKDf94osvdP/+fb1+/To03gCFOj0A4pLU\nVZZLOWRPT09X4xVcX3QWQ+hBUwcQx8fHwZPiUMJoOKfM3+nVOjY2FugSik8ODg5CKebJyYm2trYC\nWuV9KH5hrH4gsncw2H7hHvPsnkoyT5Nno2voh/fFcL4Tw8v38g4eWMQOpNOdhke5XC7QCnwfdBbe\nhwfw3lYuxZBysmQymdDRx6PonAwor3SGjpzTACk4sqFnKVcoS2dNSjAaPGNoaEgvX74MnwXBJdGh\n81gYRleKRqMRUqeSnAvjwDVPLo5ztaAFSSGJHmIcBEOy/XkunAckQOC8KxscjpfggOcxUgXCODwq\n7+kpuHDDw8Oq1Woh0s44KFogrUzqREt///13lUqlYFhOT09D7T6GB4Xf3d3tKqN1BJnkOinqoBiC\nzYar/fjx48DnYXjo2kXwkIBIq9XS2tpaiOYPDw93XYoI17y8vKz3339fv/zyi9rt9j9aDEr/TAvy\n5ja8h/O9AwMD4SA7ODgI8QLoKadV+vr6QhAtk8mEtSG3mTUDlBAg5ZnoB14c/CNrB4ePEfcLKBuN\nRuDu3QtynhLvh4rAZGDUgzvuOXrgjr3G+rsL7j87beHzBaDBVvT2dq6k4YDi4kOCX8Rk0Mdkmtd/\nkktLf/I7fFxBWBCuLcZ4kC5BPiHuJRucTeeRSowAbnYul9PS0lJIji8Wi3r+/LmmpqZCviOK7Xl5\nvhlQAPo1UmZJ9YUb0r6+vnDvE5uXSCQ8LqeyI5LJycmua4nJkfPoKe+HUkj/vkMRG5gbB7xDPmOt\n1+shncozIUDnflIfHh6q2WxqcnIyVGL5HO3v74cmIZJCsAD0w2EAL3Z62kkp46pkSYEXJ1+V5tI+\nTjbRu+++2/U50I6vXaPR0PT0dLgYDxoJHYFeomFKrVbTzMyMnj59qqmpqaBfcHfcSPvll1/qwYMH\nqlarmpqaCu/mLqx7BR5QYf6hP+g/6w3A+XdQABxw8OIYHg5P1gy9Zx68VZxz3rxju93WH3/8oW++\n+Ubff/99uJWV+XYOcWhoKETfx8fHQ2I86LnRaGhjY6OrzNLH5F5dEhAkgz3oHXPB+Hl/n+skFcZ3\nHx8fh/1EBSAcPXEZ6LJ0Ot11VfrbyqUY0tPT0+DiYRB8MjBUAwMDgf9ycp5gBJOFQYWQPy8KCuog\nNSOdTofOLzQc8YXGePim9dOPz5HAXSqVuhAspyWKgHvI1ShOQYCC9/f3A1r0IADoC84xuRE8SuvE\nOj+nUp3CB+rYcZEd0TM/SSPlvJbTD9Tuc/j4nJ+cnGh2djZc+QAdQ9FBJpPRxsZGCJoxn4VCIbzb\n3t6eRkZG9Pz5c+Vyua48TOe84KcbjYaKxWJohuMIB/oFxNdqtcKc0LmfOffUt2q1qps3b+rPP/9U\nPp8PyFQ644mfPn2qq1evamVlRcvLy5qZmQk64FSEC/PNczxoNDw8HGglN3LOCQIs/LBknp2zPi+w\nwyHO98EH7uzs6Ouvv1aj0dDt27fDIYN+uYEDTLTbnXaGzWYzHK7koA4NDalcLqtSqYQO+Nvb22o0\nGuFeMHhI96QcTOGlsObovWe5oI9OXyAOtphPj39gZ7AtFIJI6vKG30YuxZAeHBxodHRUL168CNBf\nOkNlTB6XtWWz2cDdeLoJHBCLKp0ZDk4dd1OdjAeVAuuTKNQXmf95lM8DXp4DyOKCNkkHcsPszwNp\n0PcUpMs7cDh45NoV28sveS4bzNErHeNJcZIUSnFRXA9QMNe8P89njihCICBDFy6Uv7+/X9VqNaTP\ngNrd7efzZHEcH3dqvBHanBWLRe3s7HSl/oD4PXI+Pj6uv//+W5VKRdIZL3d0dKTR0VFVq1Vdv35d\n6XTnbjBvWAO1BGoZHBxUvV4PDYIfPHig6enpQA+lUqmQAL6ysqLZ2VmVSiU9evRIxWIxGBs3khgm\nl6R+OZJFV9wYewoTJa8cjh7BZ254T/QeIIHry9o2m01duXJF3333nSqVSqAg3OM5z0ihF/39/crn\n8yoUCgFASJ3eEQ8fPlS9Xg95r5OTk5qfn1exWFRvb69WVlbUaDRCHwfGBLUlndE06Fcy6IY4R+tz\nzn4CjPE5xkDw1Of4v5FLMaQ9PT2h5Zy74NJZWZkbBtAcRoPNhDKgtBiR8xSWiYIjymQyqtVqwZ31\nkzbJi3raCgL3SWlo0o0hkMHvKHvd3t4Oi0rwiI3ApX7MA5sL3s/5Jd7Rg0FJZO8bJpXqEOxwfNTw\n8xmMiK+DBy/IuYMSINc1l8upVqtpeHg4bGTSX46PO/nCOzs7OjnpVKhxdS5K7In/qVRKOzs7oWrN\njRbon83FuzEnuGP1el1zc3OBw2ajML+PHz/WtWvXwnPJXKDvJUn76XRaY2Nj2tjY0NLSkhYXF/Xo\n0SNNTk6GlD1Q1cnJSWinOD4+rnq9HlL70BWnXJIFEO7mO23FXvHD0sfqa5NEv4wPtAU6xSjyfVKH\n9pidndWjR480NjYW9gC65QbU90jSO/M95Ea8VCqpUCh0uexra2t68uSJtre39fr1a01PT2tubk7T\n09M6PT3V5uamarVa2PvoVKPRCF4B15UAUEi5ShpW1sBjCf65dDr9j0sXk+P+v+TSKpuazaaGh4e1\nubkpSQGhwCPSlALXFvcFBOGoywNSntPmE0Egid+DGDFUbjh4R/gXfpbOOJl2ux14O1J1IKj5f+cw\nXZl5V76DBHk2hiuqu5JJPsmf43PhPJ2XezJ3rVYruMuMzSPOGFjmzccMSpXONiUnPEooKXT59+dI\nHf50bm5OjUYjGBr/O+8+MjISnuf9Sfl+RxpsjpWVFc3MzGh9fV2lUqmr+gqDSoAMfpyUHtLiHPFl\nMhmVy2WtrKzo6OhIs7Oz2tjYCB323aWk4QwVPE+fPlW73Q4pfn7YeWDEdTQJKPwggEdG51y/vAGP\nU2Nwphga8jF5F8a5sbGhr776St9++60WFha6kKbrWFIPed8kgHEDxfjgyPn+np4e5fN5jYyMBGO4\nvb0droFpt9taWFjQhx9+qImJCdXrdT179kxHR50rk4m+r6+va21tLSBiqgUJDrqn6NQUBxbvvru7\ne2685m3l0qL2UqcUjfJF58COjo40NDSkZrMZUKvzIc7JgWYwZG5UPfCDgQOFrK6uamBgIFTt4GYm\nG8bitrgi8px0Oh3SVUgI59+5sfYUJwwqSu7uvfdpZCxQEhgNxiadGXuPUjuScaqBvFzQPpRBKtV9\ngSApYWw+SQF581zpLJpL5N9zH/l7uVzW8vJyV4NnFJrCApprO5LhOhICdNwKSmf+ZCI/67y3t6dr\n166Fmn2aq4CM4ZqhiSqVSuisT+kt7mO73Q6FIeVyOXgv+XxeGxsbGh8f7+oOhC5w4F+9elX1el1b\nW1uamJgI+s3B6uvkmxwwgB67zpNZ4cbM15m19YIUfvbaczwL9Pm9997Tb7/9Fiqa3MDwXX5Y++GV\njB24/mKsJHWlMDlI4bDDwOZyuZAKSbnvzz//rGazqfHxcd28eVPFYjFw2MfHx5qamgql5rVaTbVa\nLRhqsjMcpTJ3Dkzc6Psh/bZyaR3yh4aGgpvmyE9SV1kiBpDNzeCSnKQbYi8jdM4QJYazxP0inUfq\ncEikBmHYDg4OwuV3kP6SQg4ghtYjqc7lokxekeS8Fi6l85/QH+RTJhXBeVFH0uehVudy3aj29/er\nv78/VLAwj+4Ou/FPBpZwvYeGhkL5oCNtFJjcTaLyfHcqldLY2FgICPHMnp5Olx8QNGlZeCp0r2L+\n/IDxhjFQKNxOyntxfQz8a6PRCIeqb3jmore3V5VKJTQCLhaLWltb+0eZsHs1b968UTabDd39WRsQ\nJLqJ285BxM+eg4y+EV1Gz/i8o2503NGYG1W4R4x1tVrVZ599pnv37oU7sfgseufjS/4NPUkeBuwd\n9+SS+5H3RZ8diAA2enp6NDk5qcXFRU1NTWl1dVU//vijfvjhB62uruqDDz7Q7du3NTg4qFqtpna7\nrfn5eX388ceqVCra29vTixcvQtojuuOAgP3qtIfvn7eRSzGkJGAXCoWwUM4TSWdIk9+ziZwn9dPc\nTw9XzOSJSncnX0CnAbLZbLiA7Z133gknGper8b4Q+o7meH/q9d2Qohg8g/cCrblRpGDAkQni1IGf\n7v4MSV3zwmbk+xyFHh4edh0SSePLs5yD4rs4dHCNPS8QhE2SP6hjeno6VKolDyEMBEZf6hiKg4MD\n5fP5rjQsdys94AFlhAHLZrOhnl9SMOp0jkqnO31hCegR1ecgIJ9zb29PpVIpZIVMTExoa2sreDBu\nVNBXMiNoisK8cAi6IQEFcnDCMXMYQM3w/RgEnum0kesKBi9paPv7+7W7u6vFxUXdv38/lC77HnS6\nhSolNy5+iLgR8tzR89II0X32L8/AewMwEegEgLBvFhYW9Omnn6pcLuvBgwf617/+pTt37kiSbt26\npXK5rEajocePH6u3t1dzc3OhaXm1Wg1lymQGeWaMj/G8Of13cmmI1IMozslJZ4EM6SwK50bFT1kM\ni6d7eCBCOkOAp6enXdFDtBTeAAAB90lEQVTlJEVwetq5bI0L14gQ4gZJCsjFeUU/bTHYkoL77D1M\nHUk5Ee4BBlwvxuPjAiU5D8q/cUPK73gn0GKyZJD5ZQ7hkvkO1qdQKCibzYaf2fBOK7h7h+EtFArh\nQGH+6QLV29ur9fV1pdPp4L775uRndMV7THoKD+Pp7e3V5uamrly5Ehq1rK6uhrQx5pqS0/Hx8WBs\nU6lUSIcjQ4IDlO+Cu63X62Es29vbyufzXd4Sn/drXOhxwDigtAYHB0MfAK8UwuA7Z8d6Jfl8n3dv\noMKaUkPvgILUpcXFRd27d0/ZbLbrQEvGGPxg9eDseZ91xInnxfrzDj4O/o2kLr6XPZvcY/yNKrsb\nN27oo48+UiaT0b179/TTTz+FSxRv3ryp2dnZsL+KxaIqlUo4/Gu1WqhMzOVyIfjs9uhtJHX63+DX\nKFGiRInyD7kURBolSpQo/58kGtIoUaJEuaBEQxolSpQoF5RoSKNEiRLlghINaZQoUaJcUKIhjRIl\nSpQLSjSkUaJEiXJBiYY0SpQoUS4o0ZBGiRIlygUlGtIoUaJEuaBEQxolSpQoF5RoSKNEiRLlghIN\naZQoUaJcUKIhjRIlSpQLSjSkUaJEiXJBiYY0SpQoUS4o0ZBGiRIlygUlGtIoUaJEuaBEQxolSpQo\nF5RoSKNEiRLlgvI/1luwCZFhKOYAAAAASUVORK5CYII=\n",
-       "text": [
-        "<matplotlib.figure.Figure at 0x508acd0>"
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "-----\n",
-      "\n",
-      "# Low-Level Approach: @numba.cuda.jit\n",
-      "\n",
-      "- Numba can generate CUDA functions with the `@jit` decorator\n",
-      "- Decorated function follows CUDA execution model "
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "## CUDA Execution Model\n",
-      "\n",
-      "- Kernel functions\n",
-      "    - visible to the host CPU\n",
-      "    - cannot return any value\n",
-      "        - use output argument\n",
-      "    - associates to a _grid_\n",
-      "- Grid\n",
-      "    - a group of blocks\n",
-      "    - 1D, 2D, 3D\n",
-      "- Blocks\n",
-      "    - a group of threads\n",
-      "    - 1D, 2D, 3D  \n",
-      "- Every thread executes the same kernel\n",
-      "    - thread can use the grid, block, thread coordinate system to determine its ID"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(url='http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/grid-of-thread-blocks.png')"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [
-      {
-       "html": [
-        "<img src=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/grid-of-thread-blocks.png\"/>"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 29,
-       "text": [
-        "<IPython.core.display.Image at 0x50515d0>"
-       ]
-      }
-     ],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "## Compiling a CUDA Kernel"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from numba import cuda\n",
-      "\n",
-      "@numba.cuda.jit(\"void(float32[:], float32[:], float32[:])\")\n",
-      "def vadd(arr_a, arr_b, arr_out):\n",
-      "    tx = cuda.threadIdx.x\n",
-      "    bx = cuda.blockIdx.x\n",
-      "    bw = cuda.blockDim.x    # number of threads per block\n",
-      "    i = tx + bx * bw\n",
-      "    if i >= arr_out.size:\n",
-      "        return\n",
-      "    arr_out[i] = arr_a[i] + arr_b[i]"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "### Code Explained\n",
-      "\n",
-      "#### Define a CUDA kernel with three 1D float32 arrays as args\n",
-      "\n",
-      "```\n",
-      "@numba.cuda.jit(\"void(float32[:], float32[:], float32[:])\")\n",
-      "def vadd(arr_a, arr_b, arr_out):\n",
-      "```\n",
-      "\n",
-      "#### Map thread, block coordinate to global position\n",
-      "```\n",
-      "    tx = cuda.threadIdx.x   # thread label (along x dimension)\n",
-      "    bx = cuda.blockIdx.x    # block label (along x dimension)\n",
-      "    bw = cuda.blockDim.x    # number of threads in each block (along x dimension)\n",
-      "    i = tx + bx * bw        # flattened linear address for each thread\n",
-      "```\n",
-      "or simplified to:\n",
-      "```\n",
-      "    i = cuda.grid(1)\n",
-      "``` \n",
-      "\n",
-      "#### Ensure global position is within array size\n",
-      "\n",
-      "```\n",
-      "    if i >= arr_out.size:\n",
-      "        return\n",
-      "```\n",
-      "\n",
-      "#### The actual work\n",
-      "\n",
-      "```\n",
-      "    arr_out[i] = arr_a[i] + arr_b[i]\n",
-      "```"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "## Launch kernel"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "source": [
-      "#### Prepare data"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "n = 100\n",
-      "a = np.arange(n, dtype=np.float32)\n",
-      "b = np.arange(n, dtype=np.float32)\n",
-      "c = np.empty_like(a)                 # Must prepare the output array to hold the result\n"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Calculate thread, block count\n",
-      "\n",
-      "- thread count is set to **warp size** of the GPU\n",
-      "    - Warp size is similar to SIMD vector width on the CPU\n",
-      "    - **performance tips**: set thread count to multiple of warp size\n",
-      "- block count is ceil(n/thread_ct)\n",
-      "\n",
-      "**Note:**\n",
-      "This will launch more threads than there are elements in the array"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "thread_ct = my_gpu.WARP_SIZE\n",
-      "block_ct = int(math.ceil(float(n) / thread_ct))\n",
-      "\n",
-      "print \"Threads per block:\", thread_ct\n",
-      "print \"Block per grid:\", block_ct"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Threads per block: 32\n",
-        "Block per grid: 4\n"
-       ]
-      }
-     ],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Launch kernel\n",
-      "\n",
-      "Kernel function object uses the ``__getitem__`` (indexing notation) to configure the grid and block dimensions.\n",
-      "\n",
-      "```\n",
-      "    kernel_function[griddim, blockdim](*args)\n",
-      "```\n",
-      "\n",
-      "- **griddim**\n",
-      "    - Number of blocks per grid (grid dimension)\n",
-      "    - type: int for 1d or 1,2,3-tuple of ints for 1d, 2d, or 3d respectively\n",
-      "\n",
-      "- **blockdim**: \n",
-      "    - Number of threads per block (blockdim dimension)\n",
-      "    - type: int for 1d or 1,2,3-tuple of ints for 1d, 2d, or 3d respectively\n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "vadd[block_ct, thread_ct](a, b, c)    # Last argument is the output array in this case\n",
-      "print c"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[   0.    2.    4.    6.    8.   10.   12.   14.   16.   18.   20.   22.\n",
-        "   24.   26.   28.   30.   32.   34.   36.   38.   40.   42.   44.   46.\n",
-        "   48.   50.   52.   54.   56.   58.   60.   62.   64.   66.   68.   70.\n",
-        "   72.   74.   76.   78.   80.   82.   84.   86.   88.   90.   92.   94.\n",
-        "   96.   98.  100.  102.  104.  106.  108.  110.  112.  114.  116.  118.\n",
-        "  120.  122.  124.  126.  128.  130.  132.  134.  136.  138.  140.  142.\n",
-        "  144.  146.  148.  150.  152.  154.  156.  158.  160.  162.  164.  166.\n",
-        "  168.  170.  172.  174.  176.  178.  180.  182.  184.  186.  188.  190.\n",
-        "  192.  194.  196.  198.]\n"
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "# Example: Matrix Matrix Multiplication\n",
-      "\n",
-      "- Show manual caching with shared memory\n",
-      "- Not the best matrix matrix multiplication implementation"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Prepare constants"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from numba import float32\n",
-      "\n",
-      "bpg = 150\n",
-      "tpb = 32\n",
-      "n = bpg * tpb\n",
-      "shared_mem_size = (tpb, tpb)\n",
-      "griddim = bpg, bpg\n",
-      "blockdim = tpb, tpb"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 34
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Naive version"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(url=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-without-shared-memory.png\")"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "html": [
-        "<img src=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-without-shared-memory.png\"/>"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 35,
-       "text": [
-        "<IPython.core.display.Image at 0x50510d0>"
-       ]
-      }
-     ],
-     "prompt_number": 35
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "@numba.cuda.jit(\"void(float32[:,:], float32[:,:], float32[:,:])\")\n",
-      "def naive_matrix_mult(A, B, C):\n",
-      "    x, y = cuda.grid(2)\n",
-      "    if x >= n or y >= n:\n",
-      "        return\n",
-      "\n",
-      "    C[y, x] = 0\n",
-      "    for i in range(n):\n",
-      "        C[y, x] += A[y, i] * B[i, x]\n"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 36
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Optimized version (shared memory + blocking)"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "Image(url=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-with-shared-memory.png\")"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "html": [
-        "<img src=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-with-shared-memory.png\"/>"
-       ],
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 37,
-       "text": [
-        "<IPython.core.display.Image at 0x5051a90>"
-       ]
-      }
-     ],
-     "prompt_number": 37
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "@numba.cuda.jit(\"void(float32[:,:], float32[:,:], float32[:,:])\")\n",
-      "def optimized_matrix_mult(A, B, C):\n",
-      "    # Declare shared memory\n",
-      "    sA = cuda.shared.array(shape=shared_mem_size, dtype=float32)\n",
-      "    sB = cuda.shared.array(shape=shared_mem_size, dtype=float32)\n",
-      "    \n",
-      "    tx = cuda.threadIdx.x\n",
-      "    ty = cuda.threadIdx.y\n",
-      "    x, y = cuda.grid(2)\n",
-      "\n",
-      "    acc = 0\n",
-      "    for i in range(bpg):\n",
-      "        if x < n and y < n:\n",
-      "            # Prefill cache\n",
-      "            sA[ty, tx] = A[y, tx + i * tpb]\n",
-      "            sB[ty, tx] = B[ty + i * tpb, x]\n",
-      "\n",
-      "        # Synchronize all threads in the block\n",
-      "        cuda.syncthreads()\n",
-      "\n",
-      "        if x < n and y < n:\n",
-      "            # Compute product\n",
-      "            for j in range(tpb):\n",
-      "                acc += sA[ty, j] * sB[j, tx]\n",
-      "\n",
-      "        # Wait until all threads finish the computation\n",
-      "        cuda.syncthreads()\n",
-      "\n",
-      "    if x < n and y < n:\n",
-      "        C[y, x] = acc"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 38
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Prepare data"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Prepare data on the CPU\n",
-      "A = np.array(np.random.random((n, n)), dtype=np.float32)\n",
-      "B = np.array(np.random.random((n, n)), dtype=np.float32)\n",
-      "\n",
-      "print \"N = %d x %d\" % (n, n)\n",
-      "\n",
-      "# Prepare data on the GPU\n",
-      "dA = cuda.to_device(A)\n",
-      "dB = cuda.to_device(B)\n",
-      "dC = cuda.device_array_like(A)"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "N = 4800 x 4800\n"
-       ]
-      }
-     ],
-     "prompt_number": 39
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Benchmark"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Time the unoptimized version\n",
-      "s = timer()\n",
-      "naive_matrix_mult[griddim, blockdim](dA, dB, dC)\n",
-      "numba.cuda.synchronize()\n",
-      "e = timer()\n",
-      "unopt_ans = dC.copy_to_host()\n",
-      "tcuda_unopt = e - s\n",
-      "\n",
-      "# Time the optimized version\n",
-      "s = timer()\n",
-      "optimized_matrix_mult[griddim, blockdim](dA, dB, dC)\n",
-      "numba.cuda.synchronize()\n",
-      "e = timer()\n",
-      "opt_ans = dC.copy_to_host()\n",
-      "tcuda_opt = e - s"
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [],
-     "prompt_number": 40
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "#### Result"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "assert np.allclose(unopt_ans, opt_ans)\n",
-      "print \"Without shared memory:\", \"%.2f\" % tcuda_unopt, \"s\"\n",
-      "print \"With shared memory:\", \"%.2f\" % tcuda_opt, \"s\""
-     ],
-     "language": "python",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "fragment"
-      }
-     },
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Without shared memory: 8.78 s\n",
-        "With shared memory: 5.20 s\n"
-       ]
-      }
-     ],
-     "prompt_number": 41
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "slide"
-      }
-     },
-     "source": [
-      "# Summary\n",
-      "\n",
-      "- Numba\n",
-      "    - opensource low-level GPU support\n",
-      "    - CUDA kernel ``@numba.cuda.jit``\n",
-      "- NumbaPro\n",
-      "    - commerical with high-level GPU support\n",
-      "    - vectorize ``@numbapro.vectorize``\n",
-      "    - guvectorize ``@numbapro.guvectorize``\n",
-      "    - CUDA libraries ``@numbapro.cudalib.*``\n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {
-      "slideshow": {
-       "slide_type": "subslide"
-      }
-     },
-     "source": [
-      "# Future of Numba / NumbaPro\n",
-      "\n",
-      "- OpenCL support in Numba (WiP)\n",
-      "- Deferred array object that hides most CPU+GPU details\n",
-      "    - use it like NumPy array"
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Introduction to Python GPU Programming with Numba and NumbaPro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Misc. import\n",
+    "from IPython.display import Image \n",
+    "import math\n",
+    "from __future__ import print_function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Numba\n",
+    "* Opensource BSD license\n",
+    "* Basic CUDA GPU JIT compilation\n",
+    "* OpenCL support coming"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numba 0.17.0-238-g4e3a170\n"
      ]
     }
    ],
-   "metadata": {}
+   "source": [
+    "import numba\n",
+    "print(\"numba\", numba.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# NumbaPro\n",
+    "* Commercial\n",
+    "* Contains library extensions and extra multicore and GPU features:\n",
+    "    * Parallel vectorize\n",
+    "    * GPU vectorize, guvectorize\n",
+    "    * CUDA library bindings: cuRAND, cuBLAS, cuFFT, cuSparse\n",
+    "* NumbaPro namespace re-exports all public symbols in Numba\n",
+    "* We will import from numbapro whenever the feature is NumbaPro only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "numbapro 0.17.1-6-g31cc432\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numbapro\n",
+    "print(\"numbapro\", numbapro.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Ignore this\n",
+    "# Forces flushing of license information for trial user\n",
+    "@numbapro.vectorize(['float32(float32, float32)',], target='gpu')\n",
+    "def dummy_flush_lise(x, y):\n",
+    "     return math.sin(x) * math.cos(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# The CUDA GPU\n",
+    "\n",
+    "- A massively parallel processor (many cores)\n",
+    "    - 100 threads, 1,000 threads, and more\n",
+    "- optimized for data throughput\n",
+    "    - Simple (shallow) cache hierarchy\n",
+    "    - Best with manual caching!\n",
+    "    - Cache memory is called shared memory and it is addressable\n",
+    "- CPU is latency optimized\n",
+    "    - Deep cache hierarchy\n",
+    "    - L1, L2, L3 caches\n",
+    "- GPU execution model is different\n",
+    "- GPU forces you to think and program *in parallel*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running on GPU: b'GeForce GTX 970'\n",
+      "Compute capability:  5.2 (Numba requires >= 2.0)\n",
+      "Number of streaming multiprocessors: 13\n",
+      "Number of cores per multiprocessor: 128\n",
+      "Number of cores on GPU: 1664\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get all the imports we need\n",
+    "import numba.cuda\n",
+    "import numpy as np\n",
+    "import math\n",
+    "\n",
+    "my_gpu = numba.cuda.get_current_device()\n",
+    "print(\"Running on GPU:\", my_gpu.name)\n",
+    "cores_per_capability = {\n",
+    "    (1, 1): 8,\n",
+    "    (1, 2): 8,\n",
+    "    (1, 3): 8,\n",
+    "    (2, 0): 32,\n",
+    "    (2, 1): 48,\n",
+    "    (3, 0): 192,\n",
+    "    (3, 5): 192,\n",
+    "    (5, 0): 128,\n",
+    "    (5, 2): 128\n",
+    "}\n",
+    "cc = my_gpu.compute_capability\n",
+    "print(\"Compute capability: \", \"%d.%d\" % cc, \"(Numba requires >= 2.0)\")\n",
+    "print(\"Number of streaming multiprocessors:\", my_gpu.MULTIPROCESSOR_COUNT)\n",
+    "cores_per_multiprocessor = cores_per_capability[cc]\n",
+    "print(\"Number of cores per multiprocessor:\", cores_per_multiprocessor)\n",
+    "total_cores = cores_per_multiprocessor * my_gpu.MULTIPROCESSOR_COUNT\n",
+    "print(\"Number of cores on GPU:\", total_cores)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# High-level Array-Oriented Style\n",
+    "\n",
+    "- Use NumPy array as a unit of computation\n",
+    "- Use NumPy universal function (ufunc) as an abstraction of computation and scheduling\n",
+    "- ufuncs are elementwise functions\n",
+    "- If you use NumPy, you are using ufuncs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<ufunc 'sin'> is of type <class 'numpy.ufunc'>\n",
+      "<ufunc 'add'> is of type <class 'numpy.ufunc'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(np.sin, \"is of type\", type(np.sin))\n",
+    "print(np.add, \"is of type\", type(np.add))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "# Vectorize\n",
+    "\n",
+    "- generate a ufunc from a python function\n",
+    "- converts scalar function to elementwise array function\n",
+    "- Numba provides CPU support\n",
+    "- NumbaPro provides GPU support"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# CPU version\n",
+    "@numba.vectorize(['float32(float32, float32)',\n",
+    "                  'float64(float64, float64)'], target='cpu')\n",
+    "def cpu_sincos(x, y):\n",
+    "    return math.sin(x) * math.cos(y)\n",
+    "\n",
+    "# CUDA version\n",
+    "@numbapro.vectorize(['float32(float32, float32)',\n",
+    "                     'float64(float64, float64)'], target='gpu')\n",
+    "def gpu_sincos(x, y):\n",
+    "    return math.sin(x) * math.cos(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "```\n",
+    "@numba.vectorize(<list of signatures>, target=<'cpu', 'gpu'>)\n",
+    "```\n",
+    "\n",
+    "- A ufunc can be overloaded to work on multiple type signatures\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Test it out\n",
+    "\n",
+    "- 2 input arrays\n",
+    "- 1 output array\n",
+    "- 1 million doubles (8 MB) per array\n",
+    "- Total 24 MB of data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU vectorize correct:  True\n",
+      "GPU vectorize correct:  True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate data\n",
+    "n = 1000000\n",
+    "x = np.linspace(0, np.pi, n)\n",
+    "y = np.linspace(0, np.pi, n)\n",
+    "\n",
+    "# Check result\n",
+    "np_ans = np.sin(x) * np.cos(y)\n",
+    "nb_cpu_ans = cpu_sincos(x, y)\n",
+    "nb_gpu_ans = gpu_sincos(x, y)\n",
+    "\n",
+    "print(\"CPU vectorize correct: \", np.allclose(nb_cpu_ans, np_ans))\n",
+    "print(\"GPU vectorize correct: \", np.allclose(nb_gpu_ans, np_ans))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NumPy\n",
+      "10 loops, best of 3: 37.2 ms per loop\n",
+      "CPU vectorize\n",
+      "10 loops, best of 3: 31.6 ms per loop\n",
+      "GPU vectorize\n",
+      "100 loops, best of 3: 4.68 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"NumPy\")\n",
+    "%timeit np.sin(x) * np.cos(y)\n",
+    "\n",
+    "print(\"CPU vectorize\")\n",
+    "%timeit cpu_sincos(x, y)\n",
+    "\n",
+    "print(\"GPU vectorize\")\n",
+    "%timeit gpu_sincos(x, y)\n",
+    "\n",
+    "# Optional cleanup \n",
+    "del x, y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "- CPU vectorize time is similar to pure NumPy time because ``sin()`` and ``cos()`` calls dominate the time.\n",
+    "- GPU vectorize is a lot faster\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "\n",
+    "## Behind the scenes\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "\n",
+    "### Automatic memory transfer\n",
+    "\n",
+    "- NumPy arrays are automatically transferred\n",
+    "    - CPU -> GPU\n",
+    "    - GPU -> CPU"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "\n",
+    "### Automatic work scheduling\n",
+    "\n",
+    "- The work is distributed the across all threads on the GPU\n",
+    "- The GPU hardware handles the scheduling\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "\n",
+    "### Automatic GPU memory management\n",
+    "\n",
+    "- GPU memory is tied to object lifetime\n",
+    "- freed automatically"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "# Another Vectorize Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@numba.vectorize(['float32(float32, float32, float32, float32)'])\n",
+    "def cpu_powers(p, q, r, s):\n",
+    "    return math.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)\n",
+    "\n",
+    "@numbapro.vectorize(['float32(float32, float32, float32, float32)'], target='gpu')\n",
+    "def gpu_powers(p, q, r, s):\n",
+    "    return math.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU vectorize correct True\n",
+      "GPU vectorize correct True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate data\n",
+    "n = 5000000\n",
+    "p = np.random.random(n).astype(np.float32)\n",
+    "q = np.random.random(n).astype(np.float32)\n",
+    "r = np.random.random(n).astype(np.float32)\n",
+    "s = np.random.random(n).astype(np.float32)\n",
+    "\n",
+    "# Check results\n",
+    "np_ans = np.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)\n",
+    "cpu_ans = cpu_powers(p, q, r, s)\n",
+    "gpu_ans = gpu_powers(p, q, r, s)\n",
+    "print(\"CPU vectorize correct\", np.allclose(np_ans, cpu_ans))\n",
+    "print(\"GPU vectorize correct\", np.allclose(np_ans, gpu_ans))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NumPy\n",
+      "1 loops, best of 3: 1.33 s per loop\n",
+      "CPU vectorize\n",
+      "1 loops, best of 3: 969 ms per loop\n",
+      "GPU vectorize\n",
+      "100 loops, best of 3: 16.6 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"NumPy\")\n",
+    "%timeit np.sqrt(p ** 2 + q ** 3 + r ** 4 + s ** 5)\n",
+    "print(\"CPU vectorize\")\n",
+    "%timeit cpu_powers(p, q, r, s)\n",
+    "print(\"GPU vectorize\")\n",
+    "%timeit gpu_powers(p, q, r, s)\n",
+    "\n",
+    "# Optional cleanup \n",
+    "del p, q, r, s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* NumPy is slower than CPU vectorize (likely due to allocation of temporaries)\n",
+    "* CPU version is slower than GPU version because of multiple cores running (even though copying to card and back is costly)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Generalized Universal Function (guvectorize)\n",
+    "\n",
+    "- Vectorize is limited to scalar arguments in the core function\n",
+    "- GUVectorize accepts array arguments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@numbapro.guvectorize(['void(float32[:,:], float32[:,:], float32[:,:])'],\n",
+    "                      '(m, n),(n, p)->(m, p)', target='gpu')\n",
+    "def batch_matrix_mult(a, b, c):\n",
+    "    for i in range(c.shape[0]):\n",
+    "        for j in range(c.shape[1]):\n",
+    "            tmp = 0\n",
+    "            for n in range(a.shape[1]):\n",
+    "                 tmp += a[i, n] * b[n, j]\n",
+    "            c[i, j] = tmp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "```\n",
+    "@numbapro.guvectorize(<list of function signatures>, <a string to desc the shape signature>, target=<'cpu', 'gpu'>)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NumPy result\n",
+      "[[  30.   36.   42.]\n",
+      " [  66.   81.   96.]\n",
+      " [ 102.  126.  150.]]\n",
+      "Numba GPU result\n",
+      "[[  30.   36.   42.]\n",
+      " [  66.   81.   96.]\n",
+      " [ 102.  126.  150.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "a = np.arange(1.0, 10.0, dtype=np.float32).reshape(3,3)\n",
+    "b = np.arange(1.0, 10.0, dtype=np.float32).reshape(3,3)\n",
+    "\n",
+    "# Use the builtin matrix_multiply in NumPy for CPU test\n",
+    "import numpy.core.umath_tests as ut\n",
+    "\n",
+    "# Check result\n",
+    "print('NumPy result')\n",
+    "np_ans = ut.matrix_multiply(a, b)\n",
+    "print(np_ans)\n",
+    "\n",
+    "print('Numba GPU result')\n",
+    "gpu_ans = batch_matrix_mult(a, b)\n",
+    "print(gpu_ans)\n",
+    "\n",
+    "assert np.allclose(np_ans, gpu_ans)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Test it out\n",
+    "\n",
+    "- batch multiply two 4 million 2x2 matrices "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NumPy time\n",
+      "10 loops, best of 3: 79.9 ms per loop\n",
+      "Numba GPU time\n",
+      "10 loops, best of 3: 81.3 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "n = 4000000\n",
+    "dim = 2\n",
+    "a = np.random.random(n * dim * dim).astype(np.float32).reshape(n, dim, dim)\n",
+    "b = np.random.random(n * dim * dim).astype(np.float32).reshape(n, dim, dim)\n",
+    "\n",
+    "print('NumPy time')\n",
+    "%timeit ut.matrix_multiply(a, b)\n",
+    "\n",
+    "print('Numba GPU time')\n",
+    "%timeit batch_matrix_mult(a, b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "- GPU time seems to be similar to CPU time\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "\n",
+    "## Manually Transfer the data to the GPU\n",
+    "\n",
+    "- This will let us see the actual compute time without the CPU<->GPU transfer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dc = numba.cuda.device_array_like(a)\n",
+    "da = numba.cuda.to_device(a)\n",
+    "db = numba.cuda.to_device(b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* ```numba.cuda.device_array_like``` allocate without initialization with the type and shape of another array.\n",
+    "    * similar to ```numpy.empty_like(a)```\n",
+    "* ```numba.cuda.to_device``` create a GPU copy of the CPU array\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "\n",
+    "## Pure compute time on the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100 loops, best of 3: 3.27 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "def check_pure_compute_time(da, db, dc):\n",
+    "    batch_matrix_mult(da, db, out=dc)\n",
+    "    numba.cuda.synchronize()   # ensure the call has completed\n",
+    "    \n",
+    "%timeit check_pure_compute_time(da, db, dc)\n",
+    "del da, db, dc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "* Actual compute time is **a lot faster**\n",
+    "* PCI-express transfer overhead"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "#### Tips\n",
+    "If you have a sequence of ufuncs to apply, pin the data on the GPU by manual transfer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# NumbaPro CUDA Libraries Bindings\n",
+    "\n",
+    "- Access to CUDA libraries \n",
+    "- Work seamless with NumPy\n",
+    "    - auto memory transfer\n",
+    "    - managed memory\n",
+    "\n",
+    "- cuBLAS: CUDA version of BLAS\n",
+    "- cuSparse: CUDA sparse matrix support\n",
+    "- cuFFT: FFT on CUDA\n",
+    "- cuRAND: random number generation on CUDA"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "# An Example with CUDA Libs\n",
+    "## Convolution on the GPU"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Import cuFFT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from numbapro.cudalib import cufft"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "#### Misc. imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.signal import fftconvolve\n",
+    "from scipy import misc, ndimage\n",
+    "from matplotlib import pyplot as plt\n",
+    "from timeit import default_timer as timer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Build elementwise complex array multiplication CUDA function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@numbapro.vectorize(['complex64(complex64, complex64)'], target='gpu')\n",
+    "def vmult(a, b):\n",
+    "    return a * b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Prepare image and filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Image size: (768, 1024)\n"
+     ]
+    }
+   ],
+   "source": [
+    "image = misc.face(gray=True).astype(np.float32)\n",
+    "\n",
+    "laplacian_pts = '''\n",
+    "-4 -1 0 -1 -4\n",
+    "-1 2 3 2 -1\n",
+    "0 3 4 3 0\n",
+    "-1 2 3 2 -1\n",
+    "-4 -1 0 -1 -4\n",
+    "'''.split()\n",
+    "\n",
+    "laplacian = np.array(laplacian_pts, dtype=np.float32).reshape(5, 5)\n",
+    "\n",
+    "response = np.zeros_like(image)\n",
+    "response[:5, :5] = laplacian\n",
+    "\n",
+    "print(\"Image size: %s\" % (image.shape,))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Convolution on the CPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU: 0.07s\n"
+     ]
+    }
+   ],
+   "source": [
+    "ts = timer()  # Start Timer\n",
+    "cvimage_cpu = fftconvolve(image, laplacian, mode='same')\n",
+    "te = timer()  # Stop Timer\n",
+    "print('CPU: %.2fs' % (te - ts))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Convolution on the GPU"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "image_complex = image.astype(np.complex64)\n",
+    "response_complex = response.astype(np.complex64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "skip"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<numbapro.cudalib.cufft.api.FFTPlan at 0x7f871d634f60>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Trigger initialization the cuFFT system.\n",
+    "# This takes significant time for small dataset.\n",
+    "# We should not be including the time wasted here\n",
+    "cufft.FFTPlan(shape=image.shape, itype=np.complex64, otype=np.complex64)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GPU: 0.02s\n"
+     ]
+    }
+   ],
+   "source": [
+    "ts = timer()     # Start timer\n",
+    "\n",
+    "d_image_complex = numba.cuda.to_device(image_complex)\n",
+    "d_response_complex = numba.cuda.to_device(response_complex)\n",
+    "\n",
+    "# Forward FFT\n",
+    "cufft.fft_inplace(d_image_complex)\n",
+    "cufft.fft_inplace(d_response_complex)\n",
+    "\n",
+    "# Multiply the image with teh filter\n",
+    "vmult(d_image_complex, d_response_complex, out=d_image_complex)\n",
+    "\n",
+    "# Inverse FFT\n",
+    "cufft.ifft_inplace(d_image_complex)\n",
+    "\n",
+    "cvimage_gpu = d_image_complex.copy_to_host().real / np.prod(image.shape)\n",
+    "\n",
+    "te = timer()   # Stop timer\n",
+    "\n",
+    "print('GPU: %.2fs' % (te - ts))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.title('Original')\n",
+    "plt.imshow(image, cmap=plt.cm.gray)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.title('CPU')\n",
+    "plt.imshow(cvimage_cpu, cmap=plt.cm.gray)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.title('GPU')\n",
+    "plt.imshow(cvimage_gpu, cmap=plt.cm.gray)\n",
+    "plt.axis('off')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "-----\n",
+    "\n",
+    "# Low-Level Approach: @numba.cuda.jit\n",
+    "\n",
+    "- Numba can generate CUDA functions with the `@jit` decorator\n",
+    "- Decorated function follows CUDA execution model "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## CUDA Execution Model\n",
+    "\n",
+    "- Kernel functions\n",
+    "    - visible to the host CPU\n",
+    "    - cannot return any value\n",
+    "        - use output argument\n",
+    "    - associates to a _grid_\n",
+    "- Grid\n",
+    "    - a group of blocks\n",
+    "    - 1D, 2D, 3D\n",
+    "- Blocks\n",
+    "    - a group of threads\n",
+    "    - 1D, 2D, 3D  \n",
+    "- Every thread executes the same kernel\n",
+    "    - thread can use the grid, block, thread coordinate system to determine its ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/grid-of-thread-blocks.png\"/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Image(url='http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/grid-of-thread-blocks.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Compiling a CUDA Kernel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from numba import cuda\n",
+    "\n",
+    "@numba.cuda.jit(\"void(float32[:], float32[:], float32[:])\")\n",
+    "def vadd(arr_a, arr_b, arr_out):\n",
+    "    tx = cuda.threadIdx.x\n",
+    "    bx = cuda.blockIdx.x\n",
+    "    bw = cuda.blockDim.x    # number of threads per block\n",
+    "    i = tx + bx * bw\n",
+    "    if i >= arr_out.size:\n",
+    "        return\n",
+    "    arr_out[i] = arr_a[i] + arr_b[i]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "### Code Explained\n",
+    "\n",
+    "#### Define a CUDA kernel with three 1D float32 arrays as args\n",
+    "\n",
+    "```\n",
+    "@numba.cuda.jit(\"void(float32[:], float32[:], float32[:])\")\n",
+    "def vadd(arr_a, arr_b, arr_out):\n",
+    "```\n",
+    "\n",
+    "#### Map thread, block coordinate to global position\n",
+    "```\n",
+    "    tx = cuda.threadIdx.x   # thread label (along x dimension)\n",
+    "    bx = cuda.blockIdx.x    # block label (along x dimension)\n",
+    "    bw = cuda.blockDim.x    # number of threads in each block (along x dimension)\n",
+    "    i = tx + bx * bw        # flattened linear address for each thread\n",
+    "```\n",
+    "or simplified to:\n",
+    "```\n",
+    "    i = cuda.grid(1)\n",
+    "``` \n",
+    "\n",
+    "#### Ensure global position is within array size\n",
+    "\n",
+    "```\n",
+    "    if i >= arr_out.size:\n",
+    "        return\n",
+    "```\n",
+    "\n",
+    "#### The actual work\n",
+    "\n",
+    "```\n",
+    "    arr_out[i] = arr_a[i] + arr_b[i]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Launch kernel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "#### Prepare data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "n = 100\n",
+    "a = np.arange(n, dtype=np.float32)\n",
+    "b = np.arange(n, dtype=np.float32)\n",
+    "c = np.empty_like(a)                 # Must prepare the output array to hold the result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Calculate thread, block count\n",
+    "\n",
+    "- thread count is set to **warp size** of the GPU\n",
+    "    - Warp size is similar to SIMD vector width on the CPU\n",
+    "    - **performance tips**: set thread count to multiple of warp size\n",
+    "- block count is ceil(n/thread_ct)\n",
+    "\n",
+    "**Note:**\n",
+    "This will launch more threads than there are elements in the array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Threads per block: 32\n",
+      "Block per grid: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "thread_ct = my_gpu.WARP_SIZE\n",
+    "block_ct = int(math.ceil(float(n) / thread_ct))\n",
+    "\n",
+    "print(\"Threads per block:\", thread_ct)\n",
+    "print(\"Block per grid:\", block_ct)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Launch kernel\n",
+    "\n",
+    "Kernel function object uses the ``__getitem__`` (indexing notation) to configure the grid and block dimensions.\n",
+    "\n",
+    "```\n",
+    "    kernel_function[griddim, blockdim](*args)\n",
+    "```\n",
+    "\n",
+    "- **griddim**\n",
+    "    - Number of blocks per grid (grid dimension)\n",
+    "    - type: int for 1d or 1,2,3-tuple of ints for 1d, 2d, or 3d respectively\n",
+    "\n",
+    "- **blockdim**: \n",
+    "    - Number of threads per block (blockdim dimension)\n",
+    "    - type: int for 1d or 1,2,3-tuple of ints for 1d, 2d, or 3d respectively\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[   0.    2.    4.    6.    8.   10.   12.   14.   16.   18.   20.   22.\n",
+      "   24.   26.   28.   30.   32.   34.   36.   38.   40.   42.   44.   46.\n",
+      "   48.   50.   52.   54.   56.   58.   60.   62.   64.   66.   68.   70.\n",
+      "   72.   74.   76.   78.   80.   82.   84.   86.   88.   90.   92.   94.\n",
+      "   96.   98.  100.  102.  104.  106.  108.  110.  112.  114.  116.  118.\n",
+      "  120.  122.  124.  126.  128.  130.  132.  134.  136.  138.  140.  142.\n",
+      "  144.  146.  148.  150.  152.  154.  156.  158.  160.  162.  164.  166.\n",
+      "  168.  170.  172.  174.  176.  178.  180.  182.  184.  186.  188.  190.\n",
+      "  192.  194.  196.  198.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "vadd[block_ct, thread_ct](a, b, c)    # Last argument is the output array in this case\n",
+    "print(c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "# Example: Matrix Matrix Multiplication\n",
+    "\n",
+    "- Show manual caching with shared memory\n",
+    "- Not the best matrix matrix multiplication implementation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Prepare constants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from numba import float32\n",
+    "\n",
+    "bpg = 150\n",
+    "tpb = 32\n",
+    "n = bpg * tpb\n",
+    "shared_mem_size = (tpb, tpb)\n",
+    "griddim = bpg, bpg\n",
+    "blockdim = tpb, tpb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Naive version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-without-shared-memory.png\"/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Image(url=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-without-shared-memory.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@numba.cuda.jit(\"void(float32[:,:], float32[:,:], float32[:,:])\")\n",
+    "def naive_matrix_mult(A, B, C):\n",
+    "    x, y = cuda.grid(2)\n",
+    "    if x >= n or y >= n:\n",
+    "        return\n",
+    "\n",
+    "    C[y, x] = 0\n",
+    "    for i in range(n):\n",
+    "        C[y, x] += A[y, i] * B[i, x]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Optimized version (shared memory + blocking)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-with-shared-memory.png\"/>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Image(url=\"http://docs.nvidia.com/cuda/cuda-c-programming-guide/graphics/matrix-multiplication-with-shared-memory.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "@numba.cuda.jit(\"void(float32[:,:], float32[:,:], float32[:,:])\")\n",
+    "def optimized_matrix_mult(A, B, C):\n",
+    "    # Declare shared memory\n",
+    "    sA = cuda.shared.array(shape=shared_mem_size, dtype=float32)\n",
+    "    sB = cuda.shared.array(shape=shared_mem_size, dtype=float32)\n",
+    "    \n",
+    "    tx = cuda.threadIdx.x\n",
+    "    ty = cuda.threadIdx.y\n",
+    "    x, y = cuda.grid(2)\n",
+    "\n",
+    "    acc = 0\n",
+    "    for i in range(bpg):\n",
+    "        if x < n and y < n:\n",
+    "            # Prefill cache\n",
+    "            sA[ty, tx] = A[y, tx + i * tpb]\n",
+    "            sB[ty, tx] = B[ty + i * tpb, x]\n",
+    "\n",
+    "        # Synchronize all threads in the block\n",
+    "        cuda.syncthreads()\n",
+    "\n",
+    "        if x < n and y < n:\n",
+    "            # Compute product\n",
+    "            for j in range(tpb):\n",
+    "                acc += sA[ty, j] * sB[j, tx]\n",
+    "\n",
+    "        # Wait until all threads finish the computation\n",
+    "        cuda.syncthreads()\n",
+    "\n",
+    "    if x < n and y < n:\n",
+    "        C[y, x] = acc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Prepare data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "N = 4800 x 4800\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Prepare data on the CPU\n",
+    "A = np.array(np.random.random((n, n)), dtype=np.float32)\n",
+    "B = np.array(np.random.random((n, n)), dtype=np.float32)\n",
+    "\n",
+    "print(\"N = %d x %d\" % (n, n))\n",
+    "\n",
+    "# Prepare data on the GPU\n",
+    "dA = cuda.to_device(A)\n",
+    "dB = cuda.to_device(B)\n",
+    "dC = cuda.device_array_like(A)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Benchmark"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Time the unoptimized version\n",
+    "s = timer()\n",
+    "naive_matrix_mult[griddim, blockdim](dA, dB, dC)\n",
+    "numba.cuda.synchronize()\n",
+    "e = timer()\n",
+    "unopt_ans = dC.copy_to_host()\n",
+    "tcuda_unopt = e - s\n",
+    "\n",
+    "# Time the optimized version\n",
+    "s = timer()\n",
+    "optimized_matrix_mult[griddim, blockdim](dA, dB, dC)\n",
+    "numba.cuda.synchronize()\n",
+    "e = timer()\n",
+    "opt_ans = dC.copy_to_host()\n",
+    "tcuda_opt = e - s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "#### Result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Without shared memory: 3.81 s\n",
+      "With shared memory: 4.26 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "assert np.allclose(unopt_ans, opt_ans)\n",
+    "print(\"Without shared memory:\", \"%.2f\" % tcuda_unopt, \"s\")\n",
+    "print(\"With shared memory:\", \"%.2f\" % tcuda_opt, \"s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "# Summary\n",
+    "\n",
+    "- Numba\n",
+    "    - opensource low-level GPU support\n",
+    "    - CUDA kernel ``@numba.cuda.jit``\n",
+    "- NumbaPro\n",
+    "    - commerical with high-level GPU support\n",
+    "    - vectorize ``@numbapro.vectorize``\n",
+    "    - guvectorize ``@numbapro.guvectorize``\n",
+    "    - CUDA libraries ``@numbapro.cudalib.*``\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "# Future of Numba / NumbaPro\n",
+    "\n",
+    "- OpenCL support in Numba (WiP)\n",
+    "- Deferred array object that hides most CPU+GPU details\n",
+    "    - use it like NumPy array"
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
This updates the Webinar notebook to work with Python 2 and 3, and also to support newer compute capabilities when printing out the specifications of the current GPU.

Tested with Python 2.7 and 3.4 against Numba and Numbapro master branches.